### PR TITLE
UCS/NUMA: Handle sparse NUMA node IDs in distance parsing

### DIFF
--- a/src/ucs/memory/numa.c
+++ b/src/ucs/memory/numa.c
@@ -97,9 +97,10 @@ static int ucs_numa_get_max_dirent(const char *path, const char *prefix,
 }
 
 static FILE *
-ucs_numa_open_distance_file(ucs_numa_node_t node, ucs_log_level_t log_level)
+ucs_numa_open_distance_file(ucs_numa_node_t node)
 {
-    return ucs_open_file("r", log_level, UCS_NUMA_NODE_DISTANCE_PATH, node);
+    return ucs_open_file("r", UCS_LOG_LEVEL_DEBUG,
+                         UCS_NUMA_NODE_DISTANCE_PATH, node);
 }
 
 static void ucs_numa_init_distance_nodes()
@@ -118,7 +119,7 @@ static void ucs_numa_init_distance_nodes()
      * ids and columns.
      */
     for (node = 0; node < num_nodes; ++node) {
-        distance_fp = ucs_numa_open_distance_file(node, UCS_LOG_LEVEL_TRACE);
+        distance_fp = ucs_numa_open_distance_file(node);
         if (distance_fp == NULL) {
             continue;
         }
@@ -235,7 +236,7 @@ ucs_numa_node_parse_distances(ucs_numa_node_t source, ucs_numa_node_t dest)
     FILE *distance_fp;
 
     ucs_numa_init_distance_nodes();
-    distance_fp = ucs_numa_open_distance_file(source, UCS_LOG_LEVEL_DEBUG);
+    distance_fp = ucs_numa_open_distance_file(source);
     if (distance_fp == NULL) {
         return distance_to_dest;
     }

--- a/src/ucs/memory/numa.c
+++ b/src/ucs/memory/numa.c
@@ -17,6 +17,7 @@
 #include <ucs/sys/sys.h>
 #include <ucs/type/spinlock.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <sched.h>
 #include <dirent.h>
 
@@ -38,6 +39,9 @@ typedef struct {
 typedef struct {
     ucs_spinlock_t         lock;
     khash_t(numa_distance) numa_distance_hash;
+    /* Column index in node<N>/distance to actual NUMA node id */
+    ucs_numa_node_t        distance_nodes[UCS_NUMA_NODE_MAX];
+    unsigned               num_distance_nodes;
 } ucs_numa_global_ctx_t;
 
 static ucs_numa_global_ctx_t ucs_numa_global_ctx;
@@ -90,6 +94,44 @@ static int ucs_numa_get_max_dirent(const char *path, const char *prefix,
     }
 
     return ctx.max_index;
+}
+
+static FILE *
+ucs_numa_open_distance_file(ucs_numa_node_t node, ucs_log_level_t log_level)
+{
+    return ucs_open_file("r", log_level, UCS_NUMA_NODE_DISTANCE_PATH, node);
+}
+
+static void ucs_numa_init_distance_nodes()
+{
+    unsigned num_nodes = ucs_numa_num_configured_nodes();
+    FILE *distance_fp;
+    unsigned node;
+
+    if (ucs_numa_global_ctx.num_distance_nodes != 0) {
+        return;
+    }
+
+    /*
+     * Only online NUMA nodes are listed in order in node<N>/distance, so
+     * use readable distance files to build the translation table between node
+     * ids and columns.
+     */
+    for (node = 0; node < num_nodes; ++node) {
+        distance_fp = ucs_numa_open_distance_file(node, UCS_LOG_LEVEL_TRACE);
+        if (distance_fp == NULL) {
+            continue;
+        }
+
+        fclose(distance_fp);
+        ucs_numa_global_ctx.distance_nodes[
+                ucs_numa_global_ctx.num_distance_nodes++] = node;
+    }
+
+    if (ucs_numa_global_ctx.num_distance_nodes == 0) {
+        ucs_numa_global_ctx.distance_nodes[0]  = UCS_NUMA_NODE_DEFAULT;
+        ucs_numa_global_ctx.num_distance_nodes = 1;
+    }
 }
 
 unsigned ucs_numa_num_configured_nodes()
@@ -184,20 +226,23 @@ static ucs_numa_distance_t
 ucs_numa_node_parse_distances(ucs_numa_node_t source, ucs_numa_node_t dest)
 {
     ucs_numa_distance_t distance_to_dest = UCS_NUMA_MIN_DISTANCE;
-    ucs_numa_node_t node                 = 0;
+    int dest_found                       = 0;
     ucs_numa_distance_t distance;
+    unsigned column;
+    ucs_numa_node_t node;
     int kh_put_status;
     khiter_t hash_it;
     FILE *distance_fp;
 
-    distance_fp = ucs_open_file("r", UCS_LOG_LEVEL_DEBUG,
-                                UCS_NUMA_NODE_DISTANCE_PATH, source);
+    ucs_numa_init_distance_nodes();
+    distance_fp = ucs_numa_open_distance_file(source, UCS_LOG_LEVEL_DEBUG);
     if (distance_fp == NULL) {
         return distance_to_dest;
     }
 
+    column = 0;
     while ((fscanf(distance_fp, "%u", &distance) > 0) &&
-           (node < UCS_NUMA_NODE_MAX)) {
+           (column < ucs_numa_global_ctx.num_distance_nodes)) {
         if (distance < UCS_NUMA_MIN_DISTANCE) {
             ucs_debug("node %u parsed NUMA distance %u is "
                       "smaller than the lower bound (%u)",
@@ -205,7 +250,9 @@ ucs_numa_node_parse_distances(ucs_numa_node_t source, ucs_numa_node_t dest)
             distance = UCS_NUMA_MIN_DISTANCE;
         }
 
+        node = ucs_numa_global_ctx.distance_nodes[column];
         if (node == dest) {
+            dest_found       = 1;
             distance_to_dest = distance;
         }
 
@@ -218,12 +265,12 @@ ucs_numa_node_parse_distances(ucs_numa_node_t source, ucs_numa_node_t dest)
                      hash_it) = distance;
         }
 
-        node++;
+        column++;
     }
 
-    if (node >= UCS_NUMA_NODE_MAX) {
-        ucs_diag("number of nodes in the system is out of range (%u)",
-                 UCS_NUMA_NODE_MAX);
+    if (!dest_found) {
+        ucs_debug("node %u NUMA distance has no column for node %u",
+                  source, dest);
     }
 
     fclose(distance_fp);
@@ -258,10 +305,12 @@ void ucs_numa_init()
 {
     ucs_spinlock_init(&ucs_numa_global_ctx.lock, 0);
     kh_init_inplace(numa_distance, &ucs_numa_global_ctx.numa_distance_hash);
+    ucs_numa_global_ctx.num_distance_nodes = 0;
 }
 
 void ucs_numa_cleanup()
 {
+    ucs_numa_global_ctx.num_distance_nodes = 0;
     kh_destroy_inplace(numa_distance, &ucs_numa_global_ctx.numa_distance_hash);
     ucs_spinlock_destroy(&ucs_numa_global_ctx.lock);
 }

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -5,6 +5,12 @@
 */
 
 #include <common/test.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <limits>
+#include <unistd.h>
+
 extern "C" {
 #include <ucs/memory/numa.h>
 #include <ucs/sys/sys.h>
@@ -291,12 +297,56 @@ UCS_TEST_F(test_topo, bdf_name_invalid) {
     EXPECT_EQ(UCS_ERR_INVALID_PARAM, status);
 }
 
-UCS_TEST_F(test_topo, numa_distance) {
-    ucs_numa_node_t num_of_nodes;
+static std::vector<ucs_numa_node_t> get_online_numa_nodes()
+{
+    std::vector<ucs_numa_node_t> nodes;
+    DIR *dir = opendir(UCS_SYS_FS_SYSTEM_PATH "/node");
+    struct dirent *entry;
 
-    num_of_nodes = ucs_numa_num_configured_nodes();
-    for (auto node1 = 0; node1 < num_of_nodes; ++node1) {
-        for (auto node2 = 0; node2 < num_of_nodes; ++node2) {
+    if (dir == NULL) {
+        goto out;
+    }
+
+    while ((entry = readdir(dir)) != NULL) {
+        static const char node_prefix[] = "node";
+        char *endptr;
+        std::string distance_path;
+        long node;
+
+        if (strncmp(entry->d_name, node_prefix, sizeof(node_prefix) - 1)) {
+            continue;
+        }
+
+        node = strtol(entry->d_name + sizeof(node_prefix) - 1, &endptr, 10);
+        if ((*endptr != '\0') || (node < 0) ||
+            (node > std::numeric_limits<ucs_numa_node_t>::max())) {
+            continue;
+        }
+
+        distance_path = std::string(UCS_SYS_FS_SYSTEM_PATH "/node/") +
+                        entry->d_name + "/distance";
+        if (access(distance_path.c_str(), R_OK) == 0) {
+            nodes.push_back(static_cast<ucs_numa_node_t>(node));
+        }
+    }
+
+    closedir(dir);
+
+out:
+    if (nodes.empty()) {
+        nodes.push_back(UCS_NUMA_NODE_DEFAULT);
+    } else {
+        std::sort(nodes.begin(), nodes.end());
+    }
+
+    return nodes;
+}
+
+UCS_TEST_F(test_topo, numa_distance) {
+    auto nodes = get_online_numa_nodes();
+
+    for (auto node1 : nodes) {
+        for (auto node2 : nodes) {
             UCS_TEST_MESSAGE << "Test distance: node" << node1 << " to node"
                              << node2;
             if (node1 == node2) {


### PR DESCRIPTION
## What?
Map NUMA distance columns to online node IDs instead of assuming dense IDs. 

## Why?
Some systems have sparse online nodes, while distance columns are listed only for online nodes. This can lead to wrong distance evaluation. The test failing on relevant platform is `test_topo.numa_distance`.

## How?
Build a translation table from readable `node<N>/distance` files and use it when parsing NUMA distances.

```sh
$ cat /sys/devices/system/node/online
0-1,3-9,11-17,19-25,27-33