### PR TITLE
UCT/CUDA_IPC: Return ifaces from same process as unreachable

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2774,12 +2774,11 @@ static ucs_status_t ucp_wireup_select_set_locality_flags(
             continue;
         }
 
-        params.field_mask  =
-                        UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
-                        UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR  |
-                        UCT_IFACE_IS_REACHABLE_FIELD_SCOPE       |
-                        UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR_LENGTH |
-                        UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH;
+        params.field_mask         = UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
+                                    UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR |
+                                    UCT_IFACE_IS_REACHABLE_FIELD_SCOPE |
+                                    UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR_LENGTH |
+                                    UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH;
         params.device_addr        = ae->dev_addr;
         params.iface_addr         = ae->iface_addr;
         params.device_addr_length = ae->dev_addr_len;

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2774,12 +2774,17 @@ static ucs_status_t ucp_wireup_select_set_locality_flags(
             continue;
         }
 
-        params.field_mask  = UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
-                             UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR  |
-                             UCT_IFACE_IS_REACHABLE_FIELD_SCOPE;
-        params.device_addr = ae->dev_addr;
-        params.iface_addr  = ae->iface_addr;
-        params.scope       = UCT_IFACE_REACHABILITY_SCOPE_DEVICE;
+        params.field_mask  =
+                        UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
+                        UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR  |
+                        UCT_IFACE_IS_REACHABLE_FIELD_SCOPE       |
+                        UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR_LENGTH |
+                        UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH;
+        params.device_addr        = ae->dev_addr;
+        params.iface_addr         = ae->iface_addr;
+        params.device_addr_length = ae->dev_addr_len;
+        params.iface_addr_length  = ae->iface_addr_len;
+        params.scope              = UCT_IFACE_REACHABILITY_SCOPE_DEVICE;
 
         if (uct_iface_is_reachable_v2(wiface->iface, &params)) {
             key->flags |= UCP_EP_CONFIG_KEY_FLAG_INTRA_NODE;

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1425,10 +1425,12 @@ int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
     uct_iface_is_reachable_params_t params = {
         .field_mask         = UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
                               UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR |
-                              UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR_LENGTH,
+                              UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR_LENGTH |
+                              UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH,
         .device_addr        = ae->dev_addr,
         .iface_addr         = ae->iface_addr,
-        .device_addr_length = ae->dev_addr_len
+        .device_addr_length = ae->dev_addr_len,
+        .iface_addr_length  = ae->iface_addr_len
     };
 
     if (info_str != NULL) {

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -129,7 +129,8 @@ uct_cuda_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
     uct_cuda_ipc_md_t *md       = ucs_derived_of(iface->super.super.md,
                                                  uct_cuda_ipc_md_t);
     const uct_cuda_ipc_device_addr_t *dev_addr;
-    size_t dev_addr_len;
+    uct_cuda_ipc_iface_address_t ipc_addr;
+    size_t dev_addr_len, iface_addr_len;
     int same_uuid;
 
     if (!uct_iface_is_reachable_params_addrs_valid(params)) {
@@ -141,6 +142,17 @@ uct_cuda_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
                                    sizeof(dev_addr->system_uuid));
     dev_addr     = (const uct_cuda_ipc_device_addr_t *)params->device_addr;
     same_uuid    = (ucs_get_system_id() == dev_addr->system_uuid);
+
+    iface_addr_len = UCS_PARAM_VALUE(UCT_IFACE_IS_REACHABLE_FIELD, params,
+                                     iface_addr_length, IFACE_ADDR_LENGTH,
+                                     sizeof(pid_t));
+    ipc_addr = uct_cuda_ipc_iface_address_unpack(params->iface_addr,
+                                                 iface_addr_len);
+    if (same_uuid && uct_cuda_ipc_is_rkey_local(ipc_addr.pid,
+                                                ipc_addr.pid_ns)) {
+        uct_iface_fill_info_str_buf(params, "same process");
+        return 0;
+    }
 
     if (same_uuid ||
         uct_cuda_ipc_iface_mnnvl_supported(md, dev_addr, dev_addr_len)) {

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -146,10 +146,10 @@ uct_cuda_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
     iface_addr_len = UCS_PARAM_VALUE(UCT_IFACE_IS_REACHABLE_FIELD, params,
                                      iface_addr_length, IFACE_ADDR_LENGTH,
                                      sizeof(pid_t));
-    ipc_addr = uct_cuda_ipc_iface_address_unpack(params->iface_addr,
-                                                 iface_addr_len);
-    if (same_uuid && uct_cuda_ipc_is_rkey_local(ipc_addr.pid,
-                                                ipc_addr.pid_ns)) {
+    ipc_addr       = uct_cuda_ipc_iface_address_unpack(params->iface_addr,
+                                                       iface_addr_len);
+    if (same_uuid &&
+        uct_cuda_ipc_is_rkey_local(ipc_addr.pid, ipc_addr.pid_ns)) {
         uct_iface_fill_info_str_buf(params, "same process");
         return 0;
     }

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -260,8 +260,8 @@ private:
         return UCS_OK;
     }
 
-    static ucs_status_t cuda_ipc_get_address_mock(uct_iface_h iface,
-                                                  uct_iface_addr_t *iface_addr)
+    static ucs_status_t
+    cuda_ipc_get_address_mock(uct_iface_h iface, uct_iface_addr_t *iface_addr)
     {
         UCS_MOCK_ORIG_FUNC(m_self->m_mock, &iface->ops.iface_get_address, iface,
                            iface_addr);

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -94,6 +94,29 @@ public:
         FAIL() << "Transport " << tl_name << " not found";
     }
 
+    void mock_cuda_ipc_remote_pid(ucp_worker_h worker)
+    {
+        ucp_context_h context = worker->context;
+
+        for (ucp_rsc_index_t rsc_index = 0; rsc_index < context->num_tls;
+             ++rsc_index) {
+            const uct_tl_resource_desc_t *tl_rsc =
+                    &context->tl_rscs[rsc_index].tl_rsc;
+
+            if (std::string(tl_rsc->tl_name) != "cuda_ipc") {
+                continue;
+            }
+
+            if (!UCS_STATIC_BITMAP_GET(context->tl_bitmap, rsc_index)) {
+                continue;
+            }
+
+            ucp_worker_iface_t *wiface = ucp_worker_iface(worker, rsc_index);
+            m_mock.setup(&wiface->iface->ops.iface_get_address,
+                         cuda_ipc_get_address_mock);
+        }
+    }
+
 #if HAVE_IB
     void ib_event(enum ibv_event_type event_type, uint8_t port_num)
     {
@@ -237,6 +260,16 @@ private:
         return UCS_OK;
     }
 
+    static ucs_status_t cuda_ipc_get_address_mock(uct_iface_h iface,
+                                                  uct_iface_addr_t *iface_addr)
+    {
+        UCS_MOCK_ORIG_FUNC(m_self->m_mock, &iface->ops.iface_get_address, iface,
+                           iface_addr);
+
+        *(pid_t*)iface_addr = getpid() + 1;
+        return UCS_OK;
+    }
+
     static void default_perf_mock(uct_perf_attr_t& perf_attr)
     {
         if (ucs_test_all_flags(perf_attr.field_mask,
@@ -340,6 +373,7 @@ public:
         modify_config("TOPO_PRIO", topo_prio());
 
         ucp_test::init();
+        post_ucp_init();
         connect();
     }
 
@@ -395,6 +429,10 @@ protected:
     virtual const char *topo_prio() const
     {
         return "default";
+    }
+
+    virtual void post_ucp_init()
+    {
     }
 
     static bool
@@ -1272,6 +1310,12 @@ public:
             iface_attr.latency.m         = 1e-9;
         });
         test_ucp_proto_mock::init();
+    }
+
+    virtual void post_ucp_init() override
+    {
+        mock_cuda_ipc_remote_pid(sender().worker());
+        mock_cuda_ipc_remote_pid(receiver().worker());
     }
 
     void test_cuda_rma(ucp_operation_id_t op_id,

--- a/test/gtest/uct/test_uct_iface.cc
+++ b/test/gtest/uct/test_uct_iface.cc
@@ -58,7 +58,12 @@ void test_uct_iface::test_is_reachable()
     ASSERT_UCS_OK(status);
 
     bool is_reachable = uct_iface_is_reachable_v2(iface, &params);
-    EXPECT_TRUE(is_reachable);
+    if (has_cuda_ipc()) {
+        EXPECT_FALSE(is_reachable);
+        EXPECT_EQ(std::string("same process"), std::string(info_str));
+    } else {
+        EXPECT_TRUE(is_reachable);
+    }
 
     // Allocate corrupted address buffers, make it larger than the correct
     // buffer size in case the corrupted data indicates a larger address length


### PR DESCRIPTION
## What?
Make cuda_ipc iface unreachable for peers in the same process, scoped by the system identifier.

## Why?
With one process and two UCX workers, communication is classified as intra-node rather than self. On a node with all HCAs down, cuda0-to-cuda1 GET previously fell back to TCP software emulation because cuda_ipc GET was not usable (cuIpcOpenMemHandle() failing at unpack).

#11482 introduced get/rndv with CUDA bounce buffers, which can use an RTR+PUT flow for this case. That made cuda_ipc selectable, even though CUDA IPC does not support opening memory handles exported by the same process. This was confirmed with pure CUDA reproducers for gpu0/gpu0 and gpu1/gpu0. (ucp_proto_rndv_send_start unpacks with default sys_dev 0, skip cuIpcOpenMemHandle, CUDA post zcopy that gets remote address with proper cu_device triggering cuIpcOpenMemHandle). 

## How?
Reject cuda_ipc reachability when the remote iface address belongs to the same system, PID, and PID namespace. Pass iface/device address lengths through UCP reachability calls so cuda_ipc can safely unpack the extended address, and update the UCT reachability test for the new same-process behavior.

```console
./test/unit/plugins/ucx/ucx_backend_test
....
cuda_ipc_cache.c:284  UCX  ERROR cuIpcOpenMemHandle() failed: invalid device context