### PR TITLE
UCT/CUDA_IPC: test

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -246,6 +246,9 @@ AS_IF([test "x$cuda_checked" != "xyes"],
                         [AC_DEFINE([HAVE_CUDA_FABRIC], 1, [Enable CUDA fabric handle support])],
                         [], [[#include <cuda.h>]])
 
+         AC_CHECK_DECLS([CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED],
+                        [], [], [[#include <cuda.h>]])
+
          CPPFLAGS="$save_CPPFLAGS"
          LDFLAGS="$save_LDFLAGS"
          LIBS="$save_LIBS"

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2667,12 +2667,17 @@ static ucs_status_t ucp_wireup_select_set_locality_flags(
             continue;
         }
 
-        params.field_mask  = UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
-                             UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR  |
-                             UCT_IFACE_IS_REACHABLE_FIELD_SCOPE;
-        params.device_addr = ae->dev_addr;
-        params.iface_addr  = ae->iface_addr;
-        params.scope       = UCT_IFACE_REACHABILITY_SCOPE_DEVICE;
+        params.field_mask         =
+                UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
+                UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR  |
+                UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR_LENGTH |
+                UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH |
+                UCT_IFACE_IS_REACHABLE_FIELD_SCOPE;
+        params.device_addr        = ae->dev_addr;
+        params.iface_addr         = ae->iface_addr;
+        params.device_addr_length = ae->dev_addr_len;
+        params.iface_addr_length  = ae->iface_addr_len;
+        params.scope              = UCT_IFACE_REACHABILITY_SCOPE_DEVICE;
 
         if (uct_iface_is_reachable_v2(wiface->iface, &params)) {
             key->flags |= UCP_EP_CONFIG_KEY_FLAG_INTRA_NODE;

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1299,10 +1299,12 @@ int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
     uct_iface_is_reachable_params_t params = {
         .field_mask         = UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
                               UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR |
-                              UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR_LENGTH,
+                              UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR_LENGTH |
+                              UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH,
         .device_addr        = ae->dev_addr,
         .iface_addr         = ae->iface_addr,
-        .device_addr_length = ae->dev_addr_len
+        .device_addr_length = ae->dev_addr_len,
+        .iface_addr_length  = ae->iface_addr_len
     };
 
     if (info_str != NULL) {

--- a/src/uct/cuda/base/cuda_util.c
+++ b/src/uct/cuda/base/cuda_util.c
@@ -26,6 +26,25 @@ const char *uct_cuda_cu_get_error_string(CUresult result)
     return error_str;
 }
 
+int uct_cuda_base_device_supports_fabric(CUdevice cuda_device)
+{
+#if HAVE_CUDA_FABRIC && \
+    HAVE_DECL_CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED
+    int supported;
+
+    if (UCT_CUDADRV_FUNC(cuDeviceGetAttribute(
+                &supported,
+                CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED,
+                cuda_device), UCS_LOG_LEVEL_DEBUG) != UCS_OK) {
+        return 0;
+    }
+
+    return supported;
+#else
+    return 0;
+#endif
+}
+
 ucs_sys_device_t uct_cuda_get_sys_dev(CUdevice cuda_device)
 {
     ucs_sys_device_t sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;

--- a/src/uct/cuda/base/cuda_util.h
+++ b/src/uct/cuda/base/cuda_util.h
@@ -66,4 +66,7 @@ ucs_sys_device_t uct_cuda_get_sys_dev(CUdevice cuda_device);
  */
 CUdevice uct_cuda_get_cuda_device(ucs_sys_device_t sys_dev);
 
+
+int uct_cuda_base_device_supports_fabric(CUdevice cuda_device);
+
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -176,7 +176,9 @@ uct_cuda_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
                                         iface_addr_length, IFACE_ADDR_LENGTH,
                                         sizeof(remote_iface_addr.pid));
     /* Older peers do not send pid_ns, so preserve legacy same-node reachability
-     * and apply the cross-namespace fabric check only to extended addresses. */
+     * and apply the cross-namespace fabric check only to extended addresses.
+     * New peers always send extended addresses, including from the default PID
+     * namespace. */
     remote_iface_addr = uct_cuda_ipc_iface_address_unpack(params->iface_addr,
                                                           iface_addr_len);
     if ((iface_addr_len >= sizeof(remote_iface_addr)) &&

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -176,9 +176,7 @@ uct_cuda_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
                                         iface_addr_length, IFACE_ADDR_LENGTH,
                                         sizeof(remote_iface_addr.pid));
     /* Older peers do not send pid_ns, so preserve legacy same-node reachability
-     * and apply the cross-namespace fabric check only to extended addresses.
-     * New peers always send extended addresses, including from the default PID
-     * namespace. */
+     * and apply the cross-namespace fabric check only to extended addresses. */
     remote_iface_addr = uct_cuda_ipc_iface_address_unpack(params->iface_addr,
                                                           iface_addr_len);
     if ((iface_addr_len >= sizeof(remote_iface_addr)) &&

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -15,6 +15,7 @@
 
 #include <ucs/async/eventfd.h>
 #include <ucs/debug/assert.h>
+#include <ucs/sys/sys.h>
 #include <ucs/sys/string.h>
 #include <ucs/type/class.h>
 #include <uct/api/device/uct_device_types.h>
@@ -25,7 +26,8 @@
 #include <pthread.h>
 
 typedef enum {
-    UCT_CUDA_IPC_DEVICE_ADDR_FLAG_MNNVL = UCS_BIT(0)
+    UCT_CUDA_IPC_DEVICE_ADDR_FLAG_MNNVL  = UCS_BIT(0),
+    UCT_CUDA_IPC_DEVICE_ADDR_FLAG_FABRIC = UCS_BIT(1)
 } uct_cuda_ipc_device_addr_flags_t;
 
 
@@ -91,8 +93,15 @@ ucs_status_t uct_cuda_ipc_iface_get_device_address(uct_iface_t *tl_iface,
     uct_cuda_ipc_md_t *md                = ucs_derived_of(iface->super.super.md,
                                                            uct_cuda_ipc_md_t);
 
-    if (md->enable_mnnvl) {
-        dev_addr->flags = UCT_CUDA_IPC_DEVICE_ADDR_FLAG_MNNVL;
+    if (md->enable_mnnvl || md->fabric_supported) {
+        dev_addr->flags = 0;
+        if (md->enable_mnnvl) {
+            dev_addr->flags |= UCT_CUDA_IPC_DEVICE_ADDR_FLAG_MNNVL;
+        }
+
+        if (md->fabric_supported) {
+            dev_addr->flags |= UCT_CUDA_IPC_DEVICE_ADDR_FLAG_FABRIC;
+        }
     }
 
     dev_addr->system_uuid = ucs_get_system_id();
@@ -107,18 +116,29 @@ static ucs_status_t uct_cuda_ipc_iface_get_address(uct_iface_h tl_iface,
     return UCS_OK;
 }
 
+/* Extract the flags byte from a device address, handling addresses produced by
+ * older peers (which only contained the system UUID and no trailing flags). */
+static uint8_t
+uct_cuda_ipc_iface_dev_addr_flags(const uct_cuda_ipc_device_addr_t *dev_addr,
+                                  size_t dev_addr_len)
+{
+    if (dev_addr_len == sizeof(uint64_t)) {
+        return 0;
+    }
+
+    ucs_assertv(dev_addr_len >= sizeof(uct_cuda_ipc_device_addr_t),
+                "dev_addr_len=%zu", dev_addr_len);
+    return dev_addr->flags;
+}
+
 static int
 uct_cuda_ipc_iface_mnnvl_supported(uct_cuda_ipc_md_t *md,
                                    const uct_cuda_ipc_device_addr_t *dev_addr,
                                    size_t dev_addr_len)
 {
-    if (md->enable_mnnvl && (dev_addr_len != sizeof(uint64_t))) {
-        ucs_assertv(dev_addr_len >= sizeof(uct_cuda_ipc_device_addr_t),
-                    "dev_addr_len=%zu", dev_addr_len);
-        return (dev_addr->flags & UCT_CUDA_IPC_DEVICE_ADDR_FLAG_MNNVL);
-    }
-
-    return 0;
+    return md->enable_mnnvl &&
+           (uct_cuda_ipc_iface_dev_addr_flags(dev_addr, dev_addr_len) &
+            UCT_CUDA_IPC_DEVICE_ADDR_FLAG_MNNVL);
 }
 
 static int
@@ -129,7 +149,9 @@ uct_cuda_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
     uct_cuda_ipc_md_t *md       = ucs_derived_of(iface->super.super.md,
                                                  uct_cuda_ipc_md_t);
     const uct_cuda_ipc_device_addr_t *dev_addr;
-    size_t dev_addr_len;
+    uct_cuda_ipc_iface_address_t remote_iface_addr;
+    size_t dev_addr_len, iface_addr_len;
+    int local_fabric_supported, remote_fabric_supported;
     int same_uuid;
 
     if (!uct_iface_is_reachable_params_addrs_valid(params)) {
@@ -142,13 +164,37 @@ uct_cuda_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
     dev_addr     = (const uct_cuda_ipc_device_addr_t *)params->device_addr;
     same_uuid    = (ucs_get_system_id() == dev_addr->system_uuid);
 
-    if (same_uuid ||
-        uct_cuda_ipc_iface_mnnvl_supported(md, dev_addr, dev_addr_len)) {
-        return uct_iface_scope_is_reachable(tl_iface, params);
+    if (!same_uuid &&
+        !uct_cuda_ipc_iface_mnnvl_supported(md, dev_addr, dev_addr_len)) {
+        uct_iface_fill_info_str_buf(params, "different machine and no MNNVL");
+        return 0;
     }
 
-    uct_iface_fill_info_str_buf(params, "different machine and no MNNVL");
-    return 0;
+    /* Legacy CUDA IPC handles cannot be exchanged across PID namespaces;
+     * both peers must support fabric IPC handles in that case. */
+    iface_addr_len    = UCS_PARAM_VALUE(UCT_IFACE_IS_REACHABLE_FIELD, params,
+                                        iface_addr_length, IFACE_ADDR_LENGTH,
+                                        sizeof(remote_iface_addr.pid));
+    /* Older peers do not send pid_ns, so unpack reports the default PID
+     * namespace. The comparison below treats them as same-namespace peers only
+     * when the local process is also in the default PID namespace. */
+    remote_iface_addr = uct_cuda_ipc_iface_address_unpack(params->iface_addr,
+                                                          iface_addr_len);
+    if (remote_iface_addr.pid_ns != ucs_sys_get_ns(UCS_SYS_NS_TYPE_PID)) {
+        local_fabric_supported  = md->fabric_supported;
+        remote_fabric_supported = !!(
+                uct_cuda_ipc_iface_dev_addr_flags(dev_addr, dev_addr_len) &
+                UCT_CUDA_IPC_DEVICE_ADDR_FLAG_FABRIC);
+        if (!local_fabric_supported || !remote_fabric_supported) {
+            uct_iface_fill_info_str_buf(
+                    params,
+                    "different PID namespace and FABRIC support local=%d remote=%d",
+                    local_fabric_supported, remote_fabric_supported);
+            return 0;
+        }
+    }
+
+    return uct_iface_scope_is_reachable(tl_iface, params);
 }
 
 static double uct_cuda_ipc_iface_get_bw()
@@ -257,7 +303,8 @@ static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
     uct_base_iface_query(&iface->super.super, iface_attr);
 
     iface_attr->iface_addr_len          = uct_cuda_ipc_iface_address_length();
-    iface_attr->device_addr_len         = md->enable_mnnvl ?
+    iface_attr->device_addr_len         = (md->enable_mnnvl ||
+                                           md->fabric_supported) ?
                                           sizeof(uct_cuda_ipc_device_addr_t) :
                                           sizeof(uint64_t);
     iface_attr->ep_addr_len             = 0;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -175,12 +175,12 @@ uct_cuda_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
     iface_addr_len    = UCS_PARAM_VALUE(UCT_IFACE_IS_REACHABLE_FIELD, params,
                                         iface_addr_length, IFACE_ADDR_LENGTH,
                                         sizeof(remote_iface_addr.pid));
-    /* Older peers do not send pid_ns, so unpack reports the default PID
-     * namespace. The comparison below treats them as same-namespace peers only
-     * when the local process is also in the default PID namespace. */
+    /* Older peers do not send pid_ns, so preserve legacy same-node reachability
+     * and apply the cross-namespace fabric check only to extended addresses. */
     remote_iface_addr = uct_cuda_ipc_iface_address_unpack(params->iface_addr,
                                                           iface_addr_len);
-    if (remote_iface_addr.pid_ns != ucs_sys_get_ns(UCS_SYS_NS_TYPE_PID)) {
+    if ((iface_addr_len >= sizeof(remote_iface_addr)) &&
+        (remote_iface_addr.pid_ns != ucs_sys_get_ns(UCS_SYS_NS_TYPE_PID))) {
         local_fabric_supported  = md->fabric_supported;
         remote_fabric_supported = !!(
                 uct_cuda_ipc_iface_dev_addr_flags(dev_addr, dev_addr_len) &

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface_address.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface_address.c
@@ -38,20 +38,14 @@ void uct_cuda_ipc_iface_address_pack(uct_iface_addr_t *iface_addr)
 {
     uct_cuda_ipc_iface_address_t *cuda_ipc_iface_address;
 
-    *(pid_t*)iface_addr = getpid();
-    if (ucs_sys_ns_is_default(UCS_SYS_NS_TYPE_PID)) {
-        return;
-    }
-
     cuda_ipc_iface_address         = (uct_cuda_ipc_iface_address_t*)iface_addr;
+    cuda_ipc_iface_address->pid    = getpid();
     cuda_ipc_iface_address->pid_ns = ucs_sys_get_ns(UCS_SYS_NS_TYPE_PID);
 }
 
 size_t uct_cuda_ipc_iface_address_length(void)
 {
-    return ucs_sys_ns_is_default(UCS_SYS_NS_TYPE_PID) ?
-                   sizeof(pid_t) :
-                   sizeof(uct_cuda_ipc_iface_address_t);
+    return sizeof(uct_cuda_ipc_iface_address_t);
 }
 
 uct_cuda_ipc_iface_address_t

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -112,24 +112,25 @@ uct_cuda_ipc_md_check_imex_channel_cb(const struct dirent *entry, void *arg)
 static int uct_cuda_ipc_md_check_fabric_support(void)
 {
 #if HAVE_CUDA_FABRIC
-    int fabric_supported = 0;
+    int imex_channel_found = 0;
+    ucs_status_t status;
     CUdevice cu_device;
 
-    if ((UCT_CUDADRV_FUNC(cuCtxGetDevice(&cu_device),
-                          UCS_LOG_LEVEL_DEBUG) != UCS_OK) ||
-        !uct_cuda_base_device_supports_fabric(cu_device)) {
+    /* md_open can run without a current context, so query CUDA device 0. */
+    status = UCT_CUDADRV_FUNC(cuDeviceGet(&cu_device, 0), UCS_LOG_LEVEL_DEBUG);
+    if ((status != UCS_OK) || !uct_cuda_base_device_supports_fabric(cu_device)) {
         return 0;
     }
 
     if (ucs_sys_readdir(UCT_CUDA_IPC_IMEX_CHANNELS_PATH,
                         uct_cuda_ipc_md_check_imex_channel_cb,
-                        &fabric_supported) != UCS_OK) {
+                        &imex_channel_found) != UCS_OK) {
         return 0;
     }
 
     ucs_debug("CUDA fabric IPC support on device %d is %s", cu_device,
-              fabric_supported ? "enabled" : "disabled");
-    return fabric_supported;
+              imex_channel_found ? "enabled" : "disabled");
+    return imex_channel_found;
 #else
     return 0;
 #endif

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -32,6 +32,9 @@
  * purposes. */
 #define UCT_CUDA_IPC_RKEY_FLAG_PID_NS UCS_BIT(31)
 
+#define UCT_CUDA_IPC_IMEX_CHANNELS_PATH \
+    "/dev/nvidia-caps-imex-channels"
+
 static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
     {"", "", NULL,
      ucs_offsetof(uct_cuda_ipc_md_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
@@ -81,6 +84,55 @@ static uct_cuda_ipc_dev_cache_t *uct_cuda_ipc_create_dev_cache(int dev_num)
     }
 
     return cache;
+}
+
+#if HAVE_CUDA_FABRIC
+static ucs_status_t
+uct_cuda_ipc_md_check_imex_channel_cb(const struct dirent *entry, void *arg)
+{
+    static const char channel_prefix[] = "channel";
+    int *found                         = (int*)arg;
+    char path[PATH_MAX];
+
+    if (strncmp(entry->d_name, channel_prefix,
+                sizeof(channel_prefix) - 1) != 0) {
+        return UCS_OK;
+    }
+
+    ucs_snprintf_safe(path, sizeof(path), "%s/%s",
+                      UCT_CUDA_IPC_IMEX_CHANNELS_PATH, entry->d_name);
+    if (access(path, R_OK | W_OK) == 0) {
+        *found = 1;
+    }
+
+    return UCS_OK;
+}
+#endif
+
+static int uct_cuda_ipc_md_check_fabric_support(void)
+{
+#if HAVE_CUDA_FABRIC
+    int fabric_supported = 0;
+    CUdevice cu_device;
+
+    if ((UCT_CUDADRV_FUNC(cuCtxGetDevice(&cu_device),
+                          UCS_LOG_LEVEL_DEBUG) != UCS_OK) ||
+        !uct_cuda_base_device_supports_fabric(cu_device)) {
+        return 0;
+    }
+
+    if (ucs_sys_readdir(UCT_CUDA_IPC_IMEX_CHANNELS_PATH,
+                        uct_cuda_ipc_md_check_imex_channel_cb,
+                        &fabric_supported) != UCS_OK) {
+        return 0;
+    }
+
+    ucs_debug("CUDA fabric IPC support on device %d is %s", cu_device,
+              fabric_supported ? "enabled" : "disabled");
+    return fabric_supported;
+#else
+    return 0;
+#endif
 }
 
 static uct_cuda_ipc_dev_cache_t *
@@ -613,10 +665,11 @@ uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
         return UCS_ERR_NO_MEMORY;
     }
 
-    md->super.ops       = &md_ops;
-    md->super.component = &uct_cuda_ipc_component.super;
-    md->enable_mnnvl    = uct_cuda_ipc_md_check_fabric_info(
+    md->super.ops        = &md_ops;
+    md->super.component  = &uct_cuda_ipc_component.super;
+    md->enable_mnnvl     = uct_cuda_ipc_md_check_fabric_info(
                                                   md, ipc_config->enable_mnnvl);
+    md->fabric_supported = uct_cuda_ipc_md_check_fabric_support();
 
     uct_cuda_ipc_cache_set_global_limits(ipc_config->cache_max_regions,
                                          ipc_config->cache_max_size);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -45,6 +45,7 @@ typedef struct uct_cuda_ipc_md_handle {
 typedef struct uct_cuda_ipc_md {
     uct_md_t                 super;             /**< Domain info */
     int                      enable_mnnvl;      /**< Multi-node NVLINK support status */
+    int                      fabric_supported;  /**< CUDA fabric support status */
 } uct_cuda_ipc_md_t;
 
 


### PR DESCRIPTION
## What?
Improve cuda_ipc reachability checks for peers in different PID namespaces by advertising CUDA fabric IPC support only when the local process can actually use it.

This PR adds:
- a configure-time check for `CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED`
- a CUDA base helper that queries that device attribute with `cuDeviceGetAttribute()`
- a runtime check for accessible NVIDIA IMEX channel devices
- a CUDA IPC device-address flag that lets peers exchange fabric support capability

## Why?
Legacy CUDA IPC handles cannot be exchanged across different PID namespaces. In that case cuda_ipc should be considered reachable only if both peers support fabric IPC handles.

The previous approach detected local fabric support by trying to allocate and release a small fabric VMM buffer. Querying the CUDA device attribute is cleaner and avoids using allocation as a capability probe.

## How?
When building CUDA IPC device addresses, the transport now sets a FABRIC flag if the current CUDA device reports fabric-handle support and the process can access an IMEX channel. During reachability, peers in different PID namespaces require both local and remote FABRIC support.

## Validation
- `git diff --check`
