### PR TITLE
CI/FT: Adds fault tolerance CI test

### DIFF
--- a/buildlib/tools/common.sh
+++ b/buildlib/tools/common.sh
@@ -179,7 +179,7 @@ get_ib_devices() {
 	set +x
 	for ibdev in $device_list
 	do
-		[[ "$device" =~ ^smi[0-9]*:.$ ]] && continue
+		[[ "$ibdev" =~ ^smi[0-9]*$ ]] && continue
 		num_ports=$(ibv_devinfo -d $ibdev| awk '/phys_port_cnt:/ {print $2}')
 		for port in $(seq 1 $num_ports)
 		do
@@ -264,6 +264,16 @@ get_non_rdma_ip_addr() {
 #
 get_active_ib_devices() {
 	get_ib_devices PORT_ACTIVE
+}
+
+#
+# Get active IB device names without port suffix
+#
+get_active_ib_devnames() {
+	for ibdev_port in $(get_active_ib_devices)
+	do
+		echo "${ibdev_port%:*}"
+	done | sort -u
 }
 
 #

--- a/buildlib/tools/test_mad.sh
+++ b/buildlib/tools/test_mad.sh
@@ -77,7 +77,7 @@ set_vars() {
 run_mad_test() {
     local ib_address="$1"
     sudo chmod 777 /dev/infiniband/umad*
-    "$PWD"/install/bin/ucx_perftest -t tag_bw -e -K "$HCA" -e "$ib_address"
+    "$PWD"/install/bin/ucx_perftest -t tag_bw -e peer -K "$HCA" "$ib_address"
 }
 
 detect_active_ib_hca() {

--- a/buildlib/tools/test_mad.sh
+++ b/buildlib/tools/test_mad.sh
@@ -77,7 +77,7 @@ set_vars() {
 run_mad_test() {
     local ib_address="$1"
     sudo chmod 777 /dev/infiniband/umad*
-    "$PWD"/install/bin/ucx_perftest -t tag_bw -e peer -K "$HCA" "$ib_address"
+    "$PWD"/install/bin/ucx_perftest -t tag_bw -e -K "$HCA" "$ib_address"
 }
 
 detect_active_ib_hca() {

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -716,7 +716,7 @@ run_ucx_perftest() {
 		run_client_server_app "$ucx_perftest" "$ucp_test_args" "$(hostname)" 0 0
 
 		# Run AMO tests
-		echo -e peer "4 -s 4\n8 -s 8" > "$ucx_inst_ptest/msg_atomic"
+		echo -e "4 -s 4\n8 -s 8" > "$ucx_inst_ptest/msg_atomic"
 		ucp_test_args_atomic="-b $ucx_inst_ptest/test_types_ucp_amo \
 			              -b $ucx_inst_ptest/msg_atomic \
 				      -n 1000 -w 1"

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -404,6 +404,172 @@ run_io_demo() {
 }
 
 #
+# Parse the protocol configuration info in ucx_perftest stdout to get active
+# devices 
+#
+parse_active_devices()
+{
+    file=$1
+    config_cnt=$2
+
+    while IFS= read -r line;
+	do
+        [[ $line == *"| perftest self cfg#$config_cnt "* ]] || continue
+
+        IFS= read -r line || return 1  # | remote memory write by ucp_put* from host memory to host                                            |
+        IFS= read -r line || return 1  # +--------+-------------+------------------------------------------------------------------------------+
+        IFS= read -r line || return 1  # | Range  | Description |                                    Config                                    |
+        IFS= read -r line || return 1  # +--------+-------------+------------------------------------------------------------------------------+
+        IFS= read -r line || return 1  # | 0..inf | zero-copy   | 34% on rc_mlx5/mlx5_0:1, 34% on rc_mlx5/mlx5_2:1 and 32% on rc_mlx5/mlx5_1:1 |
+        break
+    done < "$file"
+
+    for word in $line; do
+        if [[ $word == */*:* ]]; then
+            device=${word#*/}
+            device=${device%%:*}
+            echo "$device"
+        fi
+    done
+}
+
+#
+# Verify expected devices match the active device list
+#
+verify_active_devices() {
+    file=$1
+    config_cnt=$2
+    expected=$3
+
+    actual_sorted=$(parse_active_devices "$file" "$config_cnt" | sort | paste -sd' ')
+    expected_sorted=$(echo "$expected" | tr ' ' '\n' | sort | paste -sd' ')
+
+    if [[ "$actual_sorted" != "$expected_sorted" ]];
+	then
+        echo "Error: configuration ${config_cnt} device mismatch"
+        echo "  expected: ${expected_sorted}"
+        echo "  actual:   ${actual_sorted}"
+        return 1
+    fi
+
+    return 0
+}
+
+#
+# Cleanup processes running in background 
+#
+kill_background_processes() {
+    for pid in "$@"
+    do
+        kill -9 "${pid}" || true
+    done
+}
+
+#
+# Fault Tolerance Test using ucx_perftest
+#
+run_ucx_perftest_fault_tolerance() {
+
+	if [[ $(uname -m) != "x86_64" ]]; then
+		echo "==== Skip UCX Perftest Fault Tolerance Test on $(uname -m) ===="
+		return 0
+	fi
+
+	echo "==== Running UCX Perftest Fault Tolerance Test ===="
+
+	test_exe="${ucx_inst}/bin/ucx_perftest"
+	drop_tool="/hpc/scrap/fault_tolerance/ucx_drop_tool"
+	output_file=ucx_perftest.stdout
+	settle_seconds=10
+	sl=$(( EXECUTOR_NUMBER + 1 ))
+	tc=$(( EXECUTOR_NUMBER + 31 ))
+	devices=$(get_active_ib_devnames)
+	device_cnt=$(echo ${devices} | wc -w)
+	background_pids=()
+	config_cnt=0
+	affinity=$(slice_affinity 0)
+	expected_devices="${devices}"
+
+	if [[ "${devices}" == "" ]];
+	then
+		echo "No IB devices detected. Skipping Fault Tolerance test"
+		return 0 
+	fi
+
+	if [[ ! -x "${drop_tool}" ]];
+	then
+		echo "Warning: Could not find drop tool at ${drop_tool}"
+		return 0 
+	fi
+
+	export UCX_IB_SL=${sl}
+	export UCX_IB_TRAFFIC_CLASS=${tc}
+	export UCX_ZCOPY_THRESH=0
+	export UCX_MIN_RMA_CHUNK_SIZE=64
+	export UCX_PROTO_INFO=y
+	export UCX_RC_MLX5_RETRY_COUNT=2
+	export UCX_IB_NUM_PATHS=1
+	export UCX_NET_DEVICES=$(get_active_ib_devnames | paste -sd,)
+	export UCX_MAX_RMA_RAILS=${device_cnt}
+	export UCX_TLS=rc_x 
+
+	args="-t ucp_put_lat    \
+		-n 1000000000000000 \
+		-s 1048576          \
+		-e failover         \
+		-l"
+
+	taskset -c ${affinity} ${test_exe} ${args} 2>&1 | tee ${output_file} &
+	background_pids+=($!)
+
+	sleep ${settle_seconds} 
+
+	if ! verify_active_devices ${output_file} ${config_cnt} "${devices}";
+	then
+		kill_background_processes "${background_pids[@]}"
+		return 1
+	fi
+
+	echo "Baseline protocol configuration uses devices: ${devices}"
+
+	# Loop through active IB devices. Block each one in turn and verify traffic
+	for dev in $(get_active_ib_devnames)
+	do
+		echo "Blocking traffic with service level ${sl} or traffic class ${tc} on device ${dev}..."
+		${drop_tool} -d ${dev} -s ${sl} -t ${tc} &
+		background_pids+=($!)
+		config_cnt=$((config_cnt + 1))
+
+		sleep ${settle_seconds}
+
+		expected_devices=$(echo "$expected_devices" | tr ' ' '\n' | grep -vFx "$dev" | paste -sd' ')
+
+		if ! verify_active_devices ${output_file} ${config_cnt} "${expected_devices}";
+		then
+			kill_background_processes "${background_pids[@]}"
+			return 1
+		fi
+
+		echo "Reconfiguration ${config_cnt} uses devices: ${expected_devices}"
+	done
+
+	kill_background_processes "${background_pids[@]}"
+
+	unset UCX_IB_SL
+	unset UCX_IB_TRAFFIC_CLASS
+	unset UCX_ZCOPY_THRESH
+	unset UCX_MIN_RMA_CHUNK_SIZE
+	unset UCX_PROTO_INFO
+	unset UCX_RC_MLX5_RETRY_COUNT
+	unset UCX_IB_NUM_PATHS
+	unset UCX_NET_DEVICES
+	unset UCX_MAX_RMA_RAILS
+	unset UCX_TLS
+
+	return 0
+}
+
+#
 # Run UCX performance test
 # Note: If requested running with MPI, MPI has to be initialized before
 # The function accepts 0 (default value) or 1 that means launching w/ or w/o MPI
@@ -550,7 +716,7 @@ run_ucx_perftest() {
 		run_client_server_app "$ucx_perftest" "$ucp_test_args" "$(hostname)" 0 0
 
 		# Run AMO tests
-		echo -e "4 -s 4\n8 -s 8" > "$ucx_inst_ptest/msg_atomic"
+		echo -e peer "4 -s 4\n8 -s 8" > "$ucx_inst_ptest/msg_atomic"
 		ucp_test_args_atomic="-b $ucx_inst_ptest/test_types_ucp_amo \
 			              -b $ucx_inst_ptest/msg_atomic \
 				      -n 1000 -w 1"
@@ -1280,6 +1446,9 @@ run_tests() {
 
 	# nt_buffer_transfer tests
 	do_distributed_task 0 4 run_nt_buffer_transfer_tests
+
+	# fault tolerance tests
+	do_distributed_task 1 4 run_ucx_perftest_fault_tolerance
 }
 
 run_asan_check() {

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -421,6 +421,7 @@ parse_active_devices() {
         IFS= read -r line || return 1  # | Range  | Description |                                    Config                                    |
         IFS= read -r line || return 1  # +--------+-------------+------------------------------------------------------------------------------+
         IFS= read -r line || return 1  # | 0..inf | zero-copy   | 34% on rc_mlx5/mlx5_0:1, 34% on rc_mlx5/mlx5_2:1 and 32% on rc_mlx5/mlx5_1:1 |
+		found=1
         break
     done < "$file"
 

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -488,7 +488,7 @@ run_ucx_perftest_fault_tolerance() {
 	echo "==== Running UCX Perftest Fault Tolerance Test ===="
 
 	test_exe="${ucx_inst}/bin/ucx_perftest"
-	drop_tool="/hpc/scrap/fault_tolerance/ucx_drop_tool"
+	drop_tool="/hpc/local/oss/ucx/fault_tolerance/ucx_drop_tool"
 	output_file=ucx_perftest.stdout
 	settle_seconds=10
 	sl=$(( EXECUTOR_NUMBER + 1 ))

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -526,7 +526,7 @@ run_ucx_perftest_fault_tolerance() {
 	args="-t ucp_put_lat    \
 		-n 1000000000000000 \
 		-s 1048576          \
-		-e failover         \
+		-efailover          \
 		-l"
 
 	taskset -c ${affinity} ${test_exe} ${args} > ${output_file} 2>&1 &

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -407,10 +407,10 @@ run_io_demo() {
 # Parse the protocol configuration info in ucx_perftest stdout to get active
 # devices 
 #
-parse_active_devices()
-{
+parse_active_devices() {
     file=$1
     config_cnt=$2
+    found=0
 
     while IFS= read -r line;
 	do
@@ -424,8 +424,16 @@ parse_active_devices()
         break
     done < "$file"
 
-    for word in $line; do
-        if [[ $word == */*:* ]]; then
+    if [[ $found -ne 1 ]];
+	then
+        echo "Error: Failed to find protocol configuration count $config_cnt in standard out" >&2 
+        return 1
+    fi
+
+    for word in $line;
+	do
+        if [[ $word == */*:* ]];
+		then
             device=${word#*/}
             device=${device%%:*}
             echo "$device"
@@ -441,7 +449,8 @@ verify_active_devices() {
     config_cnt=$2
     expected=$3
 
-    actual_sorted=$(parse_active_devices "$file" "$config_cnt" | sort | paste -sd' ')
+    actual=$(parse_active_devices "$file" "$config_cnt") || return 1
+    actual_sorted=$(echo "$actual" | sort | paste -sd' ')
     expected_sorted=$(echo "$expected" | tr ' ' '\n' | sort | paste -sd' ')
 
     if [[ "$actual_sorted" != "$expected_sorted" ]];
@@ -519,7 +528,7 @@ run_ucx_perftest_fault_tolerance() {
 		-e failover         \
 		-l"
 
-	taskset -c ${affinity} ${test_exe} ${args} 2>&1 | tee ${output_file} &
+	taskset -c ${affinity} ${test_exe} ${args} > ${output_file} 2>&1 &
 	background_pids+=($!)
 
 	sleep ${settle_seconds} 

--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -320,6 +320,8 @@ typedef struct ucx_perf_params {
         ucp_perf_datatype_t     recv_datatype;
         size_t                  am_hdr_size; /* UCP Active Message header size
                                                 (not included in message size) */
+        ucp_err_handling_mode_t err_mode; /* UCP endpoint error handling
+                                                mode */
         int                     is_daemon_mode;  /* Whether DPU offloading daemon
                                                     is configured */
         struct sockaddr_storage dmn_local_addr;  /* IP and port of local daemon,

--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -320,8 +320,7 @@ typedef struct ucx_perf_params {
         ucp_perf_datatype_t     recv_datatype;
         size_t                  am_hdr_size; /* UCP Active Message header size
                                                 (not included in message size) */
-        ucp_err_handling_mode_t err_mode; /* UCP endpoint error handling
-                                                mode */
+        ucp_err_handling_mode_t err_mode;    /* UCP endpoint error handling mode */
         int                     is_daemon_mode;  /* Whether DPU offloading daemon
                                                     is configured */
         struct sockaddr_storage dmn_local_addr;  /* IP and port of local daemon,

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -8,6 +8,7 @@
 * See file LICENSE for terms.
 */
 
+#include "ucp/api/ucp_def.h"
 #ifdef HAVE_CONFIG_H
 #  include "config.h"
 #endif
@@ -1194,7 +1195,7 @@ static ucs_status_t ucp_perf_test_receive_remote_data(ucx_perf_context_t *perf,
                                         UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
             ep_params.err_handler.cb  = ucp_perf_test_err_handler;
             ep_params.err_handler.arg = NULL;
-            ep_params.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
+            ep_params.err_mode        = perf->params.ucp.err_mode;
         }
 
         status = UCX_PERF_VERBOSE(error, &perf->params, ucp_ep_create,

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -8,11 +8,11 @@
 * See file LICENSE for terms.
 */
 
-#include "ucp/api/ucp_def.h"
 #ifdef HAVE_CONFIG_H
 #  include "config.h"
 #endif
 
+#include <ucp/api/ucp_def.h>
 #include <ucs/arch/bitops.h>
 #include <ucs/datastruct/string_buffer.h>
 #include <ucs/datastruct/string_set.h>

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -1195,11 +1195,7 @@ static ucs_status_t ucp_perf_test_receive_remote_data(ucx_perf_context_t *perf,
                                         UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
             ep_params.err_handler.cb  = ucp_perf_test_err_handler;
             ep_params.err_handler.arg = NULL;
-            ep_params.err_mode        =
-                    (perf->params.ucp.err_mode ==
-                     UCP_ERR_HANDLING_MODE_NONE) ?
-                    UCP_ERR_HANDLING_MODE_PEER :
-                    perf->params.ucp.err_mode;
+            ep_params.err_mode        = perf->params.ucp.err_mode;
         }
 
         status = UCX_PERF_VERBOSE(error, &perf->params, ucp_ep_create,

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -1195,7 +1195,11 @@ static ucs_status_t ucp_perf_test_receive_remote_data(ucx_perf_context_t *perf,
                                         UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
             ep_params.err_handler.cb  = ucp_perf_test_err_handler;
             ep_params.err_handler.arg = NULL;
-            ep_params.err_mode        = perf->params.ucp.err_mode;
+            ep_params.err_mode        =
+                    (perf->params.ucp.err_mode ==
+                     UCP_ERR_HANDLING_MODE_NONE) ?
+                    UCP_ERR_HANDLING_MODE_PEER :
+                    perf->params.ucp.err_mode;
         }
 
         status = UCX_PERF_VERBOSE(error, &perf->params, ucp_ep_create,

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -203,6 +203,7 @@ ucs_status_t init_test_params(perftest_params_t *params)
     params->super.ucp.send_datatype   = UCP_PERF_DATATYPE_CONTIG;
     params->super.ucp.recv_datatype   = UCP_PERF_DATATYPE_CONTIG;
     params->super.ucp.am_hdr_size     = 0;
+    params->super.ucp.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
     params->super.device_channel_mode = UCX_PERF_CHANNEL_MODE_SINGLE;
     params->super.channel_rand_seed   = ucs_generate_uuid((uintptr_t)params);
     params->super.device_thread_count = 1;

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -203,7 +203,7 @@ ucs_status_t init_test_params(perftest_params_t *params)
     params->super.ucp.send_datatype   = UCP_PERF_DATATYPE_CONTIG;
     params->super.ucp.recv_datatype   = UCP_PERF_DATATYPE_CONTIG;
     params->super.ucp.am_hdr_size     = 0;
-    params->super.ucp.err_mode        = UCP_ERR_HANDLING_MODE_PEER;
+    params->super.ucp.err_mode        = UCP_ERR_HANDLING_MODE_NONE;
     params->super.device_channel_mode = UCX_PERF_CHANNEL_MODE_SINGLE;
     params->super.channel_rand_seed   = ucs_generate_uuid((uintptr_t)params);
     params->super.device_thread_count = 1;

--- a/src/tools/perf/perftest.h
+++ b/src/tools/perf/perftest.h
@@ -19,7 +19,8 @@
 #endif
 
 #define TL_RESOURCE_NAME_NONE   "<none>"
-#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:a:R:lyzL:F:Y:"
+#define TEST_PARAMS_ARGS \
+    "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUe:m:a:R:lyzL:F:Y:"
 #define TEST_ID_UNDEFINED       -1
 
 #define DEFAULT_DAEMON_PORT     1338

--- a/src/tools/perf/perftest.h
+++ b/src/tools/perf/perftest.h
@@ -20,7 +20,7 @@
 
 #define TL_RESOURCE_NAME_NONE   "<none>"
 #define TEST_PARAMS_ARGS \
-    "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUe:m:a:R:lyzL:F:Y:"
+    "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUe::m:a:R:lyzL:F:Y:"
 #define TEST_ID_UNDEFINED       -1
 
 #define DEFAULT_DAEMON_PORT     1338

--- a/src/tools/perf/perftest_context.h
+++ b/src/tools/perf/perftest_context.h
@@ -73,12 +73,14 @@ static inline ucs_status_t
 perftest_params_merge(perftest_params_t *dst, const perftest_params_t *src)
 {
     char uct_dev_name[UCT_DEVICE_NAME_MAX];
+    ucp_err_handling_mode_t needed_err_mode;
     unsigned needed_flags;
 
     /* backup required dst parameters */
     ucs_strncpy_safe(uct_dev_name, dst->super.uct.dev_name,
                      UCT_DEVICE_NAME_MAX);
-    needed_flags = (dst->super.flags & UCX_PERF_TEST_FLAG_ERR_HANDLING);
+    needed_err_mode = dst->super.ucp.err_mode;
+    needed_flags    = (dst->super.flags & UCX_PERF_TEST_FLAG_ERR_HANDLING);
 
     perftest_params_release_msg_size_list(dst);
 
@@ -99,6 +101,9 @@ perftest_params_merge(perftest_params_t *dst, const perftest_params_t *src)
     ucs_strncpy_safe(dst->super.uct.dev_name, uct_dev_name,
                      UCT_DEVICE_NAME_MAX);
     dst->super.flags |= needed_flags;
+    if (needed_flags) {
+        dst->super.ucp.err_mode = needed_err_mode;
+    }
     return UCS_OK;
 }
 

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -165,7 +165,9 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("                        recv       : Use ucp_stream_recv_nb\n");
     printf("                        recv_data  : Use ucp_stream_recv_data_nb\n");
     printf("     -I             create context with wakeup feature enabled\n");
-    printf("     -e             create endpoints with error handling support\n");
+    printf("     -e <mode>      create endpoints with error handling mode:\n");
+    printf("                        peer     - peer failure error handling\n");
+    printf("                        failover - lane failover error handling\n");
     printf("     -E <mode>      wait mode for tests\n");
     printf("                        poll       : repeatedly call worker_progress\n");
     printf("                        sleep      : go to sleep after posting requests\n");
@@ -475,6 +477,27 @@ static ucs_status_t parse_device_level(const char *opt_arg,
     return UCS_ERR_INVALID_PARAM;
 }
 
+static ucs_status_t
+parse_ucp_err_handling_mode(const char *opt_arg,
+                            ucp_err_handling_mode_t *err_mode)
+{
+    if (opt_arg == NULL) {
+        ucs_error("error handling mode string is NULL");
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    if (!strcmp(opt_arg, "peer")) {
+        *err_mode = UCP_ERR_HANDLING_MODE_PEER;
+        return UCS_OK;
+    } else if (!strcmp(opt_arg, "failover")) {
+        *err_mode = UCP_ERR_HANDLING_MODE_FAILOVER;
+        return UCS_OK;
+    }
+
+    ucs_error("Invalid option argument for error handling mode: %s", opt_arg);
+    return UCS_ERR_INVALID_PARAM;
+}
+
 static ucs_status_t parse_ucp_datatype_params(const char *opt_arg,
                                               ucp_perf_datatype_t *datatype)
 {
@@ -702,7 +725,8 @@ ucs_status_t parse_test_params(perftest_params_t *params, char opt,
         return UCS_OK;
     case 'e':
         params->super.flags |= UCX_PERF_TEST_FLAG_ERR_HANDLING;
-        return UCS_OK;
+        return parse_ucp_err_handling_mode(opt_arg,
+                                           &params->super.ucp.err_mode);
     case 'M':
         if (!strcmp(opt_arg, "single")) {
             params->super.thread_mode = UCS_THREAD_MODE_SINGLE;

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -165,7 +165,8 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("                        recv       : Use ucp_stream_recv_nb\n");
     printf("                        recv_data  : Use ucp_stream_recv_data_nb\n");
     printf("     -I             create context with wakeup feature enabled\n");
-    printf("     -e <mode>      create endpoints with error handling mode:\n");
+    printf("     -e [<mode>]    create endpoints with error handling mode (peer):\n");
+    printf("                        none     - no error handling\n");
     printf("                        peer     - peer failure error handling\n");
     printf("                        failover - lane failover error handling\n");
     printf("     -E <mode>      wait mode for tests\n");
@@ -478,24 +479,29 @@ static ucs_status_t parse_device_level(const char *opt_arg,
 }
 
 static ucs_status_t
-parse_ucp_err_handling_mode(const char *opt_arg,
-                            ucp_err_handling_mode_t *err_mode)
+parse_ucp_err_handling_params(perftest_params_t *params, const char *opt_arg)
 {
     if (opt_arg == NULL) {
-        ucs_error("error handling mode string is NULL");
-        return UCS_ERR_INVALID_PARAM;
+        params->super.flags |= UCX_PERF_TEST_FLAG_ERR_HANDLING;
+        params->super.ucp.err_mode = UCP_ERR_HANDLING_MODE_PEER;
+        return UCS_OK;
     }
 
     if (!strcmp(opt_arg, "peer")) {
-        *err_mode = UCP_ERR_HANDLING_MODE_PEER;
-        return UCS_OK;
+        params->super.flags |= UCX_PERF_TEST_FLAG_ERR_HANDLING;
+        params->super.ucp.err_mode = UCP_ERR_HANDLING_MODE_PEER;
     } else if (!strcmp(opt_arg, "failover")) {
-        *err_mode = UCP_ERR_HANDLING_MODE_FAILOVER;
-        return UCS_OK;
+        params->super.flags |= UCX_PERF_TEST_FLAG_ERR_HANDLING;
+        params->super.ucp.err_mode = UCP_ERR_HANDLING_MODE_FAILOVER;
+    } else if (!strcmp(opt_arg, "none")) {
+        params->super.flags &= ~UCX_PERF_TEST_FLAG_ERR_HANDLING;
+        params->super.ucp.err_mode = UCP_ERR_HANDLING_MODE_NONE;
+    } else {
+        ucs_error("Invalid option argument for -e: %s", opt_arg);
+        return UCS_ERR_INVALID_PARAM;
     }
 
-    ucs_error("Invalid option argument for error handling mode: %s", opt_arg);
-    return UCS_ERR_INVALID_PARAM;
+    return UCS_OK;
 }
 
 static ucs_status_t parse_ucp_datatype_params(const char *opt_arg,
@@ -724,9 +730,7 @@ ucs_status_t parse_test_params(perftest_params_t *params, char opt,
         params->super.flags |= UCX_PERF_TEST_FLAG_WAKEUP;
         return UCS_OK;
     case 'e':
-        params->super.flags |= UCX_PERF_TEST_FLAG_ERR_HANDLING;
-        return parse_ucp_err_handling_mode(opt_arg,
-                                           &params->super.ucp.err_mode);
+        return parse_ucp_err_handling_params(params, opt_arg);
     case 'M':
         if (!strcmp(opt_arg, "single")) {
             params->super.thread_mode = UCS_THREAD_MODE_SINGLE;

--- a/test/gtest/common/test_perf.cc
+++ b/test/gtest/common/test_perf.cc
@@ -252,6 +252,10 @@ void test_perf::test_params_init(const test_spec &test,
     params.iov_stride           = test.msg_stride;
     params.ucp.send_datatype    = (ucp_perf_datatype_t)test.data_layout;
     params.ucp.recv_datatype    = (ucp_perf_datatype_t)test.data_layout;
+    params.ucp.err_mode         =
+            (params.flags & UCX_PERF_TEST_FLAG_ERR_HANDLING) ?
+            UCP_ERR_HANDLING_MODE_PEER :
+            UCP_ERR_HANDLING_MODE_NONE;
     params.ucp.am_hdr_size      = 0;
     params.ucp.is_daemon_mode   = 0;
     params.ucp.dmn_local_addr   = {};


### PR DESCRIPTION
## What?

- Adds Fault Tolerance test using ucx_perftest
- Adds 'failover' as endpoint failure mode in ucx_perftest

## Why?

Allows testing of UCX handling of lane failures.
