### PR TITLE
UCP/PROTO: Widen protocol bitmap to support more than 64 protocols

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -2435,8 +2435,9 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
     ucs_debug("estimated bcopy bandwidth is %f", context->config.ext.bcopy_bw);
 
     if (config->protos.mode == UCS_CONFIG_ALLOW_LIST_ALLOW_ALL) {
-        context->proto_bitmap = UCS_MASK(ucp_protocols_count());
+        UCS_STATIC_BITMAP_MASK(&context->proto_bitmap, ucp_protocols_count());
     } else {
+        UCS_STATIC_BITMAP_RESET_ALL(&context->proto_bitmap);
         for (proto_id = 0; proto_id < ucp_protocols_count(); ++proto_id) {
             match = ucs_config_names_search(&config->protos.array,
                                             ucp_proto_id_field(proto_id, name));
@@ -2444,7 +2445,7 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
                  (match >= 0)) ||
                 ((config->protos.mode == UCS_CONFIG_ALLOW_LIST_NEGATE) &&
                  (match == -1))) {
-                context->proto_bitmap |= UCS_BIT(proto_id);
+                UCS_STATIC_BITMAP_SET(&context->proto_bitmap, proto_id);
             }
         }
     }

--- a/src/ucp/proto/proto.h
+++ b/src/ucp/proto/proto.h
@@ -11,6 +11,7 @@
 
 #include <ucp/core/ucp_types.h>
 #include <ucs/datastruct/linear_func.h>
+#include <ucs/datastruct/static_bitmap.h>
 #include <ucs/datastruct/string_buffer.h>
 
 
@@ -23,7 +24,7 @@
 
 
 /* Maximal number of protocols in total */
-#define UCP_PROTO_MAX_COUNT         65
+#define UCP_PROTO_MAX_COUNT         128
 
 
 /* Special value for non-existent protocol */
@@ -47,7 +48,7 @@ typedef unsigned ucp_proto_id_t;
 
 
 /* Bitmap of protocols */
-typedef uint64_t ucp_proto_id_mask_t;
+typedef ucs_static_bitmap_s(UCP_PROTO_MAX_COUNT) ucp_proto_id_mask_t;
 
 
 /* Performance calculation tree node */

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -221,7 +221,8 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
     ucs_array_init_dynamic(&proto_init->protocols);
     ucs_array_init_dynamic(&proto_init->priv_buf);
 
-    ucs_for_each_bit(init_params.proto_id, worker->context->proto_bitmap) {
+    UCS_STATIC_BITMAP_FOR_EACH_BIT(init_params.proto_id,
+                                   &worker->context->proto_bitmap) {
         const ucp_proto_t *proto;
 
         ucs_assert(init_params.proto_id < ucp_protocols_count()); /* Coverity */


### PR DESCRIPTION
## What?
Widen the protocol bitmap (`ucp_proto_id_mask_t`) from a single `uint64_t` to a `ucs_static_bitmap`, lifting the 64-protocol limit.

## Why?
The bitmap is a `uint64_t`, capping the framework at 64 protocols, and we're now at exactly 64. Any new protocol overflows it (`UCS_BIT(64)` shift UB, flagged by Coverity). Needed to unblock [#11577](https://github.com/openucx/ucx/pull/11577), which adds a 65th protocol.

## How?
Switch `ucp_proto_id_mask_t` to `ucs_static_bitmap_s(UCP_PROTO_MAX_COUNT)` (same pattern as `ucp_tl_bitmap_t`) and use the `UCS_STATIC_BITMAP_*` ops at the 3 call sites. `UCP_PROTO_MAX_COUNT` raised to 128.