### PR TITLE
UCP/RMA: Add software emulation protocol for SGL put

### DIFF
--- a/src/ucp/dt/datatype_iter.c
+++ b/src/ucp/dt/datatype_iter.c
@@ -384,17 +384,13 @@ void ucp_datatype_iter_sgl_mem_dereg(ucp_datatype_iter_t *dt_iter)
     size_t count = dt_iter->length;
     size_t i;
 
-    ucs_assert(dt_iter->type.sgl.memhs != NULL);
+    ucs_assert(ucp_datatype_iter_sgl_owns_memhs(dt_iter));
     for (i = 0; i < count; ++i) {
         ucp_datatype_iter_mem_dereg_single(&dt_iter->type.sgl.memhs[i]);
     }
-}
 
-static UCS_F_ALWAYS_INLINE int
-ucp_datatype_iter_sgl_owns_memhs(const ucp_datatype_iter_t *dt_iter)
-{
-    return (dt_iter->type.sgl.memhs != NULL) &&
-           !ucp_memh_is_user_memh(dt_iter->type.sgl.memhs[0]);
+    ucs_free(dt_iter->type.sgl.memhs);
+    dt_iter->type.sgl.memhs = NULL;
 }
 
 void ucp_datatype_iter_sgl_cleanup(ucp_datatype_iter_t *dt_iter, int dereg)
@@ -407,13 +403,17 @@ void ucp_datatype_iter_sgl_cleanup(ucp_datatype_iter_t *dt_iter, int dereg)
 
     if (dereg) {
         ucp_datatype_iter_sgl_mem_dereg(dt_iter);
-    } else if (UCS_ENABLE_ASSERT) {
+        return;
+    }
+
+    if (UCS_ENABLE_ASSERT) {
         for (i = 0; i < dt_iter->length; ++i) {
             ucp_datatatype_iter_memh_cleanup_check(dt_iter->type.sgl.memhs[i]);
         }
     }
 
     ucs_free(dt_iter->type.sgl.memhs);
+    dt_iter->type.sgl.memhs = NULL;
 }
 
 void ucp_datatype_iter_str(const ucp_datatype_iter_t *dt_iter,

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -710,6 +710,13 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_datatype_iter_mem_reg(
     }
 }
 
+static UCS_F_ALWAYS_INLINE int
+ucp_datatype_iter_sgl_owns_memhs(const ucp_datatype_iter_t *dt_iter)
+{
+    return (dt_iter->type.sgl.memhs != NULL) &&
+           !ucp_memh_is_user_memh(dt_iter->type.sgl.memhs[0]);
+}
+
 /*
  * De-register memory and update iterator state
  */
@@ -723,7 +730,7 @@ ucp_datatype_iter_mem_dereg(ucp_datatype_iter_t *dt_iter, unsigned dt_mask)
             ucp_datatype_iter_iov_mem_dereg(dt_iter);
         }
     } else if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_SGL, dt_mask)) {
-        if (dt_iter->type.sgl.memhs != NULL) {
+        if (ucp_datatype_iter_sgl_owns_memhs(dt_iter)) {
             ucp_datatype_iter_sgl_mem_dereg(dt_iter);
         }
     }

--- a/src/ucp/proto/proto.c
+++ b/src/ucp/proto/proto.c
@@ -32,6 +32,7 @@
     _macro(ucp_put_offload_zcopy_proto) \
     _macro(ucp_put_rndv_proto) \
     _macro(ucp_put_sgl_offload_proto) \
+    _macro(ucp_put_sgl_offload_sw_proto) \
     _macro(ucp_eager_bcopy_multi_proto) \
     _macro(ucp_eager_sync_bcopy_multi_proto) \
     _macro(ucp_eager_zcopy_multi_proto) \

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -462,10 +462,6 @@ ucp_proto_t ucp_put_sgl_offload_proto = {
 static void
 ucp_proto_put_sgl_offload_sw_probe(const ucp_proto_init_params_t *init_params)
 {
-    if (!init_params->worker->context->config.ext.proto_emulation_enable) {
-        return;
-    }
-
     ucp_proto_put_offload_zcopy_probe_param(init_params, 20, 0, 0);
 }
 

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -288,42 +288,47 @@ ucp_proto_put_offload_zcopy_progress(uct_pending_req_t *self)
 }
 
 static void
-ucp_proto_put_offload_zcopy_probe(const ucp_proto_init_params_t *init_params)
+ucp_proto_put_offload_zcopy_probe_param(
+        const ucp_proto_init_params_t *init_params, unsigned cfg_priority,
+        uint64_t extra_flags, uint64_t tl_v2_cap_flags)
 {
     ucp_context_t *context               = init_params->worker->context;
     ucp_proto_multi_init_params_t params = {
-        .super.super         = *init_params,
-        .super.latency       = 0,
-        .super.overhead      = context->config.ext.proto_overhead_multi,
-        .super.cfg_thresh    = context->config.ext.zcopy_thresh,
-        .super.cfg_priority  = 30,
-        .super.min_length    = 0,
-        .super.max_length    = SIZE_MAX,
-        .super.min_iov       = 1,
-        .super.min_frag_offs = ucs_offsetof(uct_iface_attr_t,
-                                           cap.put.min_zcopy),
-        .super.max_frag_offs = ucs_offsetof(uct_iface_attr_t,
-                                            cap.put.max_zcopy),
-        .super.max_iov_offs  = ucs_offsetof(uct_iface_attr_t, cap.put.max_iov),
-        .super.hdr_size      = 0,
-        .super.send_op       = UCT_EP_OP_PUT_ZCOPY,
-        .super.memtype_op    = UCT_EP_OP_LAST,
-        .super.flags         = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY    |
-                               UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY    |
-                               UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
-                               UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING  |
-                               UCP_PROTO_COMMON_INIT_FLAG_FAILOVER,
-        .super.exclude_map   = 0,
-        .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
+        .super.super            = *init_params,
+        .super.latency          = 0,
+        .super.overhead         = context->config.ext.proto_overhead_multi,
+        .super.cfg_thresh       = context->config.ext.zcopy_thresh,
+        .super.cfg_priority     = cfg_priority,
+        .super.min_length       = 0,
+        .super.max_length       = SIZE_MAX,
+        .super.min_iov          = 1,
+        .super.min_frag_offs    = ucs_offsetof(uct_iface_attr_t,
+                                               cap.put.min_zcopy),
+        .super.max_frag_offs    = ucs_offsetof(uct_iface_attr_t,
+                                               cap.put.max_zcopy),
+        .super.max_iov_offs     = ucs_offsetof(uct_iface_attr_t,
+                                               cap.put.max_iov),
+        .super.hdr_size         = 0,
+        .super.send_op          = UCT_EP_OP_PUT_ZCOPY,
+        .super.memtype_op       = UCT_EP_OP_LAST,
+        .super.flags            = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY    |
+                                  UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY    |
+                                  UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
+                                  UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING  |
+                                  extra_flags,
+        .super.exclude_map      = 0,
+        .super.reg_mem_info     = ucp_proto_common_select_param_mem_info(
                                                      init_params->select_param),
-        .max_lanes           = context->config.ext.max_rma_lanes,
-        .min_chunk           = context->config.ext.min_rma_chunk_size,
-        .initial_reg_md_map  = 0,
-        .first.tl_cap_flags  = UCT_IFACE_FLAG_PUT_ZCOPY,
-        .first.lane_type     = UCP_LANE_TYPE_RMA_BW,
-        .middle.tl_cap_flags = UCT_IFACE_FLAG_PUT_ZCOPY,
-        .middle.lane_type    = UCP_LANE_TYPE_RMA_BW,
-        .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID,
+        .max_lanes              = context->config.ext.max_rma_lanes,
+        .min_chunk              = context->config.ext.min_rma_chunk_size,
+        .initial_reg_md_map     = 0,
+        .first.tl_cap_flags     = UCT_IFACE_FLAG_PUT_ZCOPY,
+        .first.tl_v2_cap_flags  = tl_v2_cap_flags,
+        .first.lane_type        = UCP_LANE_TYPE_RMA_BW,
+        .middle.tl_cap_flags    = UCT_IFACE_FLAG_PUT_ZCOPY,
+        .middle.tl_v2_cap_flags = tl_v2_cap_flags,
+        .middle.lane_type       = UCP_LANE_TYPE_RMA_BW,
+        .opt_align_offs         = UCP_PROTO_COMMON_OFFSET_INVALID,
     };
 
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_PUT))) {
@@ -331,6 +336,13 @@ ucp_proto_put_offload_zcopy_probe(const ucp_proto_init_params_t *init_params)
     }
 
     ucp_proto_multi_probe(&params);
