### PR TITLE
UCP/FT: rebuild failed lanes on recovery via LANES_ADDR exchange

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -461,7 +461,7 @@ static ucs_config_field_t ucp_context_config_table[] = {
    ucs_offsetof(ucp_context_config_t, dynamic_tl_progress_factor),
    UCS_CONFIG_TYPE_TIME_UNITS},
 
-  {"RESOLVE_REMOTE_EP_ID", "n",
+  {"RESOLVE_REMOTE_EP_ID", "auto",
    "Defines whether resolving remote endpoint ID is required or not when\n"
    "creating a local endpoint. 'auto' means resolving remote endpoint ID only\n"
    "in case of error handling and keepalive enabled.",

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1819,13 +1819,275 @@ ucs_status_t ucp_ep_reconfig_clear_failed_lanes(ucp_ep_h ep,
     return UCS_OK;
 }
 
-/* Prepare failed lanes for recovery; return the subset to pack into
- * LANES_ADDR_REQUEST. */
+/* Install an empty wireup proxy on the lane, replacing any failed-stub UCT
+ * EP left by a preceding ucp_ep_failover_reconfig(). The inner UCT EP is
+ * attached separately by ucp_ep_recovery_set_next_ep(). */
+static ucs_status_t
+ucp_ep_recovery_install_wireup_ep(ucp_ep_h ep, ucp_lane_index_t lane)
+{
+    uct_ep_h old_uct_ep = ucp_ep_get_lane(ep, lane);
+    uct_ep_h wireup_ep_uct;
+    ucs_status_t status;
+
+    if ((old_uct_ep != NULL) && ucp_wireup_ep_test(old_uct_ep)) {
+        return UCS_OK;
+    }
+
+    ucs_assertv((old_uct_ep == NULL) || ucp_is_uct_ep_failed(old_uct_ep),
+                "ep %p lane %d: unexpected live uct_ep=%p - recovery path "
+                "must be preceded by ucp_ep_failover_reconfig()",
+                ep, lane, old_uct_ep);
+
+    status = ucp_wireup_ep_create(ep, &wireup_ep_uct);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    ucs_trace("ep %p: recovery lane[%d] %p -> wireup_ep %p", ep, lane,
+              old_uct_ep, wireup_ep_uct);
+    ucp_ep_set_lane(ep, lane, wireup_ep_uct);
+
+    if (old_uct_ep != NULL) {
+        uct_ep_destroy(old_uct_ep);
+    }
+
+    return UCS_OK;
+}
+
+/* Idempotently ensure the lane's wireup proxy has an inner transport EP. */
+static ucs_status_t
+ucp_ep_recovery_set_next_ep(ucp_ep_h ep, ucp_lane_index_t lane,
+                            const ucp_address_entry_t *ae)
+{
+    const ucp_ep_config_key_t *cfg_key = &ucp_ep_config(ep)->key;
+    const ucp_rsc_index_t rsc_index    = cfg_key->lanes[lane].rsc_index;
+    const unsigned path_index          = cfg_key->lanes[lane].path_index;
+    uct_ep_h proxy                     = ucp_ep_get_lane(ep, lane);
+    ucp_wireup_ep_t *wireup_ep         = ucp_wireup_ep(proxy);
+    uct_ep_h next_ep;
+    ucs_status_t status;
+
+    ucs_assertv(wireup_ep != NULL, "ep %p lane %d: expected wireup proxy",
+                ep, lane);
+
+    if (wireup_ep->super.uct_ep != NULL) {
+        return UCS_OK;
+    }
+
+    if (ae == NULL) {
+        ucs_assert(ucp_ep_is_lane_p2p(ep, lane));
+        return ucp_wireup_ep_connect(proxy, 0, rsc_index, path_index, 0, NULL);
+    }
+
+    status = ucp_wireup_iface_ep_create(ucp_worker_iface(ep->worker, rsc_index),
+                                        ae, path_index, &next_ep);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    ucp_wireup_ep_set_next_ep(proxy, next_ep, rsc_index);
+    return UCS_OK;
+}
+
+/* Mark the lane's wireup proxy as ready+remote-connected. Called once the
+ * inner EP reaches a connected state (iface: immediately after
+ * ucp_ep_recovery_set_next_ep() with a non-NULL address; p2p: after
+ * ucp_wireup_ep_connect_to_ep_v2() succeeds). */
+static void
+ucp_ep_recovery_mark_ready(ucp_ep_h ep, ucp_lane_index_t lane)
+{
+    ucp_wireup_ep_t *wireup_ep = ucp_wireup_ep(ucp_ep_get_lane(ep, lane));
+
+    ucs_assert(wireup_ep != NULL);
+    ucs_assert(wireup_ep->super.uct_ep != NULL);
+
+    wireup_ep->flags |= UCP_WIREUP_EP_FLAG_READY |
+                        UCP_WIREUP_EP_FLAG_REMOTE_CONNECTED;
+}
+
+/**
+ * @brief Find a CONNECT_TO_IFACE address entry for the specified lane.
+ *
+ * Returns the reachable entry whose memory domain index and system device
+ * match the lane's recorded destination, to keep the rebuilt lane bound to
+ * the same peer device. Returns NULL if no such entry exists.
+ */
+static const ucp_address_entry_t *
+ucp_ep_recovery_find_iface_addr(ucp_ep_h ep, ucp_lane_index_t lane,
+                                const ucp_unpacked_address_t *remote_address)
+{
+    const ucp_ep_config_key_lane_t *cfg_lane =
+            &ucp_ep_config(ep)->key.lanes[lane];
+    const ucp_rsc_index_t rsc_index          = cfg_lane->rsc_index;
+    const ucp_address_entry_t *ae;
+
+    ucp_unpacked_address_for_each(ae, remote_address) {
+        if ((ae->iface_addr != NULL) &&
+            (ae->md_index == cfg_lane->dst_md_index) &&
+            (ae->sys_dev  == cfg_lane->dst_sys_dev) &&
+            ucp_wireup_is_reachable(ep, 0, rsc_index, ae, NULL, 0)) {
+            return ae;
+        }
+    }
+
+    return NULL;
+}
+
+/* Rebuild one CONNECT_TO_IFACE lane: find peer iface addr -> install empty
+ * wireup proxy -> create fully-connected inner UCT EP and attach it -> mark
+ * ready. */
+static ucs_status_t
+ucp_ep_recovery_rebuild_iface_lane(
+        ucp_ep_h ep, ucp_lane_index_t lane,
+        const ucp_unpacked_address_t *remote_address)
+{
+    const ucp_address_entry_t *ae;
+    ucs_status_t status;
+
+    ae = ucp_ep_recovery_find_iface_addr(ep, lane, remote_address);
+    if (ae == NULL) {
+        ucs_debug("ep %p: no remote iface address for lane %d", ep, lane);
+        return UCS_ERR_UNREACHABLE;
+    }
+
+    status = ucp_ep_recovery_install_wireup_ep(ep, lane);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = ucp_ep_recovery_set_next_ep(ep, lane, ae);
+    if (status != UCS_OK) {
+        ucs_diag("ep %p: set_next_ep failed for recovery iface lane %d: %s",
+                 ep, lane, ucs_status_string(status));
+        return status;
+    }
+
+    ucp_ep_recovery_mark_ready(ep, lane);
+    ucs_debug("ep %p: recovered iface-lane[%d] via rsc[%d]", ep, lane,
+              ucp_ep_get_rsc_index(ep, lane));
+    return UCS_OK;
+}
+
+/* Rebuild one p2p (CONNECT_TO_EP) lane. Flow: find peer ep_addr ->
+ * install empty wireup proxy -> ensure iface-only inner UCT EP ->
+ * connect_to_ep_v2 against peer ep_addr -> mark ready. */
+static ucs_status_t
+ucp_ep_recovery_rebuild_p2p_lane(
+        ucp_ep_h ep, ucp_lane_index_t lane,
+        const ucp_unpacked_address_t *remote_address)
+{
+    const ucp_address_entry_t *address_entry;
+    const ucp_address_entry_ep_addr_t *ep_entry;
+    ucp_lane_index_t remote_lane;
+    ucs_status_t status;
+
+    /* Symmetric assumption: the peer's lane index mirrors ours.
+     * ucp_address_pack() with lanes2remote==NULL stamps the sender-side local
+     * lane as the remote_lane tag in the ep_addr, so we look up by our own
+     * lane index. */
+    remote_lane = lane;
+    status = ucp_wireup_find_remote_p2p_addr(ep, remote_lane, remote_address,
+                                             &address_entry, &ep_entry);
+    if (status != UCS_OK) {
+        ucs_debug("ep %p: no remote ep_addr for p2p lane %d", ep, lane);
+        return status;
+    }
+
+    status = ucp_ep_recovery_install_wireup_ep(ep, lane);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = ucp_ep_recovery_set_next_ep(ep, lane, NULL);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = ucp_wireup_ep_connect_to_ep_v2(ucp_ep_get_lane(ep, lane),
+                                            address_entry, ep_entry);
+    if (status != UCS_OK) {
+        ucs_diag("ep %p: connect_to_ep_v2 failed for recovery p2p lane %d: %s",
+                 ep, lane, ucs_status_string(status));
+        return status;
+    }
+
+    ucp_ep_recovery_mark_ready(ep, lane);
+    ucs_debug("ep %p: recovered p2p-lane[%d] via rsc[%d]", ep, lane,
+              ucp_ep_get_rsc_index(ep, lane));
+    return UCS_OK;
+}
+
+/* For each lane in `lanes_to_rebuild`, bring its UCT resources back online.
+ * Dispatches to the iface-connect or p2p helper based on lane type. Returns
+ * the bitmap of lanes successfully rebuilt; lanes not in the returned bitmap
+ * stay UCP_LANE_TYPE_FAILED and will be retried on a future recovery round. */
+ucp_lane_map_t
+ucp_ep_recovery_rebuild_lanes(ucp_ep_h ep, ucp_lane_map_t lanes_to_rebuild,
+                              const ucp_unpacked_address_t *remote_address)
+{
+    const ucp_ep_config_key_t *k = &ucp_ep_config(ep)->key;
+    ucp_lane_map_t rebuilt       = 0;
+    ucp_lane_index_t lane;
+    ucs_status_t status;
+
+    ucs_for_each_bit(lane, lanes_to_rebuild) {
+        if (lane >= k->num_lanes) {
+            continue;
+        }
+
+        if (ucp_ep_is_lane_p2p(ep, lane)) {
+            status = ucp_ep_recovery_rebuild_p2p_lane(ep, lane,
+                                                      remote_address);
+        } else {
+            status = ucp_ep_recovery_rebuild_iface_lane(ep, lane,
+                                                        remote_address);
+        }
+
+        if (status == UCS_OK) {
+            rebuilt |= UCS_BIT(lane);
+        }
+    }
+
+    return rebuilt;
+}
+
+/* Replace failed UCT stubs with wireup proxies for the given lane set and,
+ * for p2p lanes, create their iface-only inner transport EP so that the
+ * local ep_addr is available to ucp_address_pack() at REQUEST-send time.
+ * Returns the bitmap of lanes that ended up with the full proxy state
+ * required to appear in LANES_ADDR_REQUEST. Lanes that failed to reach
+ * that state are excluded so they don't get packed (which would try to
+ * read addresses from a half-built proxy). */
 static ucp_lane_map_t
 ucp_ep_recovery_prepare_lanes(ucp_ep_h ep, ucp_lane_map_t lanes)
 {
-    /* TODO: lane rebuild is not implemented yet. */
-    return 0;
+    const ucp_ep_config_key_t *cfg_key = &ucp_ep_config(ep)->key;
+    ucp_lane_map_t lane_map            = 0;
+    ucp_lane_index_t lane;
+
+    ucs_for_each_bit(lane, lanes) {
+        if (lane >= cfg_key->num_lanes) {
+            continue;
+        }
+
+        if (ucp_ep_recovery_install_wireup_ep(ep, lane) != UCS_OK) {
+            continue;
+        }
+
+        /* For p2p lanes the ep_addr has to exist before we pack the
+         * REQUEST (ucp_address_pack iterates p2p_lanes and calls
+         * uct_ep_get_address on each). On failure the lane stays with an
+         * empty proxy and is skipped from this round; the next recovery
+         * round will retry. */
+        if (ucp_ep_is_lane_p2p(ep, lane) &&
+            (ucp_ep_recovery_set_next_ep(ep, lane, NULL) != UCS_OK)) {
+            continue;
+        }
+
+        lane_map |= UCS_BIT(lane);
+    }
+
+    return lane_map;
 }
 
 /* Send a LANES_ADDR_REQUEST for the currently failed lanes. */
@@ -1950,6 +2212,11 @@ int ucp_ep_recovery_progress(ucp_ep_h ep)
 
     failed &= ~recovered;
     if (failed == 0) {
+        /* All failed lanes recovered - drop the retry state so a later
+         * round (failed == 0) does not trip the recovery_arg == NULL
+         * assertion. */
+        ucs_free(ep->ext->recovery_arg);
+        ep->ext->recovery_arg = NULL;
         goto done;
     }
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1829,14 +1829,15 @@ ucp_ep_recovery_install_wireup_ep(ucp_ep_h ep, ucp_lane_index_t lane)
     uct_ep_h wireup_ep_uct;
     ucs_status_t status;
 
-    if ((old_uct_ep != NULL) && ucp_wireup_ep_test(old_uct_ep)) {
+    ucs_assert(old_uct_ep != NULL);
+    if (ucp_wireup_ep_test(old_uct_ep)) {
         return UCS_OK;
     }
 
-    ucs_assertv((old_uct_ep == NULL) || ucp_is_uct_ep_failed(old_uct_ep),
-                "ep %p lane %d: unexpected live uct_ep=%p - recovery path "
-                "must be preceded by ucp_ep_failover_reconfig()",
-                ep, lane, old_uct_ep);
+    if (!ucp_is_uct_ep_failed(old_uct_ep)) {
+        /* The lane has been already recovered */
+        return UCS_ERR_NO_PROGRESS;
+    }
 
     status = ucp_wireup_ep_create(ep, &wireup_ep_uct);
     if (status != UCS_OK) {
@@ -1846,11 +1847,7 @@ ucp_ep_recovery_install_wireup_ep(ucp_ep_h ep, ucp_lane_index_t lane)
     ucs_trace("ep %p: recovery lane[%d] %p -> wireup_ep %p", ep, lane,
               old_uct_ep, wireup_ep_uct);
     ucp_ep_set_lane(ep, lane, wireup_ep_uct);
-
-    if (old_uct_ep != NULL) {
-        uct_ep_destroy(old_uct_ep);
-    }
-
+    uct_ep_destroy(old_uct_ep);
     return UCS_OK;
 }
 
@@ -1887,22 +1884,6 @@ ucp_ep_recovery_set_next_ep(ucp_ep_h ep, ucp_lane_index_t lane,
 
     ucp_wireup_ep_set_next_ep(proxy, next_ep, rsc_index);
     return UCS_OK;
-}
-
-/* Mark the lane's wireup proxy as ready+remote-connected. Called once the
- * inner EP reaches a connected state (iface: immediately after
- * ucp_ep_recovery_set_next_ep() with a non-NULL address; p2p: after
- * ucp_wireup_ep_connect_to_ep_v2() succeeds). */
-static void
-ucp_ep_recovery_mark_ready(ucp_ep_h ep, ucp_lane_index_t lane)
-{
-    ucp_wireup_ep_t *wireup_ep = ucp_wireup_ep(ucp_ep_get_lane(ep, lane));
-
-    ucs_assert(wireup_ep != NULL);
-    ucs_assert(wireup_ep->super.uct_ep != NULL);
-
-    wireup_ep->flags |= UCP_WIREUP_EP_FLAG_READY |
-                        UCP_WIREUP_EP_FLAG_REMOTE_CONNECTED;
 }
 
 /**
@@ -1962,7 +1943,9 @@ ucp_ep_recovery_rebuild_iface_lane(
         return status;
     }
 
-    ucp_ep_recovery_mark_ready(ep, lane);
+    ucp_wireup_update_flags(ep, UCS_BIT(lane),
+                            UCP_WIREUP_EP_FLAG_READY |
+                            UCP_WIREUP_EP_FLAG_REMOTE_CONNECTED);
     ucs_debug("ep %p: recovered iface-lane[%d] via rsc[%d]", ep, lane,
               ucp_ep_get_rsc_index(ep, lane));
     return UCS_OK;
@@ -2011,7 +1994,9 @@ ucp_ep_recovery_rebuild_p2p_lane(
         return status;
     }
 
-    ucp_ep_recovery_mark_ready(ep, lane);
+    ucp_wireup_update_flags(ep, UCS_BIT(lane),
+                            UCP_WIREUP_EP_FLAG_READY |
+                            UCP_WIREUP_EP_FLAG_REMOTE_CONNECTED);
     ucs_debug("ep %p: recovered p2p-lane[%d] via rsc[%d]", ep, lane,
               ucp_ep_get_rsc_index(ep, lane));
     return UCS_OK;
@@ -2025,16 +2010,11 @@ ucp_lane_map_t
 ucp_ep_recovery_rebuild_lanes(ucp_ep_h ep, ucp_lane_map_t lanes_to_rebuild,
                               const ucp_unpacked_address_t *remote_address)
 {
-    const ucp_ep_config_key_t *k = &ucp_ep_config(ep)->key;
-    ucp_lane_map_t rebuilt       = 0;
+    ucp_lane_map_t rebuilt = 0;
     ucp_lane_index_t lane;
     ucs_status_t status;
 
     ucs_for_each_bit(lane, lanes_to_rebuild) {
-        if (lane >= k->num_lanes) {
-            continue;
-        }
-
         if (ucp_ep_is_lane_p2p(ep, lane)) {
             status = ucp_ep_recovery_rebuild_p2p_lane(ep, lane,
                                                       remote_address);
@@ -2061,15 +2041,10 @@ ucp_ep_recovery_rebuild_lanes(ucp_ep_h ep, ucp_lane_map_t lanes_to_rebuild,
 static ucp_lane_map_t
 ucp_ep_recovery_prepare_lanes(ucp_ep_h ep, ucp_lane_map_t lanes)
 {
-    const ucp_ep_config_key_t *cfg_key = &ucp_ep_config(ep)->key;
     ucp_lane_map_t lane_map            = 0;
     ucp_lane_index_t lane;
 
     ucs_for_each_bit(lane, lanes) {
-        if (lane >= cfg_key->num_lanes) {
-            continue;
-        }
-
         if (ucp_ep_recovery_install_wireup_ep(ep, lane) != UCS_OK) {
             continue;
         }

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -1016,6 +1016,15 @@ int ucp_ep_recovery_progress(ucp_ep_h ep);
 
 
 /**
+ * Rebuild UCT endpoints for the given set of currently-failed lanes using the
+ * peer addresses in @a remote_address. Returns the bitmap of lanes rebuilt.
+ */
+ucp_lane_map_t
+ucp_ep_recovery_rebuild_lanes(ucp_ep_h ep, ucp_lane_map_t lanes_to_rebuild,
+                              const ucp_unpacked_address_t *remote_address);
+
+
+/**
  * Mark a subset of lanes as UCP_LANE_TYPE_FAILED and arm recovery.
  */
 ucs_status_t ucp_ep_failover_reconfig(ucp_ep_h ucp_ep,

--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -372,6 +372,16 @@ static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_multi_rma_init_func(ucp_request_t *req)
 {
     const ucp_proto_multi_priv_t *mpriv = req->send.proto_config->priv;
+    ucs_status_t status;
+
+    if (ucs_unlikely(ucp_ep_err_mode_eq(req->send.ep,
+                                        UCP_ERR_HANDLING_MODE_FAILOVER))) {
+        status = ucp_ep_resolve_remote_id(req->send.ep,
+                                          mpriv->lanes[0].super.lane);
+        if (status != UCS_OK) {
+            return status;
+        }
+    }
 
     return ucp_ep_rma_handle_fence(req->send.ep, req, mpriv->lane_map);
 }

--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -372,16 +372,6 @@ static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_multi_rma_init_func(ucp_request_t *req)
 {
     const ucp_proto_multi_priv_t *mpriv = req->send.proto_config->priv;
-    ucs_status_t status;
-
-    if (ucs_unlikely(ucp_ep_err_mode_eq(req->send.ep,
-                                        UCP_ERR_HANDLING_MODE_FAILOVER))) {
-        status = ucp_ep_resolve_remote_id(req->send.ep,
-                                          mpriv->lanes[0].super.lane);
-        if (status != UCS_OK) {
-            return status;
-        }
-    }
 
     return ucp_ep_rma_handle_fence(req->send.ep, req, mpriv->lane_map);
 }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -428,7 +428,7 @@ ucp_wireup_match_p2p_lanes(ucp_ep_h ep,
     }
 }
 
-static ucs_status_t
+ucs_status_t
 ucp_wireup_find_remote_p2p_addr(ucp_ep_h ep, ucp_lane_index_t remote_lane,
                                 const ucp_unpacked_address_t *remote_address,
                                 const ucp_address_entry_t **address_entry_p,
@@ -1009,18 +1009,47 @@ ucp_wireup_process_lanes_addr_request(
 {
     const ucp_wireup_msg_lanes_info_t *lanes_info =
             (const ucp_wireup_msg_lanes_info_t *)(msg + 1);
+    ucp_lane_map_t peer_unaware, to_rebuild, peer_provided;
+    ucs_status_t status;
 
     ucp_ep_update_remote_id(ep, msg->src_ep_id);
 
-    ucs_debug("ep %p: LANES_ADDR_REQ requested=0x%" PRIx64
-              " provided=0x%" PRIx64,
-              ep, lanes_info->requested_lane_map,
-              lanes_info->provided_lane_map);
+    /* Asymmetric failure: lanes the peer declared broken but we don't yet
+     * see as failed go through local failover first, so subsequent rebuild
+     * steps encounter proper failed stubs and the reply rides the new
+     * am_lane. */
+    peer_unaware = lanes_info->provided_lane_map & ~ucp_ep_get_failed_lanes(ep);
+    if (peer_unaware != 0) {
+        ucs_debug("ep %p: LANES_ADDR_REQ triggering local failover for "
+                  "asymmetric failure on lanes 0x%" PRIx64,
+                  ep, (uint64_t)peer_unaware);
+        status = ucp_ep_failover_reconfig(ep, peer_unaware,
+                                          UCS_ERR_CONNECTION_RESET);
+        if (status != UCS_OK) {
+            ucs_diag("ep %p: local failover for LANES_ADDR_REQ failed: %s",
+                     ep, ucs_status_string(status));
+        }
+    }
 
-    /* TODO: lane rebuild is not implemented yet;
-             reply with provided_lane_map=0. */
+    to_rebuild    = lanes_info->provided_lane_map & ucp_ep_get_failed_lanes(ep);
+    peer_provided = ucp_ep_recovery_rebuild_lanes(ep, to_rebuild,
+                                                  remote_address);
+
+    ucs_debug("ep %p: LANES_ADDR_REQ requested=0x%" PRIx64
+              " provided=0x%" PRIx64 " to_rebuild=0x%" PRIx64
+              " rebuilt=0x%" PRIx64,
+              ep, lanes_info->requested_lane_map, lanes_info->provided_lane_map,
+              to_rebuild, peer_provided);
+
+    if (peer_provided != 0) {
+        ucp_wireup_eps_progress_sched(ep);
+    }
+
+    /* Always reply, even if peer_provided == 0, so the initiator knows the
+     * peer handled the request (empty provided_lane_map means "I couldn't
+     * satisfy any of the lanes you asked about"). */
     ucp_wireup_send_lanes_addr_msg(ep, UCP_WIREUP_MSG_LANES_ADDR_REPLY,
-                                   lanes_info->requested_lane_map, 0);
+                                   lanes_info->requested_lane_map, peer_provided);
 }
 
 static UCS_F_NOINLINE void
@@ -1030,16 +1059,25 @@ ucp_wireup_process_lanes_addr_reply(
 {
     const ucp_wireup_msg_lanes_info_t *lanes_info =
             (const ucp_wireup_msg_lanes_info_t *)(msg + 1);
+    ucp_lane_map_t rebuilt;
 
     ucp_ep_update_remote_id(ep, msg->src_ep_id);
 
-    ucs_debug("ep %p: LANES_ADDR_REP requested=0x%" PRIx64
-              " provided=0x%" PRIx64,
-              ep, lanes_info->requested_lane_map,
-              lanes_info->provided_lane_map);
+    rebuilt = ucp_ep_recovery_rebuild_lanes(
+            ep, lanes_info->provided_lane_map & ucp_ep_get_failed_lanes(ep),
+            remote_address);
 
-    /* TODO: lane rebuild is not implemented yet;
-             recovery_progress owns FAILED-bit clearing and retries. */
+    ucs_debug("ep %p: LANES_ADDR_REP requested=0x%" PRIx64
+              " provided=0x%" PRIx64 " rebuilt=0x%" PRIx64,
+              ep, lanes_info->requested_lane_map, lanes_info->provided_lane_map,
+              rebuilt);
+
+    if (rebuilt != 0) {
+        ucp_wireup_eps_progress_sched(ep);
+    }
+
+    /* ucp_ep_recovery_progress owns FAILED-bit clearing and the retry
+     * cadence; do not clear or re-send inline here. */
 }
 
 /* -------------------------------------------------------------------------- */
@@ -1189,7 +1227,7 @@ static int ucp_wireup_should_activate_wiface(ucp_worker_iface_t *wiface,
            (ep->flags & UCP_EP_FLAG_INTERNAL);
 }
 
-static ucs_status_t
+ucs_status_t
 ucp_wireup_iface_ep_create(ucp_worker_iface_t *wiface,
                            const ucp_address_entry_t *address,
                            unsigned path_index, uct_ep_h *uct_ep_p)

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -576,12 +576,13 @@ out_unblock:
     return 0;
 }
 
-void ucp_wireup_update_flags(ucp_ep_h ucp_ep, uint32_t new_flags)
+void ucp_wireup_update_flags(ucp_ep_h ucp_ep, ucp_lane_map_t lanes,
+                             uint32_t new_flags)
 {
     ucp_lane_index_t lane;
     ucp_wireup_ep_t *wireup_ep;
 
-    for (lane = 0; lane < ucp_ep_num_lanes(ucp_ep); ++lane) {
+    ucs_for_each_bit(lane, lanes) {
         wireup_ep = ucp_wireup_ep(ucp_ep_get_lane(ucp_ep, lane));
         if (wireup_ep == NULL) {
             continue;
@@ -610,7 +611,7 @@ void ucp_wireup_remote_connected(ucp_ep_h ep)
         ucp_ep_update_flags(ep, UCP_EP_FLAG_REMOTE_CONNECTED, 0);
     }
 
-    ucp_wireup_update_flags(ep,
+    ucp_wireup_update_flags(ep, UCS_MASK(ucp_ep_num_lanes(ep)),
                             UCP_WIREUP_EP_FLAG_REMOTE_CONNECTED |
                             UCP_WIREUP_EP_FLAG_READY);
     ucp_wireup_eps_progress_sched(ep);
@@ -1073,6 +1074,7 @@ ucp_wireup_process_lanes_addr_reply(
               rebuilt);
 
     if (rebuilt != 0) {
+        ucp_wireup_update_flags(ep, rebuilt, UCP_WIREUP_EP_FLAG_READY);
         ucp_wireup_eps_progress_sched(ep);
     }
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -552,13 +552,12 @@ unsigned ucp_wireup_eps_progress(void *arg)
     ucp_wireup_eps_pending_extract(ucp_ep, &tmp_pending_queue);
     for (lane = 0; lane < ucp_ep_num_lanes(ucp_ep); ++lane) {
         wireup_ep = ucp_wireup_ep(ucp_ep_get_lane(ucp_ep, lane));
-        if (wireup_ep == NULL) {
+        if ((wireup_ep == NULL) ||
+            (!(wireup_ep->flags & UCP_WIREUP_EP_FLAG_READY))) {
             continue;
         }
 
-        ucs_assert(wireup_ep->flags & UCP_WIREUP_EP_FLAG_READY);
         ucs_assert(wireup_ep->super.uct_ep != NULL);
-
         ucs_trace("ep %p: switching wireup_ep %p to ready state", ucp_ep,
                   wireup_ep);
 
@@ -1074,7 +1073,6 @@ ucp_wireup_process_lanes_addr_reply(
               rebuilt);
 
     if (rebuilt != 0) {
-        ucp_wireup_update_flags(ep, rebuilt, UCP_WIREUP_EP_FLAG_READY);
         ucp_wireup_eps_progress_sched(ep);
     }
 

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -261,6 +261,25 @@ void ucp_wireup_send_lanes_addr_msg(ucp_ep_h ep, uint8_t msg_type,
                                     ucp_lane_map_t provided_lane_map);
 
 
+/**
+ * Find the remote p2p address entry for @a remote_lane (used by lane recovery).
+ */
+ucs_status_t
+ucp_wireup_find_remote_p2p_addr(ucp_ep_h ep, ucp_lane_index_t remote_lane,
+                                const ucp_unpacked_address_t *remote_address,
+                                const ucp_address_entry_t **address_entry_p,
+                                const ucp_address_entry_ep_addr_t **ep_entry_p);
+
+
+/**
+ * Create a fully-connected CONNECT_TO_IFACE UCT endpoint from @a address.
+ */
+ucs_status_t ucp_wireup_iface_ep_create(ucp_worker_iface_t *wiface,
+                                        const ucp_address_entry_t *address,
+                                        unsigned path_index,
+                                        uct_ep_h *uct_ep_p);
+
+
 double ucp_wireup_iface_lat_distance_v1(const ucp_worker_iface_t *wiface);
 
 double ucp_wireup_iface_lat_distance_v2(const ucp_worker_iface_t *wiface,

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -221,7 +221,8 @@ void ucp_wireup_replay_pending_requests(ucp_ep_h ucp_ep,
                                         ucs_queue_head_t *tmp_pending_queue);
 
 /* add flags to all wireup_ep->flags */
-void ucp_wireup_update_flags(ucp_ep_h ep, uint32_t new_flags);
+void ucp_wireup_update_flags(ucp_ep_h ep, ucp_lane_map_t lanes,
+                             uint32_t new_flags);
 
 void ucp_wireup_remote_connected(ucp_ep_h ep);
 

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -725,7 +725,8 @@ static unsigned ucp_cm_client_connect_progress(void *arg)
 
     if (context->config.ext.cm_use_all_devices) {
         ucp_ep->flags |= UCP_EP_FLAG_CONNECT_WAIT_PRE_REQ;
-        ucp_wireup_update_flags(ucp_ep, UCP_WIREUP_EP_FLAG_REMOTE_CONNECTED);
+        ucp_wireup_update_flags(ucp_ep, UCS_MASK(ucp_ep_num_lanes(ucp_ep)),
+                                UCP_WIREUP_EP_FLAG_REMOTE_CONNECTED);
     } else {
         ucp_wireup_remote_connected(ucp_ep);
     }
@@ -1369,7 +1370,8 @@ static unsigned ucp_cm_server_conn_notify_progress(void *arg)
     ucs_assert(ucp_ep->flags & UCP_EP_FLAG_LOCAL_CONNECTED);
 
     if (ucp_ep->worker->context->config.ext.cm_use_all_devices) {
-        ucp_wireup_update_flags(ucp_ep, UCP_WIREUP_EP_FLAG_REMOTE_CONNECTED);
+        ucp_wireup_update_flags(ucp_ep, UCS_MASK(ucp_ep_num_lanes(ucp_ep)),
+                                UCP_WIREUP_EP_FLAG_REMOTE_CONNECTED);
         ucp_wireup_send_pre_request(ucp_ep);
     } else {
         ucp_wireup_remote_connected(ucp_ep);

--- a/src/ucp/wireup/wireup_ep.c
+++ b/src/ucp/wireup/wireup_ep.c
@@ -704,6 +704,7 @@ ucp_wireup_ep_connect_to_ep_v2(uct_ep_h tl_ep,
         .ep_addr_length     = ep_entry->len
     };
     ucp_wireup_ep_t *wireup_ep                = ucp_wireup_ep(tl_ep);
+    ucs_status_t status;
 
     if (wireup_ep == NULL) {
         return uct_ep_connect_to_ep_v2(tl_ep, address_entry->dev_addr,
@@ -714,8 +715,13 @@ ucp_wireup_ep_connect_to_ep_v2(uct_ep_h tl_ep,
         return UCS_OK;
     }
 
+    status = uct_ep_connect_to_ep_v2(wireup_ep->super.uct_ep,
+                                     address_entry->dev_addr, ep_entry->addr,
+                                     &param);
+    if (status != UCS_OK) {
+        return status;
+    }
+
     wireup_ep->flags |= UCP_WIREUP_EP_FLAG_LOCAL_CONNECTED;
-    return uct_ep_connect_to_ep_v2(wireup_ep->super.uct_ep,
-                                   address_entry->dev_addr, ep_entry->addr,
-                                   &param);
+    return UCS_OK;
 }

--- a/test/gtest/ucp/test_ucp_fault_tolerance.cc
+++ b/test/gtest/ucp/test_ucp_fault_tolerance.cc
@@ -12,6 +12,7 @@
 extern "C" {
 #include <ucp/core/ucp_ep.inl>
 #include <ucp/core/ucp_context.h>
+#include <ucp/wireup/wireup_ep.h>
 }
 
 /**
@@ -30,6 +31,9 @@ public:
                                op_name(TEST_OP_GET | TEST_OP_FLUSH));
         add_variant_with_value(variants, UCP_FEATURE_AM,  TEST_OP_AM,
                                op_name(TEST_OP_AM));
+        add_variant_with_value(variants, UCP_FEATURE_AM,
+                               TEST_OP_AM | TEST_OP_ALL_LANES_FAILED,
+                               op_name(TEST_OP_AM | TEST_OP_ALL_LANES_FAILED));
         add_variant_with_value(variants, UCP_FEATURE_AM,  TEST_OP_AM | TEST_OP_FLUSH,
                                op_name(TEST_OP_AM | TEST_OP_FLUSH));
 
@@ -58,13 +62,28 @@ protected:
     };
 
     enum test_op_t {
-        TEST_OP_PUT   = UCS_BIT(0),
-        TEST_OP_GET   = UCS_BIT(1),
-        TEST_OP_AM    = UCS_BIT(2),
-        TEST_OP_FLUSH = UCS_BIT(3),
+        TEST_OP_PUT              = UCS_BIT(0),
+        TEST_OP_GET              = UCS_BIT(1),
+        TEST_OP_AM               = UCS_BIT(2),
+        TEST_OP_FLUSH            = UCS_BIT(3),
+        TEST_OP_ALL_LANES_FAILED = UCS_BIT(4)
     };
 
     void init() override {
+        if (get_variant_value() & TEST_OP_ALL_LANES_FAILED) {
+            /* Defer recovery so all per-lane invalidations accumulate as failed
+             * before recovery fires. Data-path transports detect the failure
+             * via transport completions, so a long defer is harmless. UD has no
+             * such data-path signal and relies on keepalive for detection, so a
+             * long defer would also defer the error callback (making the test
+             * run until the deadline). Use a short defer that still comfortably
+             * outlasts the (sub-second) invalidation loop. */
+            const std::string defer =
+                    has_any_transport({"ud_v", "ud_x"}) ?
+                    "3s" : std::to_string(ucs::test_timeout_in_sec) + "s";
+            modify_config("KEEPALIVE_INTERVAL", defer);
+        }
+
         ucp_test::init();
 
         ucp_ep_params_t ep_params = get_ep_params();
@@ -299,7 +318,9 @@ protected:
                                   << ucs_status_string(status);
 
         ucp_ep_h ucp_ep_for_injection = get_ucp_ep_for_err_injection(failure_side);
-        for (size_t lane_idx = 0; lane_idx < am_bw_lanes.size(); ++lane_idx) {
+        for (size_t num_lanes_to_fail = (op_mask & TEST_OP_ALL_LANES_FAILED) ? am_bw_lanes.size() :
+                                        (am_bw_lanes.size() - 1),
+             lane_idx = 0; lane_idx < num_lanes_to_fail; ++lane_idx) {
             ucp_lane_index_t lane = am_bw_lanes[lane_idx];
             uct_ep_h uct_ep_for_injection = ucp_ep_get_lane(ucp_ep_for_injection, lane);
             const bool last_lane = (lane_idx == (am_bw_lanes.size() - 1));
@@ -424,6 +445,68 @@ protected:
         UCS_TEST_MESSAGE << "Success";
     }
 
+    void test_recovery(unsigned op_mask) {
+        if (op_mask & TEST_OP_ALL_LANES_FAILED) {
+            // Recovery is not expected, it depends on timings
+            return;
+        }
+
+        UCS_TEST_MESSAGE << "Checking recovery status...";
+
+        wait_for_cond([this]() {
+            return ucp_ep_get_failed_lanes(sender().ep(0, INJECTED_EP_INDEX)) == 0;
+        }, [this]() {
+            short_progress_loop();
+        });
+
+        const ucp_lane_map_t failed_lanes =
+                ucp_ep_get_failed_lanes(sender().ep(0, INJECTED_EP_INDEX));
+        ASSERT_EQ(0, failed_lanes)
+            << "Failed lanes are not recovered" << std::hex << failed_lanes;
+        for (ucp_lane_index_t lane_idx = 0;
+             lane_idx < ucp_ep_num_lanes(sender().ep(0, INJECTED_EP_INDEX));) {
+            if (ucp_wireup_ep_test(ucp_ep_get_lane(sender().ep(0, INJECTED_EP_INDEX), lane_idx))) {
+                short_progress_loop();
+                continue;
+            }
+
+            ++lane_idx;
+        }
+
+        if (op_mask & TEST_OP_AM) {
+            ucs_status_t status = do_am_send_and_wait(sender().ep(0, INJECTED_EP_INDEX),
+                                                      am_msg_size(), true);
+            EXPECT_EQ(UCS_OK, status) << "AM operation returned status: "
+                                      << ucs_status_string(status);
+        }
+
+        if (op_mask & TEST_OP_PUT) {
+            mem_buffer lbuf(rma_msg_size(), UCS_MEMORY_TYPE_HOST);
+            mapped_buffer rbuf(rma_msg_size(), receiver());
+            ucs::handle<ucp_rkey_h> rkey = rbuf.rkey(sender());
+            lbuf.pattern_fill(m_seed);
+            ucs_status_t status = do_put_and_wait(sender().ep(0, INJECTED_EP_INDEX), lbuf, rbuf,
+                                                  rkey, rma_msg_size(), true);
+            EXPECT_EQ(UCS_OK, status) << "PUT operation returned status: "
+                                      << ucs_status_string(status);
+        }
+
+        if (op_mask & TEST_OP_GET) {
+            mem_buffer lbuf(rma_msg_size(), UCS_MEMORY_TYPE_HOST);
+            mapped_buffer rbuf(rma_msg_size(), receiver());
+            ucs::handle<ucp_rkey_h> rkey = rbuf.rkey(sender());
+            rbuf.pattern_fill(m_seed);
+            ucs_status_t status = do_get_and_wait(sender().ep(0, INJECTED_EP_INDEX), lbuf, rbuf,
+                                                  rkey, rma_msg_size(), true);
+            EXPECT_EQ(UCS_OK, status) << "GET operation returned status: "
+                                      << ucs_status_string(status);
+        }
+
+        ASSERT_EQ(0, m_total_err_count) << "Error callback invoked " << m_total_err_count
+                                        << " times";
+        UCS_TEST_MESSAGE << "All lanes are operational";
+    }
+
     void do_test(failure_side_t failure_side) {
         const unsigned op_mask = get_variant_value();
 
@@ -436,6 +519,8 @@ protected:
             ASSERT_TRUE(op_mask & (TEST_OP_PUT|TEST_OP_GET));
             test_rma_with_injected_failure(failure_side, op_mask);
         }
+
+        test_recovery(op_mask);
     }
 private:
     static size_t rma_msg_size() {
@@ -464,6 +549,10 @@ private:
 
         if (op_mask & TEST_OP_FLUSH) {
             name += "FLUSH|";
+        }
+
+        if (op_mask & TEST_OP_ALL_LANES_FAILED) {
+            name += "ALL_LANES_FAILED|";
         }
 
         if (!name.empty()) {
@@ -572,12 +661,19 @@ private:
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_fault_tolerance)
 
-UCS_TEST_P(test_ucp_fault_tolerance, initiator_failure, "MAX_EAGER_LANES=8")
+UCS_TEST_P(test_ucp_fault_tolerance, initiator_failure, "MAX_EAGER_LANES=8",
+           "RECOVERY_RETRIES=100")
 {
+    if ((get_variant_value() & TEST_OP_ALL_LANES_FAILED) && has_any_transport({"ud_v", "ud_x"})) {
+        UCS_TEST_SKIP_R("UD transport BUG: local error injection on all lanes leads to "
+                        "assertion failure in ud_ep_purge");
+    }
+
     do_test(FAILURE_SIDE_INITIATOR);
 }
 
-UCS_TEST_P(test_ucp_fault_tolerance, target_failure, "MAX_EAGER_LANES=8")
+UCS_TEST_P(test_ucp_fault_tolerance, target_failure, "MAX_EAGER_LANES=8",
+           "RECOVERY_RETRIES=100")
 {
     do_test(FAILURE_SIDE_TARGET);
 }

--- a/test/gtest/ucp/test_ucp_fault_tolerance.cc
+++ b/test/gtest/ucp/test_ucp_fault_tolerance.cc
@@ -5,8 +5,8 @@
 */
 
 #include "test_ucp_memheap.h"
+#include <common/test_helpers.h>
 #include <algorithm>
-#include <random>
 #include <string>
 
 extern "C" {
@@ -171,11 +171,7 @@ protected:
                             " available");
         }
 
-        /* Allocate randomizer on heap to avoid exceeding stack frame size limits. */
-        std::unique_ptr<std::random_device> rnd_device(new std::random_device);
-        std::unique_ptr<std::mt19937> rng(new std::mt19937((*rnd_device)()));
-        std::shuffle(lanes.begin(), lanes.end(), *rng);
-
+        std::random_shuffle(lanes.begin(), lanes.end(), ucs::rand_range);
         for (ucp_lane_index_t lane : lanes) {
             UCS_TEST_MESSAGE << lane_type << ": " << size_t(lane) << "/" << lanes.size();
         }


### PR DESCRIPTION
## What?

Complete failed-lane recovery on top of the recovery foundation and the
keepalive-driven state machine (https://github.com/openucx/ucx/pull/11545):

## How?

- Rebuild failed p2p/iface lanes: install wireup proxies over failed stubs,
  recreate the inner UCT endpoints, and drive them to READY so the lane
  resumes serving traffic.
- Wire the LANES_ADDR_REQUEST/REPLY handlers to exchange peer addresses and
  rebuild the requested lanes, including local failover for asymmetric
  failures, and free the recovery state once all lanes recover.
- Pin a recovered iface lane to its original peer device.
- UCX_RESOLVE_REMOTE_EP_ID = auto by default.
- Add end-to-end fault-tolerance gtests (initiator/target failure incl. the
  all-lanes-failed case) using the keepalive-driven recovery cadence.
