### PR TITLE
uct/device: define uct_device_completion before including gdaki.cuh

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,6 +63,7 @@ John Snyder <jms285@duke.edu>
 Jonas Zhou <JonasZhou@zhaoxin.com>
 Joseph Schuchart <schuchart@icl.utk.edu>
 Keisuke Fukuda <kfukuda@preferred.jp>
+Keith Yates <diskdog@protonmail.com>
 Ken Raffenetti <raffenet@mcs.anl.gov>
 Kento Hasegawa <hasegawa.kento@fujitsu.com>
 Khaled Hamidouche <Khaled.Hamidouche@amd.com>

--- a/src/uct/api/device/uct_device_impl.h
+++ b/src/uct/api/device/uct_device_impl.h
@@ -22,10 +22,16 @@
 
 #if __has_include(<uct/ib/mlx5/gdaki/gdaki.cuh>) && \
     __has_include(<infiniband/mlx5dv.h>)
-#include <uct/ib/mlx5/gdaki/gdaki.cuh>
 #define UCT_RC_MLX5_GDA_SUPPORTED 1
 #else
 #define UCT_RC_MLX5_GDA_SUPPORTED 0
+#endif
+
+/* Define uct_device_completion before including gdaki.cuh, whose device templates
+ * reference this union. Including gdaki.cuh first leaves the union incomplete at those
+ * template definitions, which Clang-based CUDA compilers reject. */
+#if UCT_RC_MLX5_GDA_SUPPORTED
+#include <uct/ib/mlx5/gdaki/gdaki_dev.h>
 #endif
 
 union uct_device_completion {
@@ -36,6 +42,10 @@ union uct_device_completion {
     uct_cuda_ipc_completion_t cuda_ipc;
 #endif
 };
+
+#if UCT_RC_MLX5_GDA_SUPPORTED
+#include <uct/ib/mlx5/gdaki/gdaki.cuh>
+#endif
 
 
 /**


### PR DESCRIPTION
### What
`src/uct/api/device/uct_device_impl.h` includes `gdaki.cuh` before it defines `union uct_device_completion`. The device templates in `gdaki.cuh` dereference that union's members (`uct_rc_gda_completion_t *comp = &tl_comp->rc_gda;` at lines 277 and 383), so when these headers are compiled by a Clang-based CUDA compiler the device API fails to build:

```
gdaki.cuh:277:45: error: member access into incomplete type 'uct_device_completion_t' (aka 'uct_device_completion')
```

Clang checks the non-dependent member access at template-definition time, where the union is still only forward-declared (it gets defined later in `uct_device_impl.h`, after the `gdaki.cuh` include). nvcc/EDG defers that check to instantiation, which never happens for these templates, so it builds. g++ builds too but warns (`invalid use of incomplete type`).

### Fix
Define `union uct_device_completion` before the `gdaki.cuh` include, pulling in `gdaki_dev.h` first for `uct_rc_gda_completion_t`.

### Verification
Compiling `#include <ucp/api/device/ucp_device_impl.h>` for `sm_75` against current master:
- Before: a Clang-based CUDA compiler errors at `gdaki.cuh:277` (member access into incomplete type). nvcc compiles.
- After: builds clean under both the Clang-based CUDA compiler and nvcc. Reverting just this change brings the error back.

I ran into this with Spectral Compute's SCALE, but it is not SCALE-specific: any Clang-based CUDA toolchain hits the same incomplete-type error.

### Minimal reproduction (no UCX needed)
```cpp
union U;
typedef union U Ut;
template<int level> __device__ void f(Ut* p) { auto* x = &p->m; (void)x; }
union U { int m; };
int main() { return 0; }
```
nvcc compiles it. A Clang-based CUDA compiler errors with `member access into incomplete type`, and g++ warns. Defining `U` before the template makes all three accept it.