+}
+
+static void
+ucp_proto_put_offload_zcopy_probe(const ucp_proto_init_params_t *init_params)
+{
+    ucp_proto_put_offload_zcopy_probe_param(
+            init_params, 30, UCP_PROTO_COMMON_INIT_FLAG_FAILOVER, 0);
 }
 
 ucp_proto_t ucp_put_offload_zcopy_proto = {
@@ -348,49 +360,8 @@ ucp_proto_t ucp_put_offload_zcopy_proto = {
 static void
 ucp_proto_put_sgl_offload_probe(const ucp_proto_init_params_t *init_params)
 {
-    ucp_context_t *context               = init_params->worker->context;
-    ucp_proto_multi_init_params_t params = {
-        .super.super             = *init_params,
-        .super.latency           = 0,
-        .super.overhead          = context->config.ext.proto_overhead_multi,
-        .super.cfg_thresh        = context->config.ext.zcopy_thresh,
-        .super.cfg_priority      = 30,
-        .super.min_length        = 0,
-        .super.max_length        = SIZE_MAX,
-        .super.min_iov           = 1,
-        .super.min_frag_offs     = ucs_offsetof(uct_iface_attr_t,
-                                               cap.put.min_zcopy),
-        .super.max_frag_offs     = ucs_offsetof(uct_iface_attr_t,
-                                                cap.put.max_zcopy),
-        .super.max_iov_offs      = ucs_offsetof(uct_iface_attr_t,
-                                                cap.put.max_iov),
-        .super.hdr_size          = 0,
-        .super.send_op           = UCT_EP_OP_PUT_ZCOPY,
-        .super.memtype_op        = UCT_EP_OP_LAST,
-        .super.flags             = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY    |
-                                   UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY    |
-                                   UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
-                                   UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
-        .super.exclude_map       = 0,
-        .super.reg_mem_info      = ucp_proto_common_select_param_mem_info(
-                                                     init_params->select_param),
-        .max_lanes               = context->config.ext.max_rma_lanes,
-        .min_chunk               = context->config.ext.min_rma_chunk_size,
-        .initial_reg_md_map      = 0,
-        .first.tl_cap_flags      = UCT_IFACE_FLAG_PUT_ZCOPY,
-        .first.tl_v2_cap_flags   = UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY,
-        .first.lane_type         = UCP_LANE_TYPE_RMA_BW,
-        .middle.tl_cap_flags     = UCT_IFACE_FLAG_PUT_ZCOPY,
-        .middle.tl_v2_cap_flags  = UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY,
-        .middle.lane_type        = UCP_LANE_TYPE_RMA_BW,
-        .opt_align_offs          = UCP_PROTO_COMMON_OFFSET_INVALID,
-    };
-
-    if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_PUT))) {
-        return;
-    }
-
-    ucp_proto_multi_probe(&params);
+    ucp_proto_put_offload_zcopy_probe_param(
+            init_params, 30, 0, UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
@@ -491,51 +462,11 @@ ucp_proto_t ucp_put_sgl_offload_proto = {
 static void
 ucp_proto_put_sgl_offload_sw_probe(const ucp_proto_init_params_t *init_params)
 {
-    ucp_context_t *context               = init_params->worker->context;
-    ucp_proto_multi_init_params_t params = {
-        .super.super             = *init_params,
-        .super.latency           = 0,
-        .super.overhead          = context->config.ext.proto_overhead_multi,
-        .super.cfg_thresh        = context->config.ext.zcopy_thresh,
-        .super.cfg_priority      = 20,
-        .super.min_length        = 0,
-        .super.max_length        = SIZE_MAX,
-        .super.min_iov           = 1,
-        .super.min_frag_offs     = ucs_offsetof(uct_iface_attr_t,
-                                                cap.put.min_zcopy),
-        .super.max_frag_offs     = ucs_offsetof(uct_iface_attr_t,
-                                                cap.put.max_zcopy),
-        .super.max_iov_offs      = ucs_offsetof(uct_iface_attr_t,
-                                                cap.put.max_iov),
-        .super.hdr_size          = 0,
-        .super.send_op           = UCT_EP_OP_PUT_ZCOPY,
-        .super.memtype_op        = UCT_EP_OP_LAST,
-        .super.flags             = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY    |
-                                   UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY    |
-                                   UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
-                                   UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
-        .super.exclude_map       = 0,
-        .super.reg_mem_info      = ucp_proto_common_select_param_mem_info(
-                                                     init_params->select_param),
-        .max_lanes               = context->config.ext.max_rma_lanes,
-        .min_chunk               = context->config.ext.min_rma_chunk_size,
-        .initial_reg_md_map      = 0,
-        .first.tl_cap_flags      = UCT_IFACE_FLAG_PUT_ZCOPY,
-        .first.lane_type         = UCP_LANE_TYPE_RMA_BW,
-        .middle.tl_cap_flags     = UCT_IFACE_FLAG_PUT_ZCOPY,
-        .middle.lane_type        = UCP_LANE_TYPE_RMA_BW,
-        .opt_align_offs          = UCP_PROTO_COMMON_OFFSET_INVALID,
-    };
-
-    if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_PUT))) {
+    if (!init_params->worker->context->config.ext.proto_emulation_enable) {
         return;
     }
 
-    if (!context->config.ext.proto_emulation_enable) {
-        return;
-    }
-
-    ucp_proto_multi_probe(&params);
+    ucp_proto_put_offload_zcopy_probe_param(init_params, 20, 0, 0);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -487,3 +487,120 @@ ucp_proto_t ucp_put_sgl_offload_proto = {
     .abort    = ucp_proto_request_zcopy_abort,
     .reset    = ucp_proto_offload_zcopy_reset
 };
+
+static void
+ucp_proto_put_sgl_offload_sw_probe(const ucp_proto_init_params_t *init_params)
+{
+    ucp_context_t *context               = init_params->worker->context;
+    ucp_proto_multi_init_params_t params = {
+        .super.super             = *init_params,
+        .super.latency           = 0,
+        .super.overhead          = context->config.ext.proto_overhead_multi,
+        .super.cfg_thresh        = context->config.ext.zcopy_thresh,
+        .super.cfg_priority      = 20,
+        .super.min_length        = 0,
+        .super.max_length        = SIZE_MAX,
+        .super.min_iov           = 1,
+        .super.min_frag_offs     = ucs_offsetof(uct_iface_attr_t,
+                                                cap.put.min_zcopy),
+        .super.max_frag_offs     = ucs_offsetof(uct_iface_attr_t,
+                                                cap.put.max_zcopy),
+        .super.max_iov_offs      = ucs_offsetof(uct_iface_attr_t,
+                                                cap.put.max_iov),
+        .super.hdr_size          = 0,
+        .super.send_op           = UCT_EP_OP_PUT_ZCOPY,
+        .super.memtype_op        = UCT_EP_OP_LAST,
+        .super.flags             = UCP_PROTO_COMMON_INIT_FLAG_SEND_ZCOPY    |
+                                   UCP_PROTO_COMMON_INIT_FLAG_RECV_ZCOPY    |
+                                   UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS |
+                                   UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING,
+        .super.exclude_map       = 0,
+        .super.reg_mem_info      = ucp_proto_common_select_param_mem_info(
+                                                     init_params->select_param),
+        .max_lanes               = context->config.ext.max_rma_lanes,
+        .min_chunk               = context->config.ext.min_rma_chunk_size,
+        .initial_reg_md_map      = 0,
+        .first.tl_cap_flags      = UCT_IFACE_FLAG_PUT_ZCOPY,
+        .first.lane_type         = UCP_LANE_TYPE_RMA_BW,
+        .middle.tl_cap_flags     = UCT_IFACE_FLAG_PUT_ZCOPY,
+        .middle.lane_type        = UCP_LANE_TYPE_RMA_BW,
+        .opt_align_offs          = UCP_PROTO_COMMON_OFFSET_INVALID,
+    };
+
+    if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_PUT))) {
+        return;
+    }
+
+    if (!context->config.ext.proto_emulation_enable) {
+        return;
+    }
+
+    ucp_proto_multi_probe(&params);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_put_sgl_offload_sw_send_func(ucp_request_t *req,
+                                       const ucp_proto_multi_lane_priv_t *lpriv,
+                                       ucp_datatype_iter_t *next_iter,
+                                       ucp_lane_index_t *lane_shift)
+{
+    ucp_ep_t *ep                 = req->send.ep;
+    ucp_datatype_iter_t *dt_iter = &req->send.state.dt_iter;
+    ucp_lane_index_t lane        = lpriv->super.lane;
+    uct_ep_h uct_ep              = ucp_ep_get_lane(ep, lane);
+    ucp_md_index_t md_index      = ucp_ep_md_index(ep, lane);
+    ucp_rsc_index_t rkey_index   = lpriv->super.rkey_index;
+    size_t index                 = dt_iter->offset;
+    ucp_mem_h *sgl_memhs         = dt_iter->type.sgl.memhs;
+    uint64_t remote_addr         = dt_iter->type.sgl.remote_addrs[index];
+    uct_rkey_t tl_rkey;
+    uct_iov_t iov;
+    ucs_status_t status;
+
+    /* TODO: fragment elements larger than cap.put.max_zcopy */
+    ucp_datatype_iter_next_sgl(dt_iter, 1, next_iter);
+
+    tl_rkey     = ucp_rkey_get_tl_rkey(dt_iter->type.sgl.rkeys[index],
+                                       rkey_index);
+    iov.buffer  = dt_iter->type.sgl.buffers[index];
+    iov.length  = dt_iter->type.sgl.lengths[index];
+    iov.memh    = (sgl_memhs != NULL) ? sgl_memhs[index]->uct[md_index] :
+                                        UCT_MEM_HANDLE_NULL;
+    iov.stride  = 0;
+    iov.count   = 1;
+
+    status = uct_ep_put_zcopy(uct_ep, &iov, 1, remote_addr, tl_rkey,
+                              &req->send.state.uct_comp);
+    if (!UCS_STATUS_IS_ERR(status)) {
+        ucp_proto_put_offload_update_remote_flush(ep, lpriv->flush_sys_dev_mask,
+                                                  tl_rkey, uct_ep, remote_addr);
+    }
+
+    return status;
+}
+
+static ucs_status_t
+ucp_proto_put_sgl_offload_sw_progress(uct_pending_req_t *self)
+{
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
+
+    /* coverity[tainted_data_downcast] */
+    return ucp_proto_multi_zcopy_progress(
+            req, req->send.proto_config->priv, ucp_proto_multi_rma_init_func,
+            UCT_MD_MEM_ACCESS_LOCAL_READ, UCS_BIT(UCP_DATATYPE_SGL),
+            ucp_proto_put_sgl_offload_sw_send_func,
+            ucp_request_invoke_uct_completion_success,
+            ucp_proto_request_zcopy_completion);
+}
+
+ucp_proto_t ucp_put_sgl_offload_sw_proto = {
+    .name     = "put/sgl/offload_sw",
+    .desc     = "sgl " UCP_PROTO_RMA_EMULATION_DESC,
+    .flags    = 0,
+    .dt_mask  = UCS_BIT(UCP_DATATYPE_SGL),
+    .probe    = ucp_proto_put_sgl_offload_sw_probe,
+    .query    = ucp_proto_multi_query,
+    .progress = {ucp_proto_put_sgl_offload_sw_progress},
+    .abort    = ucp_proto_request_zcopy_abort,
+    .reset    = ucp_proto_offload_zcopy_reset
+};

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -1107,9 +1107,8 @@ protected:
                       bool expect_immediate_completion = false) {
         ASSERT_FALSE(expect_immediate_completion && use_callback);
 
-        if (!sender().has_lane_with_caps(0,
-                    UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY)) {
-            UCS_TEST_SKIP_R("put_sgl_zcopy is not supported");
+        if (!sender().has_lane_with_caps(UCT_IFACE_FLAG_PUT_ZCOPY)) {
+            UCS_TEST_SKIP_R("put_zcopy is not supported");
         }
 
         sgl_ctx ctx;


### PR DESCRIPTION
## What?
Add a software-emulation PUT protocol for the SGL datatype (`put/sgl/offload_sw`), gated by `UCX_PROTO_EMULATION_ENABLE`.

## Why?
The hardware SGL offload (`put/sgl/offload`) requires `UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY`, which is not always available. A fallback is needed so SGL puts still work when that capability is absent.

## How?
Lower-priority proto that sends one SGL element per `uct_ep_put_zcopy` via the multi framework, so it's selected only when the HW offload cap is absent.