### PR TITLE
CONFIG/SPEC: Bump version to 1.23.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 AC_PREREQ([2.63])
 
 define([ucx_ver_major], 1)  # Major version. Usually does not change.
-define([ucx_ver_minor], 22) # Minor version. Increased for each release.
+define([ucx_ver_minor], 23) # Minor version. Increased for each release.
 define([ucx_ver_patch], 0)  # Patch version. Increased for a bugfix release.
 define([ucx_ver_extra], )   # Extra version string. Empty for a general release.
 

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -456,6 +456,8 @@ with the host CPU.
 %endif
 
 %changelog
+* Thu Jun 25 2026 Shachar Hasson <shasson@nvidia.com> 1.23.0-1
+- Bump version to 1.23.0
 * Wed Mar 18 2026 Yossi Itigin <yosefe@nvidia.com> 1.22.0-1
 - Bump version to 1.22.0
 * Mon Oct 20 2025 Leonid Genkin <lgenkin@nvidia.com> 1.21.0-1


### PR DESCRIPTION
## What
Bump UCX minor version from 1.22 to 1.23 and add the RPM changelog entry for 1.23.0.

## Why
This follows the same CONFIG/SPEC version bump pattern as #11272 after cutting the v1.22.x branch.

## Validation
- git diff --check