### PR TITLE
DOCS: Update boolean expressions section in `CodeStyle.md`

### DIFF
--- a/docs/CodeStyle.md
+++ b/docs/CodeStyle.md
@@ -87,9 +87,16 @@
 
 ## Miscellaneous examples
 
-### Boolean expression
+### Boolean expressions
 
-Use explicit checks with added parenthesis like below.
+- Non-boolean values (pointers, counts, status/enum codes) should use explicit
+  comparisons.
+- Boolean flags (integers that hold only 0/1, e.g. flags like `is_*`/`has_*`, 
+  the return value of a predicate function, etc.) should be tested directly.
+- Add parentheses around every comparison in compound expressions (excluding
+  direct boolean tests) to ensure correct operator precedence.
+- Negation with `!` takes no parentheses when applied to a single flag or
+  predicate call (`!is_enabled`).
 
 Good
 ```C
@@ -97,8 +104,30 @@ Good
 
     if (a == 0) {
 
-    if ((ret == UCS_KH_PUT_BUCKET_EMPTY) ||
-        (ret == UCS_KH_PUT_BUCKET_CLEAR)) {
+    if (is_enabled) {
+
+    if (!uct_iface_is_reachable(iface)) {
+
+    if ((ret == UCS_KH_PUT_BUCKET_EMPTY) || (ret == UCS_KH_PUT_BUCKET_CLEAR)) {
+
+    if (is_enabled || ((a == 2) && (b > 0))) {
+```
+
+Bad
+```C
+    if (!ptr) {
+
+    if (!a) {
+
+    if (is_enabled == 1) {
+
+    if (uct_iface_is_reachable(iface) == 0) {
+
+    if (!(uct_iface_is_reachable(iface))) {
+
+    if (ret == UCS_KH_PUT_BUCKET_EMPTY || ret == UCS_KH_PUT_BUCKET_CLEAR) {
+
+    if (is_enabled || a == 2 && b > 0) {
 ```
 
 ### Variable definition


### PR DESCRIPTION
## What?
Update `CodeStyle.md` to include specific examples about how to check boolean flags in `if` statements.

## Why?
The previous explanation required explicit checks for all values, but the standard in UCX is to use boolean flags as-is.
This caused AI agents to write code that is not according to the standard that is held in practice in the repo.
