### PR TITLE
UCT/CUDA: Fix NVLink probing and cuda_ipc mock gtest

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -246,7 +246,8 @@ static size_t uct_cuda_ipc_iface_get_max_get_zcopy(uct_cuda_ipc_iface_t *iface)
     /* assume there is at least >= 1 GPUs on the system; assume uniformity */
     num_nvlinks = uct_cuda_ipc_get_device_nvlinks(0);
 
-    if (!num_nvlinks && (iface->config.enable_get_zcopy != UCS_CONFIG_ON)) {
+    if ((num_nvlinks == 0) &&
+        (iface->config.enable_get_zcopy != UCS_CONFIG_ON)) {
         ucs_debug("cuda-ipc get zcopy disabled as no nvlinks detected");
         return 0;
     }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -189,9 +189,10 @@ static double uct_cuda_ipc_iface_get_bw()
     }
 }
 
-static int uct_cuda_ipc_get_device_nvlinks(int ordinal)
+static int uct_cuda_ipc_get_device_nvlinks(unsigned ordinal)
 {
     static int num_nvlinks = -1;
+    unsigned num_detected_nvlinks;
     unsigned link;
     nvmlDevice_t device;
     nvmlFieldValue_t value;
@@ -202,22 +203,27 @@ static int uct_cuda_ipc_get_device_nvlinks(int ordinal)
         return num_nvlinks;
     }
 
-    status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetHandleByIndex, 0, &device);
+    status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetHandleByIndex, ordinal,
+                                     &device);
     if (status != UCS_OK) {
         goto err;
     }
 
     value.fieldId = NVML_FI_DEV_NVLINK_LINK_COUNT;
 
-    UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetFieldValues, device, 1, &value);
+    status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetFieldValues, device, 1,
+                                     &value);
+    if (status != UCS_OK) {
+        goto err;
+    }
 
-    num_nvlinks = ((value.nvmlReturn == NVML_SUCCESS) &&
-                   (value.valueType == NVML_VALUE_TYPE_UNSIGNED_INT)) ?
-                  value.value.uiVal : 0;
+    num_detected_nvlinks = ((value.nvmlReturn == NVML_SUCCESS) &&
+                            (value.valueType == NVML_VALUE_TYPE_UNSIGNED_INT)) ?
+                           value.value.uiVal : 0;
 
     /* not enough to check number of nvlinks; need to check if links are active
      * by seeing if remote info can be obtained */
-    for (link = 0; link < num_nvlinks; ++link) {
+    for (link = 0; link < num_detected_nvlinks; ++link) {
         status = UCT_CUDA_NVML_WRAP_CALL(nvmlDeviceGetNvLinkRemotePciInfo,
                                          device, link, &pci);
         if (status != UCS_OK) {
@@ -226,6 +232,7 @@ static int uct_cuda_ipc_get_device_nvlinks(int ordinal)
         }
     }
 
+    num_nvlinks = num_detected_nvlinks;
     return num_nvlinks;
 
 err:

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -219,7 +219,8 @@ static int uct_cuda_ipc_get_device_nvlinks(unsigned ordinal)
 
     num_detected_nvlinks = ((value.nvmlReturn == NVML_SUCCESS) &&
                             (value.valueType == NVML_VALUE_TYPE_UNSIGNED_INT)) ?
-                           value.value.uiVal : 0;
+                                   value.value.uiVal :
+                                   0;
 
     /* not enough to check number of nvlinks; need to check if links are active
      * by seeing if remote info can be obtained */

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -1256,6 +1256,9 @@ public:
             UCS_TEST_SKIP_R("rc_mlx5 transport is not supported");
         }
 
+        /* Keep protocol selection independent of NVLink probing. */
+        modify_config("CUDA_IPC_ENABLE_GET_ZCOPY", "on", SETENV_IF_NOT_EXIST);
+
         add_mock_iface("mock", [](uct_iface_attr_t &iface_attr) {
             iface_attr.cap.am.max_short  = 208;
             iface_attr.cap.put.max_short = 2048;
@@ -1289,24 +1292,6 @@ public:
         return UCP_WORKER_CFG_INDEX_NULL;
     }
 
-    bool has_cuda_ipc_get_zcopy()
-    {
-        ucp_worker_h worker = sender().worker();
-        auto context        = worker->context;
-        std::string cuda_ipc_str("cuda_ipc");
-
-        for (ucp_rsc_index_t idx = 0; idx < context->num_tls; ++idx) {
-            if (cuda_ipc_str != context->tl_rscs[idx].tl_rsc.tl_name) {
-                continue;
-            }
-
-            auto attr = ucp_worker_iface_get_attr(worker, idx);
-            return attr->cap.get.max_zcopy > 0;
-        }
-
-        return false;
-    }
-
     void test_cuda_rma(ucp_operation_id_t op_id,
                        const proto_select_data_vec_t &data_vec)
     {
@@ -1333,10 +1318,6 @@ UCS_TEST_P(test_ucp_proto_mock_cuda_ipc, put, "IB_NUM_PATHS?=1")
 
 UCS_TEST_P(test_ucp_proto_mock_cuda_ipc, get, "IB_NUM_PATHS?=1")
 {
-    if (!has_cuda_ipc_get_zcopy()) {
-        UCS_TEST_SKIP_R("cuda_ipc get_zcopy not supported");
-    }
-
     test_cuda_rma(UCP_OP_ID_GET, {
         {0, 0,   "copy-out",  "rc_mlx5/mock"},
         {1, INF, "zero-copy", "cuda_ipc/cuda"},


### PR DESCRIPTION
## What?
Fix inconsistent CUDA IPC get_zcopy detection and make the mock gtest deterministic.

## Why?
NVLink probing could return 0 once but cache a positive link count for later calls, making GET support depend on test order.

## How?
Cache NVLink count only after successful validation, check NVML query status, and force `CUDA_IPC_ENABLE_GET_ZCOPY=on` in the mock protocol test.

Issue:
```
./test/gtest/gtest --gtest_filter=shm_rc_ipc/test_ucp_proto_mock_cuda_ipc*get*

[ RUN      ] shm_rc_ipc/test_ucp_proto_mock_cuda_ipc.get/0 <rc_x,cuda_ipc,rocm_ipc,cuda_copy,rocm_copy>
[     SKIP ] (cuda_ipc get_zcopy not supported)
[       OK ] shm_rc_ipc/test_ucp_proto_mock_cuda_ipc.get/0 (480 ms)

[==========] 1 test from 1 test suite ran. (482 ms total)
[  PASSED  ] 1 test.

./test/gtest/gtest --gtest_filter=shm_rc_ipc/test_ucp_proto_mock_cuda_ipc*

[ RUN      ] shm_rc_ipc/test_ucp_proto_mock_cuda_ipc.put/0 <rc_x,cuda_ipc,rocm_ipc,cuda_copy,rocm_copy>
[       OK ] shm_rc_ipc/test_ucp_proto_mock_cuda_ipc.put/0 (464 ms)
[ RUN      ] shm_rc_ipc/test_ucp_proto_mock_cuda_ipc.get/0 <rc_x,cuda_ipc,rocm_ipc,cuda_copy,rocm_copy>
[       OK ] shm_rc_ipc/test_ucp_proto_mock_cuda_ipc.get/0 (454 ms)

[==========] 2 tests from 1 test suite ran. (921 ms total)
[  PASSED  ] 2 tests.