### PR TITLE
GTEST/IB: Add mlx5 library option to link

### DIFF
--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -232,7 +232,8 @@ gtest_LDADD += \
 	$(top_builddir)/src/uct/ib/libuct_ib.la
 if HAVE_MLX5_DV
 gtest_LDADD += \
-	$(top_builddir)/src/uct/ib/mlx5/libuct_ib_mlx5.la
+	$(top_builddir)/src/uct/ib/mlx5/libuct_ib_mlx5.la \
+	$(LIB_MLX5)
 endif
 
 if HAVE_DEVX


### PR DESCRIPTION
## What?
Fix gtest linking with `--with-verbs` option.