### PR TITLE
UCT/IB/MLX5: Add AArch64 ST64B BF copy mode

### DIFF
--- a/config/m4/sysdep.m4
+++ b/config/m4/sysdep.m4
@@ -20,6 +20,7 @@ AC_CHECK_LIB([rt], [timer_create], [], AC_MSG_ERROR([librt not found]))
 # Extended string functions
 #
 AC_CHECK_HEADERS([libgen.h])
+AC_CHECK_HEADERS([sys/auxv.h])
 AC_CHECK_DECLS([asprintf, basename, fmemopen], [],
 				AC_MSG_ERROR([GNU string extensions not found]), 
 				[#define _GNU_SOURCE 1
@@ -29,6 +30,10 @@ AC_CHECK_DECLS([asprintf, basename, fmemopen], [],
 				 #include <libgen.h>
 				 #endif
 				 ])
+AC_CHECK_DECLS([getauxval], [], [],
+               [#if HAVE_SYS_AUXV_H
+                #include <sys/auxv.h>
+                #endif])
 
 
 #

--- a/src/ucs/arch/aarch64/cpu.c
+++ b/src/ucs/arch/aarch64/cpu.c
@@ -13,6 +13,18 @@
 #include <ucs/arch/cpu.h>
 #include <stdio.h>
 
+#if HAVE_SYS_AUXV_H
+#  include <sys/auxv.h>
+#endif
+
+/* Older userspace headers may not expose Arm64 HWCAP3 definitions. */
+#ifndef AT_HWCAP3
+#  define AT_HWCAP3 29
+#endif
+
+#ifndef HWCAP3_LS64
+#  define HWCAP3_LS64 (1UL << 3)
+#endif
 
 static void ucs_aarch64_cpuid_from_proc(ucs_aarch64_cpuid_t *cpuid)
 {
@@ -66,6 +78,29 @@ void ucs_aarch64_cpuid(ucs_aarch64_cpuid_t *cpuid)
 
     ucs_memory_cpu_load_fence();
     *cpuid = cached_cpuid;
+}
+
+ucs_cpu_flag_t ucs_arch_get_cpu_flag()
+{
+    static ucs_cpu_flag_t cpu_flag;
+    static int initialized = 0;
+
+    if (!initialized) {
+        ucs_cpu_flag_t result = 0;
+
+#if HAVE_SYS_AUXV_H && HAVE_DECL_GETAUXVAL
+        if (getauxval(AT_HWCAP3) & HWCAP3_LS64) {
+            result |= UCS_CPU_FLAG_ST64B;
+        }
+#endif
+
+        cpu_flag = result;
+        ucs_memory_cpu_store_fence();
+        initialized = 1;
+    }
+
+    ucs_memory_cpu_load_fence();
+    return cpu_flag;
 }
 
 #endif

--- a/src/ucs/arch/aarch64/cpu.c
+++ b/src/ucs/arch/aarch64/cpu.c
@@ -15,7 +15,6 @@
 
 #if HAVE_SYS_AUXV_H
 #  include <sys/auxv.h>
-#endif
 
 /* Older userspace headers may not expose Arm64 HWCAP3 definitions. */
 #ifndef AT_HWCAP3
@@ -24,6 +23,7 @@
 
 #ifndef HWCAP3_LS64
 #  define HWCAP3_LS64 (1UL << 3)
+#endif
 #endif
 
 static void ucs_aarch64_cpuid_from_proc(ucs_aarch64_cpuid_t *cpuid)
@@ -90,7 +90,7 @@ ucs_cpu_flag_t ucs_arch_get_cpu_flag()
 
 #if HAVE_SYS_AUXV_H && HAVE_DECL_GETAUXVAL
         if (getauxval(AT_HWCAP3) & HWCAP3_LS64) {
-            result |= UCS_CPU_FLAG_ST64B;
+            result |= UCS_CPU_FLAG_LS64;
         }
 #endif
 

--- a/src/ucs/arch/aarch64/cpu.h
+++ b/src/ucs/arch/aarch64/cpu.h
@@ -15,6 +15,7 @@
 #include <time.h>
 #include <string.h>
 #include <sys/times.h>
+#include <ucs/sys/compiler.h>
 #include <ucs/sys/compiler_def.h>
 #include <ucs/sys/ptr_arith.h>
 #include <ucs/arch/generic/cpu.h>
@@ -169,10 +170,7 @@ static inline ucs_cpu_model_t ucs_arch_get_cpu_model()
     return UCS_CPU_MODEL_ARM_AARCH64;
 }
 
-static inline int ucs_arch_get_cpu_flag()
-{
-    return UCS_CPU_FLAG_UNKNOWN;
-}
+ucs_cpu_flag_t ucs_arch_get_cpu_flag() UCS_F_NOOPTIMIZE;
 
 static inline void ucs_cpu_init()
 {

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -66,7 +66,7 @@ typedef enum ucs_cpu_flag {
     UCS_CPU_FLAG_SSE42      = UCS_BIT(8),
     UCS_CPU_FLAG_AVX        = UCS_BIT(9),
     UCS_CPU_FLAG_AVX2       = UCS_BIT(10),
-    UCS_CPU_FLAG_ST64B      = UCS_BIT(11)
+    UCS_CPU_FLAG_LS64       = UCS_BIT(11)
 } ucs_cpu_flag_t;
 
 

--- a/src/ucs/arch/cpu.h
+++ b/src/ucs/arch/cpu.h
@@ -65,7 +65,8 @@ typedef enum ucs_cpu_flag {
     UCS_CPU_FLAG_SSE41      = UCS_BIT(7),
     UCS_CPU_FLAG_SSE42      = UCS_BIT(8),
     UCS_CPU_FLAG_AVX        = UCS_BIT(9),
-    UCS_CPU_FLAG_AVX2       = UCS_BIT(10)
+    UCS_CPU_FLAG_AVX2       = UCS_BIT(10),
+    UCS_CPU_FLAG_ST64B      = UCS_BIT(11)
 } ucs_cpu_flag_t;
 
 

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -50,7 +50,7 @@ static UCS_F_NOOPTIMIZE void ucs_check_cpu_flags(void)
         { "sse42", UCS_CPU_FLAG_SSE42 },
         { "avx", UCS_CPU_FLAG_AVX },
         { "avx2", UCS_CPU_FLAG_AVX2 },
-        { "st64b", UCS_CPU_FLAG_ST64B },
+        { "ls64", UCS_CPU_FLAG_LS64 },
         { NULL, UCS_CPU_FLAG_UNKNOWN },
     };
 

--- a/src/ucs/sys/init.c
+++ b/src/ucs/sys/init.c
@@ -50,6 +50,7 @@ static UCS_F_NOOPTIMIZE void ucs_check_cpu_flags(void)
         { "sse42", UCS_CPU_FLAG_SSE42 },
         { "avx", UCS_CPU_FLAG_AVX },
         { "avx2", UCS_CPU_FLAG_AVX2 },
+        { "st64b", UCS_CPU_FLAG_ST64B },
         { NULL, UCS_CPU_FLAG_UNKNOWN },
     };
 

--- a/src/uct/ib/mlx5/configure.m4
+++ b/src/uct/ib/mlx5/configure.m4
@@ -8,6 +8,32 @@
 # Add IB mlx5 provider support
 #
 
+AC_CACHE_CHECK([for AArch64 ST64B assembler support],
+               [ucx_cv_have_aarch64_st64b_asm],
+               [AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+#ifndef __aarch64__
+#error "ST64B is only supported on AArch64"
+#endif
+
+void test_st64b(void *dst, void *src)
+{
+    register void *src_reg asm("x8") = src;
+    register void *dst_reg asm("x9") = dst;
+
+    asm volatile(".arch_extension ls64\n"
+                 "st64b x8, [x9]"
+                 :
+                 : "r"(src_reg), "r"(dst_reg)
+                 : "memory");
+}
+]])],
+               [ucx_cv_have_aarch64_st64b_asm=yes],
+               [ucx_cv_have_aarch64_st64b_asm=no])])
+
+AS_IF([test "x$ucx_cv_have_aarch64_st64b_asm" = "xyes"],
+      [AC_DEFINE([HAVE_AARCH64_ST64B_ASM], [1],
+                 [Define to 1 if AArch64 ST64B assembler is supported])])
+
 AC_CONFIG_FILES([src/uct/ib/mlx5/Makefile src/uct/ib/mlx5/ucx-ib-mlx5.pc])
 
 m4_include([src/uct/ib/mlx5/gdaki/configure.m4])

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -464,7 +464,8 @@ init_qp:
 
     if (dci->txwq.super.type == UCT_IB_MLX5_OBJ_TYPE_VERBS) {
         status = uct_ib_mlx5_txwq_init(iface->super.super.super.super.worker,
-                                       iface->super.tx.mmio_mode, &dci->txwq,
+                                       iface->super.tx.mmio_mode,
+                                       iface->super.tx.bf_copy_mode, &dci->txwq,
                                        dci->txwq.super.verbs.qp);
         if (status != UCS_OK) {
             goto err;

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -155,6 +155,13 @@ ucs_status_t uct_ib_mlx5_devx_create_qp_common(uct_ib_iface_t *iface,
         goto err;
     }
 
+    if (tx != NULL) {
+        status = uct_ib_mlx5_txwq_init_bf_copy(tx, attr->bf_copy_mode);
+        if (status != UCS_OK) {
+            goto err;
+        }
+    }
+
     uar = uct_worker_tl_data_get(iface->super.worker,
                                  UCT_IB_MLX5_DEVX_UAR_KEY,
                                  uct_ib_mlx5_devx_uar_t,

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -459,6 +459,7 @@ uct_rc_gdaki_init_channel_chunk(uct_rc_gdaki_iface_t *iface,
 
     cq_attr.flags                           |= UCT_IB_MLX5_CQ_IGNORE_OVERRUN;
     qp_attr.mmio_mode                        = UCT_IB_MLX5_MMIO_MODE_DB;
+    qp_attr.bf_copy_mode                     = UCT_IB_MLX5_BF_COPY_MODE_GENERIC;
     qp_attr.super.srq_num                    = 0;
     qp_attr.super.max_inl_cqe[UCT_IB_DIR_TX] = 0;
     uct_ib_mlx5_wq_calc_sizes(&qp_attr);

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -842,8 +842,9 @@ uct_ib_mlx5_bf_copy_st64b(void *dst, void *src, uint16_t num_bb,
 }
 #endif
 
-static uct_ib_mlx5_bf_copy_func_t
-uct_ib_mlx5_select_bf_copy(uct_ib_mlx5_bf_copy_mode_t bf_copy_mode)
+static ucs_status_t
+uct_ib_mlx5_select_bf_copy(uct_ib_mlx5_bf_copy_mode_t bf_copy_mode,
+                           uct_ib_mlx5_bf_copy_func_t *bf_copy_func_p)
 {
     static uct_ib_mlx5_bf_copy_func_t cached_bf_copy_func;
     uct_ib_mlx5_bf_copy_mode_t mode = bf_copy_mode;
@@ -851,10 +852,6 @@ uct_ib_mlx5_select_bf_copy(uct_ib_mlx5_bf_copy_mode_t bf_copy_mode)
     int have_st64b = 0;
 
     ucs_assert(bf_copy_mode < UCT_IB_MLX5_BF_COPY_MODE_LAST);
-
-    if (cached_bf_copy_func != NULL) {
-        return cached_bf_copy_func;
-    }
 
     bf_copy_func = uct_ib_mlx5_bf_copy_generic;
     if (mode == UCT_IB_MLX5_BF_COPY_MODE_GENERIC) {
@@ -869,18 +866,29 @@ uct_ib_mlx5_select_bf_copy(uct_ib_mlx5_bf_copy_mode_t bf_copy_mode)
                             UCT_IB_MLX5_BF_COPY_MODE_GENERIC;
     }
 
-#if HAVE_AARCH64_ST64B_ASM
     if (mode == UCT_IB_MLX5_BF_COPY_MODE_ST64B) {
-        ucs_assert(have_st64b);
+#if HAVE_AARCH64_ST64B_ASM
+        if (!have_st64b) {
+            ucs_error("mlx5 BlueFlame ST64B copy was requested but CPU does "
+                      "not report ST64B support");
+            return UCS_ERR_UNSUPPORTED;
+        }
+
         bf_copy_func = uct_ib_mlx5_bf_copy_st64b;
-    }
 #else
-    ucs_assert(mode != UCT_IB_MLX5_BF_COPY_MODE_ST64B);
+        ucs_error("mlx5 BlueFlame ST64B copy was requested but UCX was built "
+                  "without assembler support for ST64B");
+        return UCS_ERR_UNSUPPORTED;
 #endif
+    }
 
 out:
-    cached_bf_copy_func = bf_copy_func;
-    return bf_copy_func;
+    if (cached_bf_copy_func == NULL) {
+        cached_bf_copy_func = bf_copy_func;
+    }
+
+    *bf_copy_func_p = cached_bf_copy_func;
+    return UCS_OK;
 }
 #endif
 
@@ -889,21 +897,7 @@ uct_ib_mlx5_txwq_init_bf_copy(uct_ib_mlx5_txwq_t *txwq,
                               uct_ib_mlx5_bf_copy_mode_t bf_copy_mode)
 {
 #if defined(__aarch64__)
-    if (bf_copy_mode == UCT_IB_MLX5_BF_COPY_MODE_ST64B) {
-#if !HAVE_AARCH64_ST64B_ASM
-        ucs_error("mlx5 BlueFlame ST64B copy was requested but UCX was built "
-                  "without assembler support for ST64B");
-        return UCS_ERR_UNSUPPORTED;
-#else
-        if (!(ucs_arch_get_cpu_flag() & UCS_CPU_FLAG_ST64B)) {
-            ucs_error("mlx5 BlueFlame ST64B copy was requested but CPU does "
-                      "not report ST64B support");
-            return UCS_ERR_UNSUPPORTED;
-        }
-#endif
-    }
-
-    txwq->bf_copy = uct_ib_mlx5_select_bf_copy(bf_copy_mode);
+    return uct_ib_mlx5_select_bf_copy(bf_copy_mode, &txwq->bf_copy);
 #else
     (void)txwq;
 

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -32,6 +32,13 @@ static const char *uct_ib_mlx5_mmio_modes[] = {
     [UCT_IB_MLX5_MMIO_MODE_LAST]       = NULL
 };
 
+static const char *uct_ib_mlx5_bf_copy_modes[] = {
+    [UCT_IB_MLX5_BF_COPY_MODE_GENERIC] = "generic",
+    [UCT_IB_MLX5_BF_COPY_MODE_AUTO]    = "auto",
+    [UCT_IB_MLX5_BF_COPY_MODE_ST64B]   = "st64b",
+    [UCT_IB_MLX5_BF_COPY_MODE_LAST]    = NULL
+};
+
 ucs_config_field_t uct_ib_mlx5_iface_config_table[] = {
 #if HAVE_IBV_DM
     {"DM_SIZE", "2k",
@@ -53,6 +60,15 @@ ucs_config_field_t uct_ib_mlx5_iface_config_table[] = {
      " auto       - Select best according to worker thread mode.",
      ucs_offsetof(uct_ib_mlx5_iface_config_t, mmio_mode),
      UCS_CONFIG_TYPE_ENUM(uct_ib_mlx5_mmio_modes)},
+
+    {"BF_COPY_MODE", "auto",
+     "How to copy WQE building blocks to BlueFlame MMIO register. One of "
+     "the following:\n"
+     " generic - Use portable scalar stores.\n"
+     " st64b   - Use AArch64 ST64B store when supported.\n"
+     " auto    - Select best according to runtime CPU capabilities.",
+     ucs_offsetof(uct_ib_mlx5_iface_config_t, bf_copy_mode),
+     UCS_CONFIG_TYPE_ENUM(uct_ib_mlx5_bf_copy_modes)},
 
     {"AR_ENABLE", "auto",
      "Enable Adaptive Routing (out of order) feature on SL that supports it.\n"
@@ -763,8 +779,146 @@ uct_ib_mlx5_get_mmio_mode(uct_priv_worker_t *worker,
     return UCS_OK;
 }
 
+#if defined(__aarch64__)
+static UCS_F_ALWAYS_INLINE void
+uct_ib_mlx5_bf_copy_bb_generic(void *restrict dst, void *restrict src)
+{
+    UCS_WORD_COPY(volatile uint64_t, dst, uint64_t, src, MLX5_SEND_WQE_BB);
+}
+
+static UCS_F_ALWAYS_INLINE void *
+uct_ib_mlx5_bf_copy_generic(void *dst, void *src, uint16_t num_bb,
+                            const uct_ib_mlx5_txwq_t *wq)
+{
+    uint16_t n;
+
+    for (n = 0; n < num_bb; ++n) {
+        uct_ib_mlx5_bf_copy_bb_generic(dst, src);
+        dst = UCS_PTR_BYTE_OFFSET(dst, MLX5_SEND_WQE_BB);
+        src = UCS_PTR_BYTE_OFFSET(src, MLX5_SEND_WQE_BB);
+        if (ucs_unlikely(src == wq->qend)) {
+            src = wq->qstart;
+        }
+    }
+
+    return src;
+}
+
+#if HAVE_AARCH64_ST64B_ASM
+static UCS_F_ALWAYS_INLINE void
+uct_ib_mlx5_bf_copy_bb_st64b(void *restrict dst, void *restrict src)
+{
+    ucs_assert(((uintptr_t)src % MLX5_SEND_WQE_BB) == 0);
+    ucs_assert(((uintptr_t)dst % MLX5_SEND_WQE_BB) == 0);
+
+    asm volatile(".arch_extension ls64\n"
+                 "ldp x8, x9, [%[src], #0]\n"
+                 "ldp x10, x11, [%[src], #16]\n"
+                 "ldp x12, x13, [%[src], #32]\n"
+                 "ldp x14, x15, [%[src], #48]\n"
+                 "st64b x8, [%[dst]]"
+                 :
+                 : [src] "r"(src), [dst] "r"(dst)
+                 : "x8", "x9", "x10", "x11", "x12", "x13", "x14",
+                   "x15", "memory");
+}
+
+static UCS_F_ALWAYS_INLINE void *
+uct_ib_mlx5_bf_copy_st64b(void *dst, void *src, uint16_t num_bb,
+                          const uct_ib_mlx5_txwq_t *wq)
+{
+    uint16_t n;
+
+    for (n = 0; n < num_bb; ++n) {
+        uct_ib_mlx5_bf_copy_bb_st64b(dst, src);
+        dst = UCS_PTR_BYTE_OFFSET(dst, MLX5_SEND_WQE_BB);
+        src = UCS_PTR_BYTE_OFFSET(src, MLX5_SEND_WQE_BB);
+        if (ucs_unlikely(src == wq->qend)) {
+            src = wq->qstart;
+        }
+    }
+
+    return src;
+}
+#endif
+
+static uct_ib_mlx5_bf_copy_func_t
+uct_ib_mlx5_select_bf_copy(uct_ib_mlx5_bf_copy_mode_t bf_copy_mode)
+{
+    static uct_ib_mlx5_bf_copy_func_t cached_bf_copy_func;
+    uct_ib_mlx5_bf_copy_mode_t mode = bf_copy_mode;
+    uct_ib_mlx5_bf_copy_func_t bf_copy_func;
+    int have_st64b = 0;
+
+    ucs_assert(bf_copy_mode < UCT_IB_MLX5_BF_COPY_MODE_LAST);
+
+    if (cached_bf_copy_func != NULL) {
+        return cached_bf_copy_func;
+    }
+
+    bf_copy_func = uct_ib_mlx5_bf_copy_generic;
+    if (mode == UCT_IB_MLX5_BF_COPY_MODE_GENERIC) {
+        goto out;
+    }
+
+#if HAVE_AARCH64_ST64B_ASM
+    have_st64b = ucs_arch_get_cpu_flag() & UCS_CPU_FLAG_ST64B;
+#endif
+    if (mode == UCT_IB_MLX5_BF_COPY_MODE_AUTO) {
+        mode = have_st64b ? UCT_IB_MLX5_BF_COPY_MODE_ST64B :
+                            UCT_IB_MLX5_BF_COPY_MODE_GENERIC;
+    }
+
+#if HAVE_AARCH64_ST64B_ASM
+    if (mode == UCT_IB_MLX5_BF_COPY_MODE_ST64B) {
+        ucs_assert(have_st64b);
+        bf_copy_func = uct_ib_mlx5_bf_copy_st64b;
+    }
+#else
+    ucs_assert(mode != UCT_IB_MLX5_BF_COPY_MODE_ST64B);
+#endif
+
+out:
+    cached_bf_copy_func = bf_copy_func;
+    return bf_copy_func;
+}
+#endif
+
+ucs_status_t
+uct_ib_mlx5_txwq_init_bf_copy(uct_ib_mlx5_txwq_t *txwq,
+                              uct_ib_mlx5_bf_copy_mode_t bf_copy_mode)
+{
+#if defined(__aarch64__)
+    if (bf_copy_mode == UCT_IB_MLX5_BF_COPY_MODE_ST64B) {
+#if !HAVE_AARCH64_ST64B_ASM
+        ucs_error("mlx5 BlueFlame ST64B copy was requested but UCX was built "
+                  "without assembler support for ST64B");
+        return UCS_ERR_UNSUPPORTED;
+#else
+        if (!(ucs_arch_get_cpu_flag() & UCS_CPU_FLAG_ST64B)) {
+            ucs_error("mlx5 BlueFlame ST64B copy was requested but CPU does "
+                      "not report ST64B support");
+            return UCS_ERR_UNSUPPORTED;
+        }
+#endif
+    }
+
+    txwq->bf_copy = uct_ib_mlx5_select_bf_copy(bf_copy_mode);
+#else
+    (void)txwq;
+
+    if (bf_copy_mode == UCT_IB_MLX5_BF_COPY_MODE_ST64B) {
+        ucs_error("mlx5 BlueFlame ST64B copy is supported only on AArch64");
+        return UCS_ERR_UNSUPPORTED;
+    }
+#endif
+
+    return UCS_OK;
+}
+
 ucs_status_t uct_ib_mlx5_txwq_init(uct_priv_worker_t *worker,
                                    uct_ib_mlx5_mmio_mode_t cfg_mmio_mode,
+                                   uct_ib_mlx5_bf_copy_mode_t bf_copy_mode,
                                    uct_ib_mlx5_txwq_t *txwq,
                                    struct ibv_qp *verbs_qp)
 {
@@ -794,6 +948,11 @@ ucs_status_t uct_ib_mlx5_txwq_init(uct_priv_worker_t *worker,
     status = uct_ib_mlx5_get_mmio_mode(worker, cfg_mmio_mode,
                                        txwq->super.verbs.rd->td == NULL,
                                        qp_info.dv.bf.size, &mmio_mode);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_ib_mlx5_txwq_init_bf_copy(txwq, bf_copy_mode);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -33,8 +33,8 @@ static const char *uct_ib_mlx5_mmio_modes[] = {
 };
 
 static const char *uct_ib_mlx5_bf_copy_modes[] = {
-    [UCT_IB_MLX5_BF_COPY_MODE_GENERIC] = "generic",
     [UCT_IB_MLX5_BF_COPY_MODE_AUTO]    = "auto",
+    [UCT_IB_MLX5_BF_COPY_MODE_GENERIC] = "generic",
     [UCT_IB_MLX5_BF_COPY_MODE_ST64B]   = "st64b",
     [UCT_IB_MLX5_BF_COPY_MODE_LAST]    = NULL
 };
@@ -64,9 +64,9 @@ ucs_config_field_t uct_ib_mlx5_iface_config_table[] = {
     {"BF_COPY_MODE", "auto",
      "How to copy WQE building blocks to BlueFlame MMIO register. One of "
      "the following:\n"
+     " auto    - Select best according to runtime CPU capabilities.\n"
      " generic - Use portable scalar stores.\n"
-     " st64b   - Use AArch64 ST64B store when supported.\n"
-     " auto    - Select best according to runtime CPU capabilities.",
+     " st64b   - Use AArch64 ST64B store when supported.",
      ucs_offsetof(uct_ib_mlx5_iface_config_t, bf_copy_mode),
      UCS_CONFIG_TYPE_ENUM(uct_ib_mlx5_bf_copy_modes)},
 
@@ -779,125 +779,35 @@ uct_ib_mlx5_get_mmio_mode(uct_priv_worker_t *worker,
     return UCS_OK;
 }
 
-#if defined(__aarch64__)
-static UCS_F_ALWAYS_INLINE void
-uct_ib_mlx5_bf_copy_bb_generic(void *restrict dst, void *restrict src)
-{
-    UCS_WORD_COPY(volatile uint64_t, dst, uint64_t, src, MLX5_SEND_WQE_BB);
-}
-
-static UCS_F_ALWAYS_INLINE void *
-uct_ib_mlx5_bf_copy_generic(void *dst, void *src, uint16_t num_bb,
-                            const uct_ib_mlx5_txwq_t *wq)
-{
-    uint16_t n;
-
-    for (n = 0; n < num_bb; ++n) {
-        uct_ib_mlx5_bf_copy_bb_generic(dst, src);
-        dst = UCS_PTR_BYTE_OFFSET(dst, MLX5_SEND_WQE_BB);
-        src = UCS_PTR_BYTE_OFFSET(src, MLX5_SEND_WQE_BB);
-        if (ucs_unlikely(src == wq->qend)) {
-            src = wq->qstart;
-        }
-    }
-
-    return src;
-}
-
-#if HAVE_AARCH64_ST64B_ASM
-static UCS_F_ALWAYS_INLINE void
-uct_ib_mlx5_bf_copy_bb_st64b(void *restrict dst, void *restrict src)
-{
-    ucs_assert(((uintptr_t)src % MLX5_SEND_WQE_BB) == 0);
-    ucs_assert(((uintptr_t)dst % MLX5_SEND_WQE_BB) == 0);
-
-    asm volatile(".arch_extension ls64\n"
-                 "ldp x8, x9, [%[src], #0]\n"
-                 "ldp x10, x11, [%[src], #16]\n"
-                 "ldp x12, x13, [%[src], #32]\n"
-                 "ldp x14, x15, [%[src], #48]\n"
-                 "st64b x8, [%[dst]]"
-                 :
-                 : [src] "r"(src), [dst] "r"(dst)
-                 : "x8", "x9", "x10", "x11", "x12", "x13", "x14",
-                   "x15", "memory");
-}
-
-static UCS_F_ALWAYS_INLINE void *
-uct_ib_mlx5_bf_copy_st64b(void *dst, void *src, uint16_t num_bb,
-                          const uct_ib_mlx5_txwq_t *wq)
-{
-    uint16_t n;
-
-    for (n = 0; n < num_bb; ++n) {
-        uct_ib_mlx5_bf_copy_bb_st64b(dst, src);
-        dst = UCS_PTR_BYTE_OFFSET(dst, MLX5_SEND_WQE_BB);
-        src = UCS_PTR_BYTE_OFFSET(src, MLX5_SEND_WQE_BB);
-        if (ucs_unlikely(src == wq->qend)) {
-            src = wq->qstart;
-        }
-    }
-
-    return src;
-}
-#endif
-
-static ucs_status_t
-uct_ib_mlx5_select_bf_copy(uct_ib_mlx5_bf_copy_mode_t bf_copy_mode,
-                           uct_ib_mlx5_bf_copy_func_t *bf_copy_func_p)
-{
-    static uct_ib_mlx5_bf_copy_func_t cached_bf_copy_func;
-    uct_ib_mlx5_bf_copy_mode_t mode = bf_copy_mode;
-    uct_ib_mlx5_bf_copy_func_t bf_copy_func;
-    int have_st64b = 0;
-
-    ucs_assert(bf_copy_mode < UCT_IB_MLX5_BF_COPY_MODE_LAST);
-
-    bf_copy_func = uct_ib_mlx5_bf_copy_generic;
-    if (mode == UCT_IB_MLX5_BF_COPY_MODE_GENERIC) {
-        goto out;
-    }
-
-#if HAVE_AARCH64_ST64B_ASM
-    have_st64b = ucs_arch_get_cpu_flag() & UCS_CPU_FLAG_ST64B;
-#endif
-    if (mode == UCT_IB_MLX5_BF_COPY_MODE_AUTO) {
-        mode = have_st64b ? UCT_IB_MLX5_BF_COPY_MODE_ST64B :
-                            UCT_IB_MLX5_BF_COPY_MODE_GENERIC;
-    }
-
-    if (mode == UCT_IB_MLX5_BF_COPY_MODE_ST64B) {
-#if HAVE_AARCH64_ST64B_ASM
-        if (!have_st64b) {
-            ucs_error("mlx5 BlueFlame ST64B copy was requested but CPU does "
-                      "not report ST64B support");
-            return UCS_ERR_UNSUPPORTED;
-        }
-
-        bf_copy_func = uct_ib_mlx5_bf_copy_st64b;
-#else
-        ucs_error("mlx5 BlueFlame ST64B copy was requested but UCX was built "
-                  "without assembler support for ST64B");
-        return UCS_ERR_UNSUPPORTED;
-#endif
-    }
-
-out:
-    if (cached_bf_copy_func == NULL) {
-        cached_bf_copy_func = bf_copy_func;
-    }
-
-    *bf_copy_func_p = cached_bf_copy_func;
-    return UCS_OK;
-}
-#endif
-
 ucs_status_t
 uct_ib_mlx5_txwq_init_bf_copy(uct_ib_mlx5_txwq_t *txwq,
                               uct_ib_mlx5_bf_copy_mode_t bf_copy_mode)
 {
+    ucs_assert(bf_copy_mode < UCT_IB_MLX5_BF_COPY_MODE_LAST);
+
 #if defined(__aarch64__)
-    return uct_ib_mlx5_select_bf_copy(bf_copy_mode, &txwq->bf_copy);
+    txwq->bf_copy_mode = UCT_IB_MLX5_BF_COPY_MODE_GENERIC;
+    if (bf_copy_mode == UCT_IB_MLX5_BF_COPY_MODE_GENERIC) {
+        return UCS_OK;
+    }
+
+#if HAVE_AARCH64_ST64B_ASM
+    if (ucs_arch_get_cpu_flag() & UCS_CPU_FLAG_LS64) {
+        txwq->bf_copy_mode = UCT_IB_MLX5_BF_COPY_MODE_ST64B;
+        return UCS_OK;
+    }
+#endif
+
+    if (bf_copy_mode == UCT_IB_MLX5_BF_COPY_MODE_ST64B) {
+#if HAVE_AARCH64_ST64B_ASM
+        ucs_error("mlx5 BlueFlame ST64B copy was requested but CPU does "
+                  "not report LS64 support");
+#else
+        ucs_error("mlx5 BlueFlame ST64B copy was requested but UCX was built "
+                  "without assembler support for ST64B");
+#endif
+        return UCS_ERR_UNSUPPORTED;
+    }
 #else
     (void)txwq;
 

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -468,6 +468,14 @@ typedef enum {
 } uct_ib_mlx5_mmio_mode_t;
 
 
+typedef enum {
+    UCT_IB_MLX5_BF_COPY_MODE_GENERIC,
+    UCT_IB_MLX5_BF_COPY_MODE_AUTO,
+    UCT_IB_MLX5_BF_COPY_MODE_ST64B,
+    UCT_IB_MLX5_BF_COPY_MODE_LAST
+} uct_ib_mlx5_bf_copy_mode_t;
+
+
 typedef struct uct_ib_mlx5_iface_config {
 #if HAVE_IBV_DM
     struct {
@@ -475,9 +483,10 @@ typedef struct uct_ib_mlx5_iface_config {
         unsigned             count;
     } dm;
 #endif
-    uct_ib_mlx5_mmio_mode_t  mmio_mode;
-    ucs_ternary_auto_value_t ar_enable;
-    int                      cqe_zip_enable[UCT_IB_DIR_LAST];
+    uct_ib_mlx5_mmio_mode_t     mmio_mode;
+    uct_ib_mlx5_bf_copy_mode_t  bf_copy_mode;
+    ucs_ternary_auto_value_t    ar_enable;
+    int                         cqe_zip_enable[UCT_IB_DIR_LAST];
 } uct_ib_mlx5_iface_config_t;
 
 
@@ -643,6 +652,7 @@ typedef struct uct_ib_mlx5_res_domain {
 typedef struct uct_ib_mlx5_qp_attr {
     uct_ib_qp_attr_t            super;
     uct_ib_mlx5_mmio_mode_t     mmio_mode;
+    uct_ib_mlx5_bf_copy_mode_t  bf_copy_mode;
     uint32_t                    uidx;
     int                         full_handshake;
     int                         rdma_wr_disabled;
@@ -674,6 +684,14 @@ typedef struct uct_ib_mlx5_qp {
 } uct_ib_mlx5_qp_t;
 
 /* Send work-queue */
+struct uct_ib_mlx5_txwq;
+
+#if defined(__aarch64__)
+typedef void *(*uct_ib_mlx5_bf_copy_func_t)(
+        void *dst, void *src, uint16_t num_bb,
+        const struct uct_ib_mlx5_txwq *wq);
+#endif
+
 typedef struct uct_ib_mlx5_txwq {
     uct_ib_mlx5_qp_t            super;
     uint16_t                    sw_pi;      /* PI for next WQE */
@@ -690,6 +708,9 @@ typedef struct uct_ib_mlx5_txwq {
     uint8_t                     flags; /* Debug flags */
 #endif
     uct_ib_fence_info_t         fi;
+#if defined(__aarch64__)
+    uct_ib_mlx5_bf_copy_func_t  bf_copy;
+#endif
 } uct_ib_mlx5_txwq_t;
 
 
@@ -892,7 +913,13 @@ uct_ib_mlx5_get_mmio_mode(uct_priv_worker_t *worker,
  */
 ucs_status_t uct_ib_mlx5_txwq_init(uct_priv_worker_t *worker,
                                    uct_ib_mlx5_mmio_mode_t cfg_mmio_mode,
-                                   uct_ib_mlx5_txwq_t *txwq, struct ibv_qp *verbs_qp);
+                                   uct_ib_mlx5_bf_copy_mode_t bf_copy_mode,
+                                   uct_ib_mlx5_txwq_t *txwq,
+                                   struct ibv_qp *verbs_qp);
+
+ucs_status_t
+uct_ib_mlx5_txwq_init_bf_copy(uct_ib_mlx5_txwq_t *txwq,
+                              uct_ib_mlx5_bf_copy_mode_t bf_copy_mode);
 
 /* Get pointer to a WQE by producer index */
 void *uct_ib_mlx5_txwq_get_wqe(const uct_ib_mlx5_txwq_t *txwq, uint16_t pi);

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -469,8 +469,8 @@ typedef enum {
 
 
 typedef enum {
-    UCT_IB_MLX5_BF_COPY_MODE_GENERIC,
     UCT_IB_MLX5_BF_COPY_MODE_AUTO,
+    UCT_IB_MLX5_BF_COPY_MODE_GENERIC,
     UCT_IB_MLX5_BF_COPY_MODE_ST64B,
     UCT_IB_MLX5_BF_COPY_MODE_LAST
 } uct_ib_mlx5_bf_copy_mode_t;
@@ -683,15 +683,6 @@ typedef struct uct_ib_mlx5_qp {
     };
 } uct_ib_mlx5_qp_t;
 
-/* Send work-queue */
-struct uct_ib_mlx5_txwq;
-
-#if defined(__aarch64__)
-typedef void *(*uct_ib_mlx5_bf_copy_func_t)(
-        void *dst, void *src, uint16_t num_bb,
-        const struct uct_ib_mlx5_txwq *wq);
-#endif
-
 typedef struct uct_ib_mlx5_txwq {
     uct_ib_mlx5_qp_t            super;
     uint16_t                    sw_pi;      /* PI for next WQE */
@@ -703,14 +694,14 @@ typedef struct uct_ib_mlx5_txwq {
     void                        *qend;
     uint16_t                    bb_max;
     uint16_t                    sig_pi;     /* PI for last signaled WQE */
+#if defined(__aarch64__)
+    uint8_t                     bf_copy_mode;
+#endif
 #if UCS_ENABLE_ASSERT
     uint16_t                    hw_ci; /* First BB index of last completed WQE */
     uint8_t                     flags; /* Debug flags */
 #endif
     uct_ib_fence_info_t         fi;
-#if defined(__aarch64__)
-    uct_ib_mlx5_bf_copy_func_t  bf_copy;
-#endif
 } uct_ib_mlx5_txwq_t;
 
 

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -536,9 +536,6 @@ size_t uct_ib_mlx5_set_data_seg_iov(uct_ib_mlx5_txwq_t *txwq,
 static UCS_F_ALWAYS_INLINE void uct_ib_mlx5_bf_copy_bb(void * restrict dst,
                                                        void * restrict src)
 {
-#if defined(__ARM_NEON)
-    UCS_WORD_COPY(int16x8_t, dst, int16x8_t, src, MLX5_SEND_WQE_BB);
-#else
 #if defined(__SSE4_2__)
     typedef __m128i uct_ib_mlx5_send_wqe_bb_block_t;
 #else
@@ -553,13 +550,15 @@ static UCS_F_ALWAYS_INLINE void uct_ib_mlx5_bf_copy_bb(void * restrict dst,
     UCS_WORD_COPY(uct_ib_mlx5_send_wqe_bb_t, dst,
                   uct_ib_mlx5_send_wqe_bb_t, src,
                   MLX5_SEND_WQE_BB);
-#endif
 }
 
 static UCS_F_ALWAYS_INLINE
 void *uct_ib_mlx5_bf_copy(void *dst, void *src, uint16_t num_bb,
                           const uct_ib_mlx5_txwq_t *wq)
 {
+#if defined(__aarch64__)
+    return wq->bf_copy(dst, src, num_bb, wq);
+#else
     uint16_t n;
 
     for (n = 0; n < num_bb; ++n) {
@@ -571,6 +570,7 @@ void *uct_ib_mlx5_bf_copy(void *dst, void *src, uint16_t num_bb,
         }
     }
     return src;
+#endif
 }
 
 static UCS_F_ALWAYS_INLINE uint16_t

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -536,6 +536,9 @@ size_t uct_ib_mlx5_set_data_seg_iov(uct_ib_mlx5_txwq_t *txwq,
 static UCS_F_ALWAYS_INLINE void uct_ib_mlx5_bf_copy_bb(void * restrict dst,
                                                        void * restrict src)
 {
+#if defined(__ARM_NEON)
+    UCS_WORD_COPY(int16x8_t, dst, int16x8_t, src, MLX5_SEND_WQE_BB);
+#else
 #if defined(__SSE4_2__)
     typedef __m128i uct_ib_mlx5_send_wqe_bb_block_t;
 #else
@@ -550,27 +553,58 @@ static UCS_F_ALWAYS_INLINE void uct_ib_mlx5_bf_copy_bb(void * restrict dst,
     UCS_WORD_COPY(uct_ib_mlx5_send_wqe_bb_t, dst,
                   uct_ib_mlx5_send_wqe_bb_t, src,
                   MLX5_SEND_WQE_BB);
+#endif
 }
+
+#if defined(__aarch64__) && HAVE_AARCH64_ST64B_ASM
+static UCS_F_ALWAYS_INLINE void
+uct_ib_mlx5_bf_copy_bb_st64b(void *restrict dst, void *restrict src)
+{
+    ucs_assert(((uintptr_t)src % MLX5_SEND_WQE_BB) == 0);
+    ucs_assert(((uintptr_t)dst % MLX5_SEND_WQE_BB) == 0);
+
+    asm volatile(".arch_extension ls64\n"
+                 "ldp x8, x9, [%[src], #0]\n"
+                 "ldp x10, x11, [%[src], #16]\n"
+                 "ldp x12, x13, [%[src], #32]\n"
+                 "ldp x14, x15, [%[src], #48]\n"
+                 "st64b x8, [%[dst]]"
+                 :
+                 : [src] "r"(src), [dst] "r"(dst)
+                 : "x8", "x9", "x10", "x11", "x12", "x13", "x14",
+                   "x15", "memory");
+}
+#endif
+
+#define UCT_IB_MLX5_BF_COPY(_dst, _src, _num_bb, _wq, _copy_bb) \
+    ({ \
+        uint16_t _bb_num = (_num_bb); \
+        uint16_t _n; \
+        \
+        for (_n = 0; _n < _bb_num; ++_n) { \
+            _copy_bb(_dst, _src); \
+            (_dst) = UCS_PTR_BYTE_OFFSET(_dst, MLX5_SEND_WQE_BB); \
+            (_src) = UCS_PTR_BYTE_OFFSET(_src, MLX5_SEND_WQE_BB); \
+            if (ucs_unlikely((_src) == (_wq)->qend)) { \
+                (_src) = (_wq)->qstart; \
+            } \
+        } \
+        \
+        (_src); \
+    })
 
 static UCS_F_ALWAYS_INLINE
 void *uct_ib_mlx5_bf_copy(void *dst, void *src, uint16_t num_bb,
                           const uct_ib_mlx5_txwq_t *wq)
 {
-#if defined(__aarch64__)
-    return wq->bf_copy(dst, src, num_bb, wq);
-#else
-    uint16_t n;
-
-    for (n = 0; n < num_bb; ++n) {
-        uct_ib_mlx5_bf_copy_bb(dst, src);
-        dst = UCS_PTR_BYTE_OFFSET(dst, MLX5_SEND_WQE_BB);
-        src = UCS_PTR_BYTE_OFFSET(src, MLX5_SEND_WQE_BB);
-        if (ucs_unlikely(src == wq->qend)) {
-            src = wq->qstart;
-        }
+#if defined(__aarch64__) && HAVE_AARCH64_ST64B_ASM
+    if (wq->bf_copy_mode == UCT_IB_MLX5_BF_COPY_MODE_ST64B) {
+        return UCT_IB_MLX5_BF_COPY(dst, src, num_bb, wq,
+                                   uct_ib_mlx5_bf_copy_bb_st64b);
     }
-    return src;
 #endif
+
+    return UCT_IB_MLX5_BF_COPY(dst, src, num_bb, wq, uct_ib_mlx5_bf_copy_bb);
 }
 
 static UCS_F_ALWAYS_INLINE uint16_t

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -289,6 +289,7 @@ ucs_status_t uct_rc_mlx5_devx_create_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
     attr.super.srq_num          = iface->rx.srq.srq_num;
     attr.super.port             = dev->first_port;
     attr.mmio_mode              = iface->tx.mmio_mode;
+    attr.bf_copy_mode           = iface->tx.bf_copy_mode;
     status = uct_ib_mlx5_devx_create_qp(&iface->super.super,
                                         &iface->cq[UCT_IB_DIR_RX],
                                         &iface->cq[UCT_IB_DIR_RX],
@@ -414,6 +415,7 @@ uct_rc_mlx5_get_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
     iface->tm.cmd_wq.super.super.qp_num = qp->qp_num;
     return uct_ib_mlx5_txwq_init(iface->super.super.super.worker,
                                  iface->tx.mmio_mode,
+                                 iface->tx.bf_copy_mode,
                                  &iface->tm.cmd_wq.super, qp);
 }
 #endif
@@ -534,12 +536,13 @@ void uct_rc_mlx5_iface_fill_attr(uct_rc_mlx5_iface_common_t *iface,
     case UCT_IB_MLX5_OBJ_TYPE_DEVX:
     case UCT_IB_MLX5_OBJ_TYPE_NULL:
         uct_rc_iface_fill_attr(&iface->super, &qp_attr->super, max_send_wr, NULL);
-        qp_attr->mmio_mode = iface->tx.mmio_mode;
         break;
     case UCT_IB_MLX5_OBJ_TYPE_LAST:
         break;
     }
 
+    qp_attr->mmio_mode     = iface->tx.mmio_mode;
+    qp_attr->bf_copy_mode  = iface->tx.bf_copy_mode;
     qp_attr->super.srq_num = srq->srq_num;
 }
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -347,6 +347,7 @@ typedef struct uct_rc_mlx5_iface_common {
     struct {
         ucs_mpool_t                    atomic_desc_mp;
         uct_ib_mlx5_mmio_mode_t        mmio_mode;
+        uct_ib_mlx5_bf_copy_mode_t     bf_copy_mode;
         uint16_t                       bb_max;     /* limit number of outstanding WQE BBs */
     } tx;
     struct {

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -315,7 +315,8 @@ ucs_status_t uct_rc_mlx5_iface_create_qp(uct_rc_mlx5_iface_common_t *iface,
 
     if (attr->super.cap.max_send_wr) {
         status = uct_ib_mlx5_txwq_init(iface->super.super.super.worker,
-                                       iface->tx.mmio_mode, txwq,
+                                       iface->tx.mmio_mode,
+                                       iface->tx.bf_copy_mode, txwq,
                                        qp->verbs.qp);
         if (status != UCS_OK) {
             ucs_error("Failed to get mlx5 QP information");
@@ -777,6 +778,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
 
     dev                       = uct_ib_iface_device(&self->super.super);
     self->tx.mmio_mode        = mlx5_config->super.mmio_mode;
+    self->tx.bf_copy_mode     = mlx5_config->super.bf_copy_mode;
     self->tx.bb_max           = ucs_min(mlx5_config->tx_max_bb, UINT16_MAX);
     self->tm.am_desc.super.cb = uct_rc_mlx5_release_desc;
 

--- a/src/uct/ib/mlx5/ud/ud_mlx5.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.c
@@ -815,7 +815,8 @@ static ucs_status_t uct_ud_mlx5_iface_create_qp(uct_ib_iface_t *ib_iface,
     }
 
     status = uct_ib_mlx5_txwq_init(iface->super.super.super.worker,
-                                   iface->tx.mmio_mode, &iface->tx.wq,
+                                   iface->tx.mmio_mode,
+                                   iface->tx.bf_copy_mode, &iface->tx.wq,
                                    qp->verbs.qp);
     if (status != UCS_OK) {
         goto err_destroy_qp;
@@ -1002,8 +1003,9 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t, uct_md_h tl_md,
 
     uct_ib_mlx5_parse_cqe_zipping(md, &config->mlx5_common, &init_attr);
 
-    self->tx.mmio_mode     = config->mlx5_common.mmio_mode;
-    self->tx.wq.super.type = UCT_IB_MLX5_OBJ_TYPE_LAST;
+    self->tx.mmio_mode        = config->mlx5_common.mmio_mode;
+    self->tx.bf_copy_mode     = config->mlx5_common.bf_copy_mode;
+    self->tx.wq.super.type    = UCT_IB_MLX5_OBJ_TYPE_LAST;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ud_iface_t, &uct_ud_mlx5_iface_ops,
                               &uct_ud_mlx5_iface_tl_ops, tl_md, worker, params,

--- a/src/uct/ib/mlx5/ud/ud_mlx5.h
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.h
@@ -37,6 +37,7 @@ typedef struct {
     struct {
         uct_ib_mlx5_txwq_t              wq;
         uct_ib_mlx5_mmio_mode_t         mmio_mode;
+        uct_ib_mlx5_bf_copy_mode_t      bf_copy_mode;
     } tx;
     struct {
         uct_ib_mlx5_rxwq_t              wq;
@@ -60,4 +61,3 @@ uct_ud_mlx5_tx_moderation(uct_ud_mlx5_iface_t *iface, uint8_t ce_se)
 }
 
 #endif
-

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -9,6 +9,16 @@
 #include <uct/ib/rc/verbs/rc_verbs.h>
 #include <uct/test_peer_failure.h>
 
+extern "C" {
+#include <ucs/arch/cpu.h>
+}
+
+#ifdef HAVE_MLX5_DV
+extern "C" {
+#include <uct/ib/mlx5/rc/rc_mlx5.h>
+#include <uct/ib/mlx5/rc/rc_mlx5_common.h>
+}
+#endif
 
 void test_rc::init()
 {
@@ -143,6 +153,90 @@ UCS_TEST_SKIP_COND_P(test_rc_max_wr, send_limit,
 }
 
 UCT_INSTANTIATE_RC_TEST_CASE(test_rc_max_wr)
+
+#ifdef HAVE_MLX5_DV
+/* Real-HCA BF MMIO workload to compare copy modes with external counters. */
+class test_rc_mlx5_bf_mmio : public test_rc {
+protected:
+    enum {
+        NUM_ITERS = 65536
+    };
+
+    void verify_bf_post()
+    {
+        uct_rc_mlx5_base_ep_t *ep;
+
+        ep = ucs_derived_of(m_e1->ep(0), uct_rc_mlx5_base_ep_t);
+        ASSERT_TRUE(ep->tx.wq.reg != NULL);
+        ASSERT_EQ(UCT_IB_MLX5_MMIO_MODE_BF_POST, ep->tx.wq.reg->mode);
+    }
+
+    void run_bf_mmio_workload()
+    {
+        const uint64_t payload = 0xdeadbeefULL;
+        ucs_status_t status;
+
+        ASSERT_NO_FATAL_FAILURE(verify_bf_post());
+
+        for (unsigned i = 0; i < NUM_ITERS; ++i) {
+            do {
+                status = uct_ep_am_short(m_e1->ep(0), 0, i, &payload,
+                                         sizeof(payload));
+                if (status == UCS_ERR_NO_RESOURCE) {
+                    short_progress_loop();
+                }
+            } while (status == UCS_ERR_NO_RESOURCE);
+
+            ASSERT_UCS_OK(status);
+
+            if ((i & 0x3ff) == 0) {
+                progress();
+            }
+        }
+
+        flush();
+        UCS_TEST_MESSAGE << "posted " << NUM_ITERS
+                         << " rc_mlx5 BlueFlame AM short operations";
+    }
+};
+
+UCS_TEST_SKIP_COND_P(test_rc_mlx5_bf_mmio, bf_copy_generic,
+                     !check_caps(UCT_IFACE_FLAG_AM_SHORT),
+                     "RC_MLX5_MMIO_MODE=bf_post",
+                     "RC_MLX5_BF_COPY_MODE=generic",
+                     "RC_FC_ENABLE?=n")
+{
+    run_bf_mmio_workload();
+}
+
+_UCT_INSTANTIATE_TEST_CASE(test_rc_mlx5_bf_mmio, rc_mlx5)
+
+#if defined(__aarch64__) && HAVE_AARCH64_ST64B_ASM
+class test_rc_mlx5_bf_mmio_st64b : public test_rc_mlx5_bf_mmio {
+public:
+    virtual void init()
+    {
+        if (!(ucs_arch_get_cpu_flag() & UCS_CPU_FLAG_ST64B)) {
+            UCS_TEST_SKIP_R("CPU does not report ST64B support");
+        }
+
+        test_rc_mlx5_bf_mmio::init();
+    }
+};
+
+UCS_TEST_SKIP_COND_P(test_rc_mlx5_bf_mmio_st64b, bf_copy_st64b,
+                     !check_caps(UCT_IFACE_FLAG_AM_SHORT),
+                     "RC_MLX5_MMIO_MODE=bf_post",
+                     "RC_MLX5_BF_COPY_MODE=st64b",
+                     "RC_FC_ENABLE?=n")
+{
+    run_bf_mmio_workload();
+}
+
+_UCT_INSTANTIATE_TEST_CASE(test_rc_mlx5_bf_mmio_st64b, rc_mlx5)
+#endif
+
+#endif
 
 
 class test_rc_iface_flush_remote : public uct_test {
@@ -1024,12 +1118,6 @@ UCS_TEST_SKIP_COND_P(test_rc_flow_control_stats, soft_request,
 
 UCT_INSTANTIATE_RC_TEST_CASE(test_rc_flow_control_stats)
 
-#endif
-
-#ifdef HAVE_MLX5_DV
-extern "C" {
-#include <uct/ib/mlx5/rc/rc_mlx5_common.h>
-}
 #endif
 
 test_uct_iface_attrs::attr_map_t test_rc_iface_attrs::get_num_iov() {

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -216,8 +216,8 @@ class test_rc_mlx5_bf_mmio_st64b : public test_rc_mlx5_bf_mmio {
 public:
     virtual void init()
     {
-        if (!(ucs_arch_get_cpu_flag() & UCS_CPU_FLAG_ST64B)) {
-            UCS_TEST_SKIP_R("CPU does not report ST64B support");
+        if (!(ucs_arch_get_cpu_flag() & UCS_CPU_FLAG_LS64)) {
+            UCS_TEST_SKIP_R("CPU does not report LS64 support");
         }
 
         test_rc_mlx5_bf_mmio::init();


### PR DESCRIPTION
### What
Add an aarch64 `st64b` BlueFlame copy mode for mlx5, with runtime selection and generic-copy fallback.

### Why

`st64b` can issue a single 64-byte store for BlueFlame doorbell writes, which may improve MMIO write-combining behavior on LS64-capable ARM CPUs.

### How

Detect LS64 support with `getauxval(AT_HWCAP3) & HWCAP3_LS64`, add an mlx5 BF copy function using `st64b`, select it through the BF copy-mode config, and add a gtest variant for the ST64B MMIO path.