### PR TITLE
UCT/CUDA_IPC: Export VMM memory as POSIX FD when fabric is unavailable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -123,6 +123,7 @@ Tzafrir Cohen <tzafrirc@nvidia.com>
 Valentin Petrov <valentinp@mellanox.com>
 Wenbin Lu <wenbin.lu@stonybrook.edu>
 Xin Zhao <xinz@mellanox.com>
+Xinyu Zhang <xinyzng@gmail.com>
 Xu Yifeng <yifeng.xyf@alibaba-inc.com>
 Yaser Afshar <yaser.afshar@intel.com>
 Yihua Xu <yihua.xu@intel.com>

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -20,6 +20,21 @@
 #include <uct/cuda/base/cuda_ctx.inl>
 #include "cuda_ipc.inl"
 
+#if HAVE_CUDA_FABRIC && defined(__linux__)
+#include <unistd.h>
+#include <sys/syscall.h>
+
+/* pidfd_open(2) and pidfd_getfd(2) syscall numbers are identical on all
+ * architectures; define them for kernel headers older than the syscalls
+ * themselves (Linux 5.3 and 5.6 respectively) */
+#ifndef __NR_pidfd_open
+#define __NR_pidfd_open  434
+#endif
+#ifndef __NR_pidfd_getfd
+#define __NR_pidfd_getfd 438
+#endif
+#endif
+
 typedef struct uct_cuda_ipc_cache_hash_key {
     pid_t        pid;
     ucs_sys_ns_t pid_ns;
@@ -175,7 +190,8 @@ static ucs_status_t uct_cuda_ipc_close_memhandle(uct_cuda_ipc_cache_region_t *re
 #if HAVE_CUDA_FABRIC
     ucs_status_t status;
 
-    if (region->key.ph.handle_type == UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM) {
+    if ((region->key.ph.handle_type == UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM) ||
+        (region->key.ph.handle_type == UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD)) {
         status = UCT_CUDADRV_FUNC_LOG_WARN(cuMemUnmap(
                     (CUdeviceptr)region->mapped_addr, region->key.b_len));
         if (status != UCS_OK) {
@@ -300,54 +316,129 @@ uct_cuda_ipc_init_access_desc(CUmemAccessDesc *access_desc, CUdevice cu_dev)
     access_desc->location.id   = cu_dev;
 }
 
+/* Map an imported VMM allocation handle into the local VA space. The handle
+ * itself is not released, regardless of the outcome. */
 static ucs_status_t
-uct_cuda_ipc_open_memhandle_vmm(const uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
-                                CUdeviceptr *mapped_addr,
-                                ucs_log_level_t log_level)
+uct_cuda_ipc_map_alloc_handle(CUmemGenericAllocationHandle handle,
+                              size_t b_len, CUdevice cu_dev,
+                              CUdeviceptr *mapped_addr,
+                              ucs_log_level_t log_level)
 {
     CUmemAccessDesc access_desc = {};
     ucs_status_t status;
     CUdeviceptr dptr;
-    CUmemGenericAllocationHandle handle;
 
-    status = UCT_CUDADRV_FUNC(cuMemImportFromShareableHandle(&handle,
-                (void*)&key->ph.handle.fabric_handle,
-                CU_MEM_HANDLE_TYPE_FABRIC), log_level);
+    status = UCT_CUDADRV_FUNC(cuMemAddressReserve(&dptr, b_len, 0, 0, 0),
+                              log_level);
     if (status != UCS_OK) {
         goto out;
     }
 
-    status = UCT_CUDADRV_FUNC(cuMemAddressReserve(&dptr, key->b_len, 0, 0, 0),
-                              log_level);
-    if (status != UCS_OK) {
-        goto release_handle;
-    }
-
-    status = UCT_CUDADRV_FUNC(cuMemMap(dptr, key->b_len, 0, handle, 0),
-                              log_level);
+    status = UCT_CUDADRV_FUNC(cuMemMap(dptr, b_len, 0, handle, 0), log_level);
     if (status != UCS_OK) {
         goto release_va_range;
     }
 
     uct_cuda_ipc_init_access_desc(&access_desc, cu_dev);
 
-    status = UCT_CUDADRV_FUNC(cuMemSetAccess(dptr, key->b_len, &access_desc, 1),
+    status = UCT_CUDADRV_FUNC(cuMemSetAccess(dptr, b_len, &access_desc, 1),
                               log_level);
     if (status != UCS_OK) {
         goto unmap_range;
     }
 
     *mapped_addr = dptr;
-    goto release_handle;
+    return UCS_OK;
 
 unmap_range:
-    UCT_CUDADRV_FUNC_LOG_WARN(cuMemUnmap(dptr, key->b_len));
+    UCT_CUDADRV_FUNC_LOG_WARN(cuMemUnmap(dptr, b_len));
 release_va_range:
-    UCT_CUDADRV_FUNC_LOG_WARN(cuMemAddressFree(dptr, key->b_len));
-release_handle:
-    UCT_CUDADRV_FUNC_LOG_WARN(cuMemRelease(handle));
+    UCT_CUDADRV_FUNC_LOG_WARN(cuMemAddressFree(dptr, b_len));
 out:
     return status;
+}
+
+static ucs_status_t
+uct_cuda_ipc_open_memhandle_vmm(const uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
+                                CUdeviceptr *mapped_addr,
+                                ucs_log_level_t log_level)
+{
+    ucs_status_t status;
+    CUmemGenericAllocationHandle handle;
+
+    status = UCT_CUDADRV_FUNC(cuMemImportFromShareableHandle(&handle,
+                (void*)&key->ph.handle.fabric_handle,
+                CU_MEM_HANDLE_TYPE_FABRIC), log_level);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_cuda_ipc_map_alloc_handle(handle, key->b_len, cu_dev,
+                                           mapped_addr, log_level);
+    UCT_CUDADRV_FUNC_LOG_WARN(cuMemRelease(handle));
+    return status;
+}
+
+/* Import a VMM allocation that the exporter shared as a POSIX file
+ * descriptor: take a local duplicate of the exporter's descriptor with
+ * pidfd_getfd(2) and import it. Requires Linux >= 5.6, a shared PID
+ * namespace, and ptrace permission toward the exporting process; on any
+ * failure the peer is reported as unreachable, in which case the transport
+ * selection falls back to other transports the same way it does for
+ * UCT_CUDA_IPC_KEY_HANDLE_TYPE_NO_IPC keys. */
+static ucs_status_t
+uct_cuda_ipc_open_memhandle_posix_fd(
+        const uct_cuda_ipc_extended_rkey_t *ext_key, CUdevice cu_dev,
+        CUdeviceptr *mapped_addr, ucs_log_level_t log_level)
+{
+#if defined(__linux__)
+    const uct_cuda_ipc_rkey_t *key = &ext_key->super;
+    CUmemGenericAllocationHandle handle;
+    ucs_status_t status;
+    int pidfd;
+    int fd;
+
+    if (ext_key->pid_ns != ucs_sys_get_ns(UCS_SYS_NS_TYPE_PID)) {
+        ucs_diag("cannot import posix fd exported by pid %d: peer is in a "
+                 "different pid namespace", key->pid);
+        return UCS_ERR_UNREACHABLE;
+    }
+
+    pidfd = syscall(__NR_pidfd_open, key->pid, 0);
+    if (pidfd < 0) {
+        ucs_diag("pidfd_open(pid=%d) failed: %m", key->pid);
+        return UCS_ERR_UNREACHABLE;
+    }
+
+    fd = syscall(__NR_pidfd_getfd, pidfd, key->ph.handle.posix_fd, 0);
+    if (fd < 0) {
+        /* EPERM: no PTRACE_MODE_ATTACH_REALCREDS permission toward the
+         * exporter; ENOSYS: kernel older than Linux 5.6 */
+        ucs_diag("pidfd_getfd(pid=%d, fd=%d) failed: %m", key->pid,
+                 key->ph.handle.posix_fd);
+        close(pidfd);
+        return UCS_ERR_UNREACHABLE;
+    }
+
+    close(pidfd);
+
+    status = UCT_CUDADRV_FUNC(cuMemImportFromShareableHandle(&handle,
+                (void*)(uintptr_t)fd,
+                CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR), log_level);
+    close(fd);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_cuda_ipc_map_alloc_handle(handle, key->b_len, cu_dev,
+                                           mapped_addr, log_level);
+    UCT_CUDADRV_FUNC_LOG_WARN(cuMemRelease(handle));
+    return status;
+#else
+    ucs_log(log_level, "importing a posix fd handle requires pidfd_getfd(2), "
+            "which is not supported on this platform");
+    return UCS_ERR_UNSUPPORTED;
+#endif
 }
 
 static ucs_status_t cuda_ipc_rem_mpool_cache_create(uct_cuda_ipc_rkey_t *key,
@@ -448,9 +539,11 @@ err:
 #endif
 
 static ucs_status_t
-uct_cuda_ipc_open_memhandle(uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
-                            CUdeviceptr *mapped_addr, ucs_log_level_t log_level)
+uct_cuda_ipc_open_memhandle(uct_cuda_ipc_extended_rkey_t *ext_key,
+                            CUdevice cu_dev, CUdeviceptr *mapped_addr,
+                            ucs_log_level_t log_level)
 {
+    uct_cuda_ipc_rkey_t *key = &ext_key->super;
     ucs_log_level_t level;
 
     ucs_trace("key handle type %u", key->ph.handle_type);
@@ -466,6 +559,9 @@ uct_cuda_ipc_open_memhandle(uct_cuda_ipc_rkey_t *key, CUdevice cu_dev,
     case UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL:
         return uct_cuda_ipc_open_memhandle_mempool(key, cu_dev, mapped_addr,
                                                    log_level);
+    case UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD:
+        return uct_cuda_ipc_open_memhandle_posix_fd(ext_key, cu_dev,
+                                                    mapped_addr, log_level);
 #endif
     case UCT_CUDA_IPC_KEY_HANDLE_TYPE_NO_IPC:
         level = UCS_LOG_LEVEL_DEBUG;
@@ -660,15 +756,15 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
         }
     }
 
-    status = uct_cuda_ipc_open_memhandle(key, cu_dev, (CUdeviceptr*)mapped_addr,
-                                         log_level);
+    status = uct_cuda_ipc_open_memhandle(ext_key, cu_dev,
+                                         (CUdeviceptr*)mapped_addr, log_level);
     if (ucs_unlikely(status != UCS_OK)) {
         if (ucs_likely(status == UCS_ERR_ALREADY_EXISTS)) {
             /* unmap all overlapping regions and retry*/
             uct_cuda_ipc_cache_invalidate_regions(cache, (void *)key->d_bptr,
                                                   UCS_PTR_BYTE_OFFSET(key->d_bptr,
                                                                       key->b_len));
-            status = uct_cuda_ipc_open_memhandle(key, cu_dev,
+            status = uct_cuda_ipc_open_memhandle(ext_key, cu_dev,
                                                  (CUdeviceptr*)mapped_addr,
                                                  log_level);
             if (ucs_unlikely(status != UCS_OK)) {
@@ -676,7 +772,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_map_memhandle,
                     /* unmap all cache entries and retry */
                     uct_cuda_ipc_cache_purge(cache);
                     status = uct_cuda_ipc_open_memhandle(
-                            key, cu_dev, (CUdeviceptr*)mapped_addr, log_level);
+                            ext_key, cu_dev, (CUdeviceptr*)mapped_addr,
+                            log_level);
                     if (status != UCS_OK) {
                         ucs_fatal("%s: failed to open ipc mem handle. addr:%p "
                                   "len:%lu (%s)", cache->name,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -40,6 +40,17 @@ static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
      "Enable multi-node NVLINK capabilities.",
      ucs_offsetof(uct_cuda_ipc_md_config_t, enable_mnnvl), UCS_CONFIG_TYPE_TERNARY},
 
+    {"ENABLE_POSIX_FD", "y",
+     "Allow exporting VMM (cuMemCreate) memory whose allowed handle types\n"
+     "include CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR but which cannot be\n"
+     "exported as a fabric handle. The importing process retrieves the file\n"
+     "descriptor with pidfd_getfd(2), which requires Linux >= 5.6, a shared\n"
+     "PID namespace, and ptrace permission toward the exporting process.\n"
+     "Each registered region keeps one file descriptor open in the exporting\n"
+     "process until it is deregistered.",
+     ucs_offsetof(uct_cuda_ipc_md_config_t, enable_posix_fd),
+     UCS_CONFIG_TYPE_BOOL},
+
     {"CACHE_MAX_REGIONS", "inf",
      "Maximum number of regions in each per-peer CUDA IPC remote handle cache.\n"
      "Each remote peer has a separate cache; this limit applies independently\n"
@@ -134,8 +145,78 @@ uct_cuda_ipc_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
     return UCS_OK;
 }
 
+#if HAVE_CUDA_FABRIC
+/* An rkey carries a single allocation handle, so a VA range that is backed by
+ * more than one VMM allocation (e.g. a PyTorch expandable segment that grew
+ * over time) cannot be exported. Check that the same allocation backs both
+ * ends of the range. */
 static ucs_status_t
-uct_cuda_ipc_mem_add_reg(void *addr, uct_cuda_ipc_memh_t *memh,
+uct_cuda_ipc_check_single_handle_range(CUmemGenericAllocationHandle handle,
+                                       const uct_cuda_ipc_lkey_t *key)
+{
+    CUmemGenericAllocationHandle end_handle;
+    ucs_status_t status;
+
+    status = UCT_CUDADRV_FUNC(
+            cuMemRetainAllocationHandle(
+                    &end_handle,
+                    (void*)(uintptr_t)(key->d_bptr + key->b_len - 1)),
+            UCS_LOG_LEVEL_DIAG);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    UCT_CUDADRV_FUNC_LOG_WARN(cuMemRelease(end_handle));
+    if (end_handle != handle) {
+        ucs_diag("vmm range %p..%p is backed by multiple allocation handles",
+                 (void*)key->d_bptr,
+                 (void*)(uintptr_t)(key->d_bptr + key->b_len));
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_cuda_ipc_pack_posix_fd(uct_cuda_ipc_md_t *md, uct_cuda_ipc_lkey_t *key,
+                           CUmemGenericAllocationHandle handle,
+                           uint64_t allowed_handle_types, void *addr)
+{
+    ucs_status_t status;
+    int fd;
+
+    if (!md->enable_posix_fd ||
+        !(allowed_handle_types & CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    status = uct_cuda_ipc_check_single_handle_range(handle, key);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = UCT_CUDADRV_FUNC(cuMemExportToShareableHandle(
+                                      &fd, handle,
+                                      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
+                                      0),
+                              UCS_LOG_LEVEL_DIAG);
+    if (status != UCS_OK) {
+        ucs_debug("unable to export posix fd handle for VMM ptr: %p", addr);
+        return status;
+    }
+
+    /* The file descriptor stays open until the region is deregistered, so
+     * that the importer can retrieve it with pidfd_getfd(2) at any time */
+    key->ph.handle.posix_fd = fd;
+    key->ph.handle_type     = UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD;
+    ucs_trace("packed vmm posix fd %d for %p", fd, addr);
+    return UCS_OK;
+}
+#endif
+
+static ucs_status_t
+uct_cuda_ipc_mem_add_reg(uct_cuda_ipc_md_t *md, void *addr,
+                         uct_cuda_ipc_memh_t *memh,
                          uct_cuda_ipc_lkey_t **key_p)
 {
     uct_cuda_ipc_lkey_t *key;
@@ -198,7 +279,9 @@ uct_cuda_ipc_mem_add_reg(void *addr, uct_cuda_ipc_memh_t *memh,
         goto legacy_path;
     }
 
-    if (!(allowed_handle_types & CU_MEM_HANDLE_TYPE_FABRIC)) {
+    if (!(allowed_handle_types &
+          (CU_MEM_HANDLE_TYPE_FABRIC |
+           CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR))) {
         goto non_ipc;
     }
 
@@ -206,19 +289,35 @@ uct_cuda_ipc_mem_add_reg(void *addr, uct_cuda_ipc_memh_t *memh,
         UCT_CUDADRV_FUNC(cuMemRetainAllocationHandle(&handle, addr),
                 UCS_LOG_LEVEL_DIAG);
     if (status == UCS_OK) {
-        status =
-            UCT_CUDADRV_FUNC_LOG_ERR(cuMemExportToShareableHandle(
-                        &key->ph.handle.fabric_handle, handle,
-                        CU_MEM_HANDLE_TYPE_FABRIC, 0));
-        UCT_CUDADRV_FUNC_LOG_WARN(cuMemRelease(handle));
-        if (status != UCS_OK) {
-            ucs_debug("unable to export handle for VMM ptr: %p", addr);
-            goto non_ipc;
+        if (allowed_handle_types & CU_MEM_HANDLE_TYPE_FABRIC) {
+            status = UCT_CUDADRV_FUNC(cuMemExportToShareableHandle(
+                                              &key->ph.handle.fabric_handle,
+                                              handle, CU_MEM_HANDLE_TYPE_FABRIC,
+                                              0),
+                                      UCS_LOG_LEVEL_DIAG);
+            if (status == UCS_OK) {
+                UCT_CUDADRV_FUNC_LOG_WARN(cuMemRelease(handle));
+                key->ph.handle_type = UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM;
+                ucs_trace("packed vmm fabric handle for %p", addr);
+                goto common_path;
+            }
+
+            ucs_debug("unable to export fabric handle for VMM ptr: %p", addr);
         }
 
-        key->ph.handle_type = UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM;
-        ucs_trace("packed vmm fabric handle for %p", addr);
-        goto common_path;
+        status = uct_cuda_ipc_pack_posix_fd(md, key, handle,
+                                            allowed_handle_types, addr);
+        UCT_CUDADRV_FUNC_LOG_WARN(cuMemRelease(handle));
+        if (status == UCS_OK) {
+            goto common_path;
+        }
+
+        goto non_ipc;
+    }
+
+    if (!(allowed_handle_types & CU_MEM_HANDLE_TYPE_FABRIC)) {
+        /* Mempool memory is currently exported as a fabric handle only */
+        goto non_ipc;
     }
 
     if (mempool == 0) {
@@ -298,7 +397,8 @@ uct_cuda_ipc_mkey_pack(uct_md_h md, uct_mem_h tl_memh, void *address,
         }
     }
 
-    status = uct_cuda_ipc_mem_add_reg(address, memh, &key);
+    status = uct_cuda_ipc_mem_add_reg(ucs_derived_of(md, uct_cuda_ipc_md_t),
+                                      address, memh, &key);
     if (status != UCS_OK) {
         return status;
     }
@@ -484,6 +584,11 @@ uct_cuda_ipc_mem_dereg(uct_md_h md, const uct_md_mem_dereg_params_t *params)
     UCT_MD_MEM_DEREG_CHECK_PARAMS(params, 0);
 
     ucs_list_for_each_safe(key, tmp, &memh->list, link) {
+#if HAVE_CUDA_FABRIC
+        if (key->ph.handle_type == UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD) {
+            close(key->ph.handle.posix_fd);
+        }
+#endif
         ucs_free(key);
     }
 
@@ -617,6 +722,7 @@ uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
     md->super.component = &uct_cuda_ipc_component.super;
     md->enable_mnnvl    = uct_cuda_ipc_md_check_fabric_info(
                                                   md, ipc_config->enable_mnnvl);
+    md->enable_posix_fd = ipc_config->enable_posix_fd;
 
     uct_cuda_ipc_cache_set_global_limits(ipc_config->cache_max_regions,
                                          ipc_config->cache_max_size);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -19,7 +19,9 @@ typedef enum {
     UCT_CUDA_IPC_KEY_HANDLE_TYPE_LEGACY, /* cudaMalloc memory */
 #if HAVE_CUDA_FABRIC
     UCT_CUDA_IPC_KEY_HANDLE_TYPE_VMM, /* cuMemCreate memory */
-    UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL /* cudaMallocAsync memory */
+    UCT_CUDA_IPC_KEY_HANDLE_TYPE_MEMPOOL, /* cudaMallocAsync memory */
+    UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD /* cuMemCreate memory exported as a
+                                             POSIX file descriptor */
 #endif
 } uct_cuda_ipc_key_handle_t;
 
@@ -30,6 +32,10 @@ typedef struct uct_cuda_ipc_md_handle {
         CUipcMemHandle        legacy;        /* Legacy IPC handle */
 #if HAVE_CUDA_FABRIC
         CUmemFabricHandle     fabric_handle; /* VMM/Mallocasync export handle */
+        int                   posix_fd;      /* Exporter-side file descriptor;
+                                                the importer retrieves a local
+                                                duplicate of it with
+                                                pidfd_getfd(2) */
 #endif
     } handle;
 #if HAVE_CUDA_FABRIC
@@ -45,6 +51,8 @@ typedef struct uct_cuda_ipc_md_handle {
 typedef struct uct_cuda_ipc_md {
     uct_md_t                 super;             /**< Domain info */
     int                      enable_mnnvl;      /**< Multi-node NVLINK support status */
+    int                      enable_posix_fd;   /**< Allow exporting VMM memory
+                                                     as a POSIX file descriptor */
 } uct_cuda_ipc_md_t;
 
 
@@ -105,6 +113,8 @@ extern uct_cuda_ipc_component_t uct_cuda_ipc_component;
 typedef struct uct_cuda_ipc_md_config {
     uct_md_config_t          super;
     ucs_ternary_auto_value_t enable_mnnvl;
+    int                      enable_posix_fd;   /**< Allow exporting VMM memory
+                                                     as a POSIX file descriptor */
     unsigned long            cache_max_regions; /**< Max cached IPC regions per peer */
     size_t                   cache_max_size;    /**< Max total cached IPC mapping size */
 } uct_cuda_ipc_md_config_t;

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -107,6 +107,66 @@ protected:
         free_mempool(&ptr, &mpool, &cu_stream);
         return rkey;
     }
+
+    static CUmemAllocationProp vmm_posix_fd_prop()
+    {
+        CUmemAllocationProp prop = {};
+        CUdevice cu_device;
+
+        EXPECT_EQ(CUDA_SUCCESS, cuCtxGetDevice(&cu_device));
+        prop.type                 = CU_MEM_ALLOCATION_TYPE_PINNED;
+        prop.location.type        = CU_MEM_LOCATION_TYPE_DEVICE;
+        prop.location.id          = (int)cu_device;
+        prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+        return prop;
+    }
+
+    static bool vmm_posix_fd_supported()
+    {
+        constexpr CUdevice_attribute attr =
+                CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR_SUPPORTED;
+        CUdevice cu_device;
+        int supported = 0;
+
+        EXPECT_EQ(CUDA_SUCCESS, cuCtxGetDevice(&cu_device));
+        EXPECT_EQ(CUDA_SUCCESS,
+                  cuDeviceGetAttribute(&supported, attr, cu_device));
+        return supported != 0;
+    }
+
+    static void alloc_vmm_posix_fd(CUdeviceptr *ptr, size_t size,
+                                   CUmemGenericAllocationHandle *handle)
+    {
+        CUmemAllocationProp prop    = vmm_posix_fd_prop();
+        CUmemAccessDesc access_desc = {};
+
+        EXPECT_EQ(CUDA_SUCCESS, cuMemAddressReserve(ptr, size, 0, 0, 0));
+        EXPECT_EQ(CUDA_SUCCESS, cuMemCreate(handle, size, &prop, 0));
+        EXPECT_EQ(CUDA_SUCCESS, cuMemMap(*ptr, size, 0, *handle, 0));
+
+        access_desc.location = prop.location;
+        access_desc.flags    = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+        EXPECT_EQ(CUDA_SUCCESS, cuMemSetAccess(*ptr, size, &access_desc, 1));
+    }
+
+    static void free_vmm_posix_fd(CUdeviceptr ptr, size_t size,
+                                  CUmemGenericAllocationHandle handle)
+    {
+        EXPECT_EQ(CUDA_SUCCESS, cuMemUnmap(ptr, size));
+        EXPECT_EQ(CUDA_SUCCESS, cuMemRelease(handle));
+        EXPECT_EQ(CUDA_SUCCESS, cuMemAddressFree(ptr, size));
+    }
+
+    static size_t vmm_posix_fd_granularity()
+    {
+        CUmemAllocationProp prop = vmm_posix_fd_prop();
+        size_t granularity       = 0;
+
+        EXPECT_EQ(CUDA_SUCCESS,
+                  cuMemGetAllocationGranularity(&granularity, &prop,
+                                                CU_MEM_ALLOC_GRANULARITY_MINIMUM));
+        return granularity;
+    }
 #endif
 
     void test_mkey_pack_on_thread(void *ptr, size_t size)
@@ -221,6 +281,91 @@ UCS_TEST_P(test_cuda_ipc_md, mkey_pack_mempool)
     alloc_mempool(&ptr, &mpool, &cu_stream, size);
     test_mkey_pack_on_thread((void*)ptr, size);
     free_mempool(&ptr, &mpool, &cu_stream);
+#else
+    UCS_TEST_SKIP_R("built without fabric support");
+#endif
+}
+
+UCS_TEST_P(test_cuda_ipc_md, mkey_pack_vmm_posix_fd)
+{
+#if HAVE_CUDA_FABRIC
+    if (!vmm_posix_fd_supported()) {
+        UCS_TEST_SKIP_R("posix fd handle type is not supported");
+    }
+
+    const size_t size = vmm_posix_fd_granularity();
+    CUmemGenericAllocationHandle handle;
+    uct_cuda_ipc_extended_rkey_t rkey;
+    CUdeviceptr ptr;
+    uct_mem_h memh;
+
+    alloc_vmm_posix_fd(&ptr, size, &handle);
+
+    EXPECT_UCS_OK(md()->ops->mem_reg(md(), (void*)ptr, size, NULL, &memh));
+    EXPECT_UCS_OK(md()->ops->mkey_pack(md(), memh, (void*)ptr, size, NULL,
+                                       &rkey));
+    EXPECT_EQ(UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD,
+              rkey.super.ph.handle_type);
+
+    /* Self-import: spoof the device uuid so that rkey unpack does not take
+     * the local rkey shortcut and exercises the pidfd import path. The
+     * import may be blocked by the environment (kernel < 5.6, seccomp), in
+     * which case the peer is unreachable, same as a no-ipc key. */
+    auto uuid64 = reinterpret_cast<int64_t*>(rkey.super.uuid.bytes);
+    uuid64[0]   = ~uuid64[0];
+    uuid64[1]   = ~uuid64[1];
+
+    uct_rkey_unpack_params_t unpack_params = {0};
+    uct_rkey_bundle_t rkey_bundle;
+    ucs_status_t status = uct_rkey_unpack_v2(md()->component, &rkey,
+                                             &unpack_params, &rkey_bundle);
+    EXPECT_TRUE((status == UCS_OK) || (status == UCS_ERR_UNREACHABLE))
+            << ucs_status_string(status);
+    if (status == UCS_OK) {
+        uct_rkey_release(md()->component, &rkey_bundle);
+    } else {
+        UCS_TEST_MESSAGE << "posix fd import is unavailable: "
+                         << ucs_status_string(status);
+    }
+
+    uct_md_mem_dereg_params_t params;
+    params.field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH;
+    params.memh       = memh;
+    EXPECT_UCS_OK(md()->ops->mem_dereg(md(), &params));
+
+    free_vmm_posix_fd(ptr, size, handle);
+#else
+    UCS_TEST_SKIP_R("built without fabric support");
+#endif
+}
+
+UCS_TEST_P(test_cuda_ipc_md, mkey_pack_vmm_posix_fd_disabled,
+           "CUDA_IPC_ENABLE_POSIX_FD=n")
+{
+#if HAVE_CUDA_FABRIC
+    if (!vmm_posix_fd_supported()) {
+        UCS_TEST_SKIP_R("posix fd handle type is not supported");
+    }
+
+    const size_t size = vmm_posix_fd_granularity();
+    CUmemGenericAllocationHandle handle;
+    uct_cuda_ipc_extended_rkey_t rkey;
+    CUdeviceptr ptr;
+    uct_mem_h memh;
+
+    alloc_vmm_posix_fd(&ptr, size, &handle);
+
+    EXPECT_UCS_OK(md()->ops->mem_reg(md(), (void*)ptr, size, NULL, &memh));
+    EXPECT_UCS_OK(md()->ops->mkey_pack(md(), memh, (void*)ptr, size, NULL,
+                                       &rkey));
+    EXPECT_EQ(UCT_CUDA_IPC_KEY_HANDLE_TYPE_NO_IPC, rkey.super.ph.handle_type);
+
+    uct_md_mem_dereg_params_t params;
+    params.field_mask = UCT_MD_MEM_DEREG_FIELD_MEMH;
+    params.memh       = memh;
+    EXPECT_UCS_OK(md()->ops->mem_dereg(md(), &params));
+
+    free_vmm_posix_fd(ptr, size, handle);
 #else
     UCS_TEST_SKIP_R("built without fabric support");
 #endif


### PR DESCRIPTION
## What?

Add a POSIX file descriptor arm to the `cuda_ipc` handle-type dispatch, so that
VMM (`cuMemCreate`) memory whose `allowed_handle_types` is
`CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR` (and not fabric) can use the
`cuda_ipc` transport instead of being classified `NO_IPC`.

Fixes #11548.

## Why?

`cuda_ipc` currently exports VMM and mempool memory **only** as
`CU_MEM_HANDLE_TYPE_FABRIC`. PyTorch under
`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` (a very common
fragmentation mitigation in large-model training) allocates via VMM with
`requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`, so such
buffers silently lose the `cuda_ipc` lane: on a same-node H100/NVLink system
with no RDMA NIC, a one-sided READ drops from ~200 GB/s (`zero-copy |
cuda_ipc/cuda`) to ~0.3 GB/s (`software emulation | tcp`), with data staying
correct — brutal to diagnose. Fabric handles cannot help here: they require
fabricmanager/IMEX, which most single-node and cloud deployments lack, and
`allowed_handle_types` is fixed by the allocator at `cuMemCreate` time.

Full bisect data and reproducers in #11548 and ai-dynamo/nixl#1754.

## How?

**Exporter** (`cuda_ipc_md.c`): when the allocation is not legacy-IPC-capable
and cannot be exported as a fabric handle, but allows POSIX FD handles, export
it with `cuMemExportToShareableHandle(..., POSIX_FILE_DESCRIPTOR)` and pack the
fd under a new `UCT_CUDA_IPC_KEY_HANDLE_TYPE_POSIX_FD`. The exporter pid is
already part of the rkey, and the fd fits in the existing handle union, so the
**rkey wire format and size are unchanged**. The fd stays open until
deregistration.

**Importer** (`cuda_ipc_cache.c`): obtain a local duplicate of the exporter's
fd with `pidfd_open(2)` + `pidfd_getfd(2)` (no side channel needed), then
`cuMemImportFromShareableHandle` and map exactly like the fabric VMM path (the
reserve/map/set-access sequence is factored into a shared helper). Imported
regions are cached/unmapped through the same code paths as fabric VMM regions.
This is the same protocol PyTorch ships for its own expandable-segments IPC
(`ExpandableSegment::share/fromShared`).

**Fallbacks** — on any import failure the peer is reported unreachable for
this handle type, and transport selection falls back exactly like today's
`NO_IPC`:
- different PID namespace (pid not translatable for `pidfd_open`)
- kernel < 5.6 (`ENOSYS`) or missing `PTRACE_MODE_ATTACH_REALCREDS`
  permission toward the exporter (`EPERM`) — logged at diag level
- non-Linux build (importer arm is `#ifdef __linux__`)

**Safety check**: an rkey carries a single allocation handle, but a VMM VA
range can be stitched from several `cuMemCreate` allocations (PyTorch
expandable segments grow this way — its own IPC protocol shares a *vector* of
fds). The exporter verifies the same allocation handle backs both ends of the
registered range and falls back to `NO_IPC` otherwise, instead of exporting a
partial mapping. (The pre-existing fabric arm has no such check; happy to lift
it there too if you want.)

**Config**: new `UCX_CUDA_IPC_ENABLE_POSIX_FD` (default `y`) to disable the
path; each registered region holds one open fd in the exporter until dereg,
which deployments with tight `RLIMIT_NOFILE` may care about.

**Behavior notes**:
- The fabric export failure log is demoted from error to diag, since a
  fallback now exists and the failure is no longer final.
- Mempool (`cudaMallocAsync`) memory is still fabric-only; POSIX FD support
  for mempools needs a different remote-cache key and is left as a follow-up.
- The peer accessibility cache is keyed by `(uuid, handle_type)`, not by pid,
  so in mixed-credential same-node jobs a successful probe against one peer
  does not guarantee `pidfd_getfd` permission toward another. Same-user
  colocated processes (the typical ML case) are unaffected;
  `UCX_CUDA_IPC_ENABLE_POSIX_FD=n` is the escape hatch.

## Testing

- I don't have a GPU machine available, so this is **compile-tested only** on
  my side: full `src/uct` build (`-Wall -Werror`) against CUDA 12.6 headers
  with `HAVE_CUDA_FABRIC` enabled, plus the gtest TU, on Linux aarch64.
- Added gtests: `mkey_pack_vmm_posix_fd` packs a single-handle
  POSIX-FD-only VMM allocation, checks the rkey handle type, and exercises the
  pidfd import end-to-end via self-import with a spoofed device uuid
  (tolerating `UNREACHABLE` where seccomp/kernel forbids pidfd);
  `mkey_pack_vmm_posix_fd_disabled` checks the config knob falls back to
  `NO_IPC`.
- I'd appreciate CI + a maintainer sanity check on a GPU box. I can also
  share the two-process PyTorch reproducer from #11548 that shows the
  end-to-end ~600x recovery with this patch applied.
