### PR TITLE
UCT/CUDA/IB: Match dmabuf mapping to the importer's registration verb

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -2024,6 +2024,9 @@ static void ucp_fill_resources_reg_md_map_update(ucp_context_h context)
 
         if (md_attr->flags & UCT_MD_FLAG_REG_DMABUF) {
             context->dmabuf_reg_md_map |= UCS_BIT(md_index);
+            if (md_attr->flags & UCT_MD_FLAG_DMABUF_REG_PCIE) {
+                context->dmabuf_pcie_md_map |= UCS_BIT(md_index);
+            }
         }
     }
 

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -423,6 +423,10 @@ typedef struct ucp_context {
     /* Map of MDs that support dmabuf registration */
     ucp_md_map_t                  dmabuf_reg_md_map;
 
+    /* Subset of dmabuf_reg_md_map that registers device-memory dmabuf via the
+       device PCIe BAR (Direct NIC / DATA_DIRECT) and needs a PCIe-mapped fd */
+    ucp_md_map_t                  dmabuf_pcie_md_map;
+
     /* List of MDs that detect non host memory type */
     ucp_md_index_t                mem_type_detect_mds[UCS_MEMORY_TYPE_LAST];
     ucp_md_index_t                num_mem_type_detect_mds;  /* Number of mem type MDs */

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2015. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -557,9 +557,14 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
     size_t length                       = ucp_memh_length(memh);
     ucp_md_map_t md_map_registered      = 0;
     ucp_md_map_t dmabuf_md_map          = 0;
+    int host_dmabuf_fd                  = UCT_DMABUF_FD_INVALID;
+    int pcie_dmabuf_fd                  = UCT_DMABUF_FD_INVALID;
+    size_t pcie_dmabuf_offset           = 0;
+    size_t host_dmabuf_offset           = 0;
     ucp_md_map_t reg_md_map;
     uct_md_mem_reg_params_t reg_params;
     uct_md_mem_attr_t mem_attr;
+    uct_md_mem_attr_t pcie_attr;
     ucp_md_index_t md_index;
     ucs_status_t status;
     void *reg_address;
@@ -591,10 +596,13 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
 
     if ((dmabuf_prov_md_index != UCP_NULL_RESOURCE) &&
         (reg_md_map & context->dmabuf_reg_md_map)) {
-        /* Query dmabuf file descriptor and offset */
-        mem_attr.field_mask = UCT_MD_MEM_ATTR_FIELD_DMABUF_FD |
-                              UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET |
-                              UCT_MD_MEM_ATTR_FIELD_SYS_DEV;
+        /* Query the host-mapped dmabuf fd shared by all generic-verb mds;
+           Direct-NIC importers get a PCIe-mapped fd below. */
+        mem_attr.field_mask     = UCT_MD_MEM_ATTR_FIELD_DMABUF_FD |
+                                  UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET |
+                                  UCT_MD_MEM_ATTR_FIELD_SYS_DEV |
+                                  UCT_MD_MEM_ATTR_FIELD_DMABUF_MAPPING;
+        mem_attr.dmabuf_mapping = UCT_MD_DMABUF_MAPPING_HOST;
         status = uct_md_mem_query(context->tl_mds[dmabuf_prov_md_index].md,
                                   address, length, &mem_attr);
         if (status != UCS_OK) {
@@ -607,9 +615,9 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
                       address, length, mem_attr.dmabuf_fd,
                       mem_attr.dmabuf_offset, mem_attr.sys_dev);
 
-            dmabuf_md_map            = context->dmabuf_reg_md_map;
-            reg_params.dmabuf_fd     = mem_attr.dmabuf_fd;
-            reg_params.dmabuf_offset = mem_attr.dmabuf_offset;
+            dmabuf_md_map      = context->dmabuf_reg_md_map;
+            host_dmabuf_fd     = mem_attr.dmabuf_fd;
+            host_dmabuf_offset = mem_attr.dmabuf_offset;
 
             /* Exclude any unreachable MD from registration */
             ucs_for_each_bit(md_index, dmabuf_md_map) {
@@ -619,6 +627,20 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
                     ucs_trace("md[%d] skipped: cannot reach mem_sys_dev=%u",
                               md_index, mem_attr.sys_dev);
                     reg_md_map &= ~UCS_BIT(md_index);
+                }
+            }
+
+            /* Query a PCIe-mapped handle once if any md needs it. */
+            if (reg_md_map & context->dmabuf_pcie_md_map) {
+                pcie_attr.field_mask     = UCT_MD_MEM_ATTR_FIELD_DMABUF_FD |
+                                           UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET |
+                                           UCT_MD_MEM_ATTR_FIELD_DMABUF_MAPPING;
+                pcie_attr.dmabuf_mapping = UCT_MD_DMABUF_MAPPING_PCIE;
+                pcie_attr.dmabuf_fd      = UCT_DMABUF_FD_INVALID;
+                if (uct_md_mem_query(context->tl_mds[dmabuf_prov_md_index].md,
+                                     address, length, &pcie_attr) == UCS_OK) {
+                    pcie_dmabuf_fd     = pcie_attr.dmabuf_fd;
+                    pcie_dmabuf_offset = pcie_attr.dmabuf_offset;
                 }
             }
         }
@@ -639,6 +661,18 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
             /* If this MD can consume a dmabuf and we have it - provide it */
             reg_params.field_mask |= UCT_MD_MEM_REG_FIELD_DMABUF_FD |
                                      UCT_MD_MEM_REG_FIELD_DMABUF_OFFSET;
+
+            /* A Direct-NIC importer (dmabuf_pcie_md_map) registers via mlx5dv +
+               DATA_DIRECT and must use the PCIe-mapped handle; every other
+               importer uses the shared host-mapped handle. */
+            if ((pcie_dmabuf_fd != UCT_DMABUF_FD_INVALID) &&
+                (context->dmabuf_pcie_md_map & UCS_BIT(md_index))) {
+                reg_params.dmabuf_fd     = pcie_dmabuf_fd;
+                reg_params.dmabuf_offset = pcie_dmabuf_offset;
+            } else {
+                reg_params.dmabuf_fd     = host_dmabuf_fd;
+                reg_params.dmabuf_offset = host_dmabuf_offset;
+            }
         }
 
         reg_address = address;
@@ -653,8 +687,12 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
                                    reg_length, &reg_params, &memh->uct[md_index]);
         if (ucs_unlikely(status != UCS_OK)) {
             ucp_memh_register_log_fail(err_level, reg_address, reg_length,
-                                       mem_type, reg_params.dmabuf_fd, md_index,
-                                       context, status);
+                                       mem_type,
+                                       (reg_params.field_mask &
+                                        UCT_MD_MEM_REG_FIELD_DMABUF_FD) ?
+                                               reg_params.dmabuf_fd :
+                                               UCT_DMABUF_FD_INVALID,
+                                       md_index, context, status);
             if (allow_partial_reg &&
                 (uct_flags & UCT_MD_MEM_FLAG_HIDE_ERRORS)) {
                 continue;
@@ -667,11 +705,11 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
         ucs_trace("register address %p length %zu dmabuf-fd %d flags %ld "
                   "on md[%d]=%s %p",
                   reg_address, reg_length,
-                  (dmabuf_md_map & UCS_BIT(md_index)) ? reg_params.dmabuf_fd :
-                                                        UCT_DMABUF_FD_INVALID,
-                  reg_params.flags,
-                  md_index, context->tl_mds[md_index].rsc.md_name,
-                  memh->uct[md_index]);
+                  (reg_params.field_mask & UCT_MD_MEM_REG_FIELD_DMABUF_FD) ?
+                          reg_params.dmabuf_fd :
+                          UCT_DMABUF_FD_INVALID,
+                  reg_params.flags, md_index,
+                  context->tl_mds[md_index].rsc.md_name, memh->uct[md_index]);
         md_map_registered |= UCS_BIT(md_index);
     }
 
@@ -683,7 +721,8 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
 
 out_close_dmabuf_fd:
     UCS_STATIC_ASSERT(UCT_DMABUF_FD_INVALID == -1);
-    ucs_close_fd(&reg_params.dmabuf_fd);
+    ucs_close_fd(&host_dmabuf_fd);
+    ucs_close_fd(&pcie_dmabuf_fd);
     return status;
 }
 

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -1046,19 +1046,6 @@ out:
     return status;
 }
 
-int ucs_topo_device_has_sibling(ucs_sys_device_t sys_dev)
-{
-    int result;
-
-    ucs_spin_lock(&ucs_topo_global_ctx.lock);
-    result = (sys_dev < ucs_topo_global_ctx.num_devices) &&
-             (ucs_topo_global_ctx.devices[sys_dev].sibling_sys_dev !=
-              UCS_SYS_DEVICE_ID_UNKNOWN);
-    ucs_spin_unlock(&ucs_topo_global_ctx.lock);
-
-    return result;
-}
-
 ucs_status_t
 ucs_topo_sys_device_set_user_value(ucs_sys_device_t sys_dev, uintptr_t value)
 {

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -430,9 +430,6 @@ ucs_topo_is_reachable(ucs_sys_device_t sys_dev, ucs_sys_device_t sys_dev_mem);
 int ucs_topo_is_sibling(ucs_sys_device_t sys_dev, ucs_sys_device_t sys_dev_mem);
 
 
-int ucs_topo_device_has_sibling(ucs_sys_device_t sys_dev);
-
-
 /**
  * Get the number of registered system devices.
  *

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -1,6 +1,6 @@
 /**
  * @file        uct.h
- * @date        2014-2020
+ * @date        2014-2026
  * @copyright   NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
  * @copyright   Oak Ridge National Laboratory. All rights received.
  * @copyright   Advanced Micro Devices, Inc. All rights received.
@@ -1601,33 +1601,60 @@ struct uct_md_attr {
  */
 typedef enum uct_md_mem_attr_field {
     /** Indicate if memory type is populated. E.g. CPU/GPU */
-    UCT_MD_MEM_ATTR_FIELD_MEM_TYPE      = UCS_BIT(0),
+    UCT_MD_MEM_ATTR_FIELD_MEM_TYPE       = UCS_BIT(0),
 
     /**
      * Indicate if details of system device backing the pointer are populated.
      * For example: GPU device, NUMA domain, etc.
      */
-    UCT_MD_MEM_ATTR_FIELD_SYS_DEV       = UCS_BIT(1),
+    UCT_MD_MEM_ATTR_FIELD_SYS_DEV        = UCS_BIT(1),
 
     /** Request base address of the allocation to which the buffer belongs. */
-    UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS  = UCS_BIT(2),
+    UCT_MD_MEM_ATTR_FIELD_BASE_ADDRESS   = UCS_BIT(2),
 
     /** Request the whole length of the allocation to which the buffer belongs. */
-    UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH  = UCS_BIT(3),
+    UCT_MD_MEM_ATTR_FIELD_ALLOC_LENGTH   = UCS_BIT(3),
 
     /**
      * Request a cross-device dmabuf file descriptor that represents a memory
      * region, and can be used to register the region with another memory
      * domain.
      */
-    UCT_MD_MEM_ATTR_FIELD_DMABUF_FD     = UCS_BIT(4),
+    UCT_MD_MEM_ATTR_FIELD_DMABUF_FD      = UCS_BIT(4),
 
     /**
      * Request the offset of the provided virtual address relative to the
      * beginning of its backing dmabuf region.
      */
-    UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET = UCS_BIT(5)
+    UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET  = UCS_BIT(5),
+
+    /** Select the dmabuf mapping type (see @ref uct_md_dmabuf_mapping_t). */
+    UCT_MD_MEM_ATTR_FIELD_DMABUF_MAPPING = UCS_BIT(6)
 } uct_md_mem_attr_field_t;
+
+
+/**
+ * @ingroup UCT_MD
+ * @brief  Mapping type of a dmabuf file descriptor.
+ *
+ * Used as an input hint to @ref uct_md_mem_query (via the @a dmabuf_mapping
+ * field of @ref uct_md_mem_attr_t) to control how the memory domain maps the
+ * memory region backing the returned dmabuf file descriptor. The mapping must
+ * match the verb that will be used to register the descriptor.
+ */
+typedef enum uct_md_dmabuf_mapping {
+    /**
+     * Map the region through the host (default), so the descriptor can be
+     * registered by generic verbs (e.g. ibv_reg_dmabuf_mr).
+     */
+    UCT_MD_DMABUF_MAPPING_HOST = 0,
+
+    /**
+     * Map the region through the device PCIe BAR, so the descriptor can be
+     * registered by a Direct NIC (e.g. mlx5dv_reg_dmabuf_mr with DATA_DIRECT).
+     */
+    UCT_MD_DMABUF_MAPPING_PCIE
+} uct_md_dmabuf_mapping_t;
 
 
 /**
@@ -1688,6 +1715,14 @@ typedef struct uct_md_mem_attr {
      * (identified by dmabuf_fd) backing the memory region being queried.
      */
     size_t            dmabuf_offset;
+
+    /**
+     * Input hint for the dmabuf mapping of the returned @a dmabuf_fd, from
+     * @ref uct_md_dmabuf_mapping_t. Used only when
+     * @ref UCT_MD_MEM_ATTR_FIELD_DMABUF_MAPPING is set, otherwise the default
+     * (host) mapping is used.
+     */
+    uct_md_dmabuf_mapping_t dmabuf_mapping;
 } uct_md_mem_attr_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1028,7 +1028,7 @@ typedef struct {
  * @brief  Memory domain capability flags.
  */
 typedef enum {
-    UCT_MD_FLAG_V2_FIRST       = UCT_MD_FLAG_LAST,
+    UCT_MD_FLAG_V2_FIRST        = UCT_MD_FLAG_LAST,
 
     /**
      * Memory domain supports invalidation of memory handle registered by
@@ -1036,7 +1036,7 @@ typedef enum {
      * key by @ref uct_md_mkey_pack_v2 with
      * @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE_RMA flag.
      */
-    UCT_MD_FLAG_INVALIDATE_RMA = UCT_MD_FLAG_V2_FIRST,
+    UCT_MD_FLAG_INVALIDATE_RMA  = UCT_MD_FLAG_V2_FIRST,
 
     /**
      * Memory domain supports invalidation of memory handle registered by
@@ -1044,12 +1044,19 @@ typedef enum {
      * packed key by @ref uct_md_mkey_pack_v2 with
      * @ref UCT_MD_MKEY_PACK_FLAG_INVALIDATE_AMO flag.
      */
-    UCT_MD_FLAG_INVALIDATE_AMO = UCS_BIT(12),
+    UCT_MD_FLAG_INVALIDATE_AMO  = UCS_BIT(12),
 
     /**
      * Memory domain performs memory type related copy operations.
      */
-    UCT_MD_FLAG_MEMTYPE_COPY   = UCS_BIT(13)
+    UCT_MD_FLAG_MEMTYPE_COPY    = UCS_BIT(13),
+
+    /**
+     * Memory domain registers device-memory dmabuf through the device PCIe BAR
+     * (Direct NIC / DATA_DIRECT) and therefore requires a PCIe-mapped dmabuf
+     * handle (see @ref uct_md_dmabuf_mapping_t).
+     */
+    UCT_MD_FLAG_DMABUF_REG_PCIE = UCS_BIT(14)
 } uct_md_flags_v2_t;
 
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2017-2019. ALL RIGHTS RESERVED.
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2017-2026. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -740,7 +740,7 @@ out_default_range:
 }
 
 static int uct_cuda_copy_md_get_dmabuf_fd(uintptr_t address, size_t length,
-                                          ucs_sys_device_t sys_dev)
+                                          uct_md_dmabuf_mapping_t mapping)
 {
 #if CUDA_VERSION >= 11070
     unsigned long long flags = 0;
@@ -772,15 +772,8 @@ static int uct_cuda_copy_md_get_dmabuf_fd(uintptr_t address, size_t length,
 #endif
 
 #if CUDA_VERSION >= 12080
-    /**
-     * DMA_BUF handle mapped via PCIE BAR1 can only be used in conjunction with
-     * mlx5dv_reg_dmabuf_mr. Other interfaces (e.g. ibv_reg_dmabuf_mr) may
-     * successfully register the handle, but the subsequent remote ib operation
-     * will fail.
-     * Check if there is a sibling device to determine if the handle will be
-     * used by a Direct NIC via mlx5dv_reg_dmabuf_mr.
-     */
-    if (ucs_topo_device_has_sibling(sys_dev)) {
+    /* Set flags to the requested mapping; host mapping (flags 0) is the default. */
+    if (mapping == UCT_MD_DMABUF_MAPPING_PCIE) {
         flags = CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE;
     }
 #endif
@@ -801,9 +794,9 @@ static int uct_cuda_copy_md_get_dmabuf_fd(uintptr_t address, size_t length,
     return UCT_DMABUF_FD_INVALID;
 }
 
-uct_cuda_copy_md_dmabuf_t uct_cuda_copy_md_get_dmabuf(const void *address,
-                                                      size_t length,
-                                                      ucs_sys_device_t sys_dev)
+uct_cuda_copy_md_dmabuf_t
+uct_cuda_copy_md_get_dmabuf(const void *address, size_t length,
+                            uct_md_dmabuf_mapping_t mapping)
 {
     uct_cuda_copy_md_dmabuf_t dmabuf;
     uintptr_t base_address, aligned_start, aligned_end;
@@ -811,9 +804,9 @@ uct_cuda_copy_md_dmabuf_t uct_cuda_copy_md_get_dmabuf(const void *address,
     base_address  = (uintptr_t)address;
     aligned_start = ucs_align_down_pow2(base_address, ucs_get_page_size());
     aligned_end = ucs_align_up_pow2(base_address + length, ucs_get_page_size());
-    dmabuf.fd   = uct_cuda_copy_md_get_dmabuf_fd(aligned_start,
-                                                 aligned_end - aligned_start,
-                                                 sys_dev);
+    dmabuf.fd     = uct_cuda_copy_md_get_dmabuf_fd(aligned_start,
+                                                   aligned_end - aligned_start,
+                                                   mapping);
     dmabuf.offset = base_address - aligned_start;
     return dmabuf;
 }
@@ -832,6 +825,7 @@ uct_cuda_copy_md_mem_query(uct_md_h tl_md, const void *address, size_t length,
     ucs_memory_info_t addr_mem_info;
     ucs_status_t status;
     uct_cuda_copy_md_dmabuf_t dmabuf;
+    uct_md_dmabuf_mapping_t mapping;
 
     if (!(mem_attr->field_mask &
           (UCT_MD_MEM_ATTR_FIELD_MEM_TYPE | UCT_MD_MEM_ATTR_FIELD_SYS_DEV |
@@ -874,9 +868,12 @@ uct_cuda_copy_md_mem_query(uct_md_h tl_md, const void *address, size_t length,
 
     if ((mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_DMABUF_FD) ||
         (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_DMABUF_OFFSET)) {
-        dmabuf = uct_cuda_copy_md_get_dmabuf(addr_mem_info.base_address,
-                                             addr_mem_info.alloc_length,
-                                             addr_mem_info.sys_dev);
+        mapping = (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_DMABUF_MAPPING) ?
+                          mem_attr->dmabuf_mapping :
+                          UCT_MD_DMABUF_MAPPING_HOST;
+        dmabuf  = uct_cuda_copy_md_get_dmabuf(addr_mem_info.base_address,
+                                              addr_mem_info.alloc_length,
+                                              mapping);
         if (mem_attr->field_mask & UCT_MD_MEM_ATTR_FIELD_DMABUF_FD) {
             mem_attr->dmabuf_fd = dmabuf.fd;
         }

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -871,21 +871,22 @@ ucs_status_t uct_cuda_copy_md_mem_query(uct_md_h tl_md, const void *address,
         .fd     = UCT_DMABUF_FD_INVALID,
         .offset = 0
     };
-    int dmabuf_queried               = 0;
-    int is_async_managed             = 0;
+    int dmabuf_queried    = 0;
+    int is_async_managed  = 0;
     ucs_memory_info_t addr_mem_info;
     ucs_status_t status;
     uct_md_dmabuf_mapping_t mapping;
 
-    if (!(mem_attr->field_mask & (UCT_MD_MEM_ATTR_V2_FIELD_MEM_TYPE |
-                                  UCT_MD_MEM_ATTR_V2_FIELD_SYS_DEV |
-                                  UCT_MD_MEM_ATTR_V2_FIELD_BASE_ADDRESS |
-                                  UCT_MD_MEM_ATTR_V2_FIELD_ALLOC_LENGTH |
-                                  UCT_MD_MEM_ATTR_V2_FIELD_DMABUF_FD |
-                                  UCT_MD_MEM_ATTR_V2_FIELD_DMABUF_OFFSET |
-                                  UCT_MD_MEM_ATTR_V2_FIELD_MEM_FLAGS))) {
+    if (!(mem_attr->field_mask &
+          (UCT_MD_MEM_ATTR_V2_FIELD_MEM_TYPE |
+           UCT_MD_MEM_ATTR_V2_FIELD_SYS_DEV |
+           UCT_MD_MEM_ATTR_V2_FIELD_BASE_ADDRESS |
+           UCT_MD_MEM_ATTR_V2_FIELD_ALLOC_LENGTH |
+           UCT_MD_MEM_ATTR_V2_FIELD_DMABUF_FD |
+           UCT_MD_MEM_ATTR_V2_FIELD_DMABUF_OFFSET |
+           UCT_MD_MEM_ATTR_V2_FIELD_MEM_FLAGS))) {
         return UCS_OK;
-    }
+  }
 
     if (address != NULL) {
         status = uct_cuda_copy_md_query_attributes(md, address, length,

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2017. ALL RIGHTS RESERVED.
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2017-2026. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -94,14 +94,15 @@ int uct_cuda_copy_md_is_dmabuf_supported();
  *
  * @param address [in] Starting address of the MR
  * @param length  [in] Size of the MR
- * @param sys_dev [in] System device ID of the MR. The ID is used to check if
-                       file descriptor can be used by a Direct NIC. If sys_dev
-                       is UCS_SYS_DEVICE_ID_UNKNOWN, the file descriptor can
-                       be used by any device.
+ * @param mapping [in] Requested mapping type of the region backing the file
+                       descriptor. UCT_MD_DMABUF_MAPPING_PCIE maps it via the
+                       device PCIe BAR (Direct NIC / DATA_DIRECT);
+                       UCT_MD_DMABUF_MAPPING_HOST maps it through the host
+                       (generic verbs).
  * @return The dmabuf file descriptor and offset
  */
-uct_cuda_copy_md_dmabuf_t uct_cuda_copy_md_get_dmabuf(const void *address,
-                                                      size_t length,
-                                                      ucs_sys_device_t sys_dev);
+uct_cuda_copy_md_dmabuf_t
+uct_cuda_copy_md_get_dmabuf(const void *address, size_t length,
+                            uct_md_dmabuf_mapping_t mapping);
 
 #endif

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019-2026. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -2505,6 +2505,12 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
 
     md->direct_nic_sys_dev = uct_ib_mlx5dv_check_direct_nic(
             ctx, dev->sys_dev, md_config->ext.direct_nic);
+    if (md->direct_nic_sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
+        /* This MD registers device-memory dmabuf via the Direct NIC
+         * (mlx5dv_reg_dmabuf_mr + DATA_DIRECT), which needs a PCIe-mapped
+         * handle. Advertise it so UCP requests the matching mapping. */
+        md->super.cap_flags |= UCT_MD_FLAG_DMABUF_REG_PCIE;
+    }
 
     if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, atomic)) {
         int ops = UCT_IB_MLX5_ATOMIC_OPS_CMP_SWAP |

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -149,7 +149,7 @@ static int uct_gdaki_check_umem_dmabuf(const uct_ib_md_t *md)
     }
 
     dmabuf = uct_cuda_copy_md_get_dmabuf((void*)buff, 1,
-                                         UCS_SYS_DEVICE_ID_UNKNOWN);
+                                         UCT_MD_DMABUF_MAPPING_HOST);
     if (dmabuf.fd == UCT_DMABUF_FD_INVALID) {
         goto out_free;
     }
@@ -334,7 +334,7 @@ uct_rc_gdaki_umem_reg(const uct_ib_md_t *md, struct ibv_context *ibv_context,
 
     if (uct_gdaki_get_driver_features(md) & UCT_GDAKI_DMABUF_UMEM) {
         dmabuf = uct_cuda_copy_md_get_dmabuf(address, length,
-                                             UCS_SYS_DEVICE_ID_UNKNOWN);
+                                             UCT_MD_DMABUF_MAPPING_HOST);
     }
 
     if (dmabuf.fd == UCT_DMABUF_FD_INVALID) {


### PR DESCRIPTION
## What?
Register CUDA dmabuf memory with the mapping that matches the importing NIC's registration verb: 
- a PCIe-mapped handle for Direct-NIC importers (mlx5dv + DATA_DIRECT)
- a host-mapped handle for generic-verb importers (ibv_reg_dmabuf_mr). 
The importing MD advertises if it needs a PCIe-mapped handle via the new UCT_MD_FLAG_DMABUF_REG_PCIE capability, and UCP requests the matching mapping from the exporter MD per importer.

## Why?
Registering device memory over the IB backend failed with `ibv_reg_dmabuf_mr(...) failed: Unknown error 524` (ENOTSUPP) on GB200 setups.
In `uct_cuda_copy_md_get_dmabuf_fd` the mapping was chosen based on GPU-only check (`ucs_topo_device_has_sibling`), so the flag `CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE` was added even though the direct NIC is not necessarily being used.
Specifically on the GB200, the direct NIC was DOWN causing this to fail CI.

## How?
- UCT: add `UCT_MD_FLAG_DMABUF_REG_PCIE`; the mlx5 DEVX MD sets it when it has a Direct-NIC (`direct_nic_sys_dev`).
- Replace the exporter's `has_sibling` guess with an explicit `uct_md_dmabuf_mapping_t` request (default host).
- UCP: build `dmabuf_pcie_md_map` from the capability; query the host fd once  (shared fallback) and a PCIe fd only when a surviving importer needs it, then hand each importer the matching fd.