### PR TITLE
UCT/IB: add CoCo control object allocation

### DIFF
--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1300,7 +1300,8 @@ void uct_ib_iface_fill_attr(uct_ib_iface_t *iface, uct_ib_qp_attr_t *attr)
 #if HAVE_DECL_IBV_CREATE_QP_EX
     if (!(attr->ibv.comp_mask & IBV_QP_INIT_ATTR_PD)) {
         attr->ibv.comp_mask       = IBV_QP_INIT_ATTR_PD;
-        attr->ibv.pd              = uct_ib_iface_md(iface)->pd;
+        attr->ibv.pd              =
+                uct_ib_md_control_pd(uct_ib_iface_md(iface));
     }
 #endif
 
@@ -1320,7 +1321,8 @@ ucs_status_t uct_ib_iface_create_qp(uct_ib_iface_t *iface,
     qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp_ex, dev->ibv_context,
                                  &attr->ibv);
 #else
-    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp, uct_ib_iface_md(iface)->pd,
+    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp,
+                                 uct_ib_md_control_pd(uct_ib_iface_md(iface)),
                                  &attr->ibv);
 #endif
     if (qp == NULL) {
@@ -1359,10 +1361,35 @@ ucs_status_t uct_ib_verbs_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
     struct ibv_cq *cq;
 #if HAVE_DECL_IBV_CREATE_CQ_EX
     struct ibv_cq_init_attr_ex cq_attr = {};
+#endif
+#if !HAVE_DECL_IBV_CREATE_CQ_EX || \
+    !HAVE_DECL_IBV_CQ_INIT_ATTR_MASK_PD || \
+    !HAVE_STRUCT_IBV_CQ_INIT_ATTR_EX_PARENT_DOMAIN
+    if (uct_ib_md_is_cc_dma_bounce(uct_ib_iface_md(iface))) {
+        ucs_error("CoCo CQ creation requires ibv_create_cq_ex() "
+                  "parent-domain support");
+        return UCS_ERR_UNSUPPORTED;
+    }
+#endif
 
+#if HAVE_DECL_IBV_CREATE_CQ_EX
     uct_ib_fill_cq_attr(&cq_attr, init_attr, iface, preferred_cpu, cq_size);
 
     cq = ibv_cq_ex_to_cq(ibv_create_cq_ex(ibv_context, &cq_attr));
+    if ((cq == NULL) &&
+        uct_ib_md_is_cc_dma_bounce(uct_ib_iface_md(iface))) {
+        if ((errno == EOPNOTSUPP) || (errno == ENOSYS) ||
+            (errno == EINVAL)) {
+            ucs_error("CoCo CQ creation requires ibv_create_cq_ex() "
+                      "parent-domain support");
+            return UCS_ERR_UNSUPPORTED;
+        }
+
+        uct_ib_check_memlock_limit_msg(ibv_context, UCS_LOG_LEVEL_ERROR,
+                                       "ibv_create_cq_ex(cqe=%d)", cq_size);
+        return UCS_ERR_IO_ERROR;
+    }
+
     if (!cq && ((errno == EOPNOTSUPP) || (errno == ENOSYS)))
 #endif
     {

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -789,6 +789,14 @@ uct_ib_fill_cq_attr(struct ibv_cq_init_attr_ex *cq_attr,
         cq_attr->flags     = IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN;
     }
 #endif /* HAVE_DECL_IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN */
+
+#if HAVE_DECL_IBV_CQ_INIT_ATTR_MASK_PD && \
+    HAVE_STRUCT_IBV_CQ_INIT_ATTR_EX_PARENT_DOMAIN
+    if (uct_ib_md_is_cc_dma_bounce(uct_ib_iface_md(iface))) {
+        cq_attr->comp_mask    |= IBV_CQ_INIT_ATTR_MASK_PD;
+        cq_attr->parent_domain = uct_ib_md_control_pd(uct_ib_iface_md(iface));
+    }
+#endif
 }
 #endif /* HAVE_DECL_IBV_CREATE_CQ_EX */
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1292,6 +1292,43 @@ void uct_ib_md_check_odp(uct_ib_md_t *md, const uct_ib_md_config_t *md_config)
     ucs_debug("%s: ODP is supported", device_name);
 }
 
+static int uct_ib_md_detect_cc_dma_bounce(uct_ib_md_t *md)
+{
+#if HAVE_DECL_IBV_DEVICE_CC_DMA_BOUNCE && HAVE_DECL_IBV_QUERY_DEVICE_EX
+    return !!(md->dev.dev_attr.device_cap_flags_ex &
+              IBV_DEVICE_CC_DMA_BOUNCE);
+#else
+    return 0;
+#endif
+}
+
+static ucs_status_t uct_ib_md_create_coco_pd(uct_ib_md_t *md)
+{
+#if HAVE_DECL_IBV_ALLOC_PARENT_DOMAIN && \
+    HAVE_DECL_IBV_PARENT_DOMAIN_INIT_ATTR_ALLOW_CC_UNPROTECTED_ALLOC
+    struct ibv_parent_domain_init_attr attr = {};
+
+    attr.pd        = md->pd;
+    attr.td        = NULL;
+    attr.comp_mask = IBV_PARENT_DOMAIN_INIT_ATTR_ALLOW_CC_UNPROTECTED_ALLOC;
+
+    md->coco_pd = ibv_alloc_parent_domain(md->dev.ibv_context, &attr);
+    if (md->coco_pd == NULL) {
+        ucs_error("%s: ibv_alloc_parent_domain() with CoCo unprotected allocation failed: %m",
+                  uct_ib_device_name(&md->dev));
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    ucs_debug("%s: enabled CoCo RDMA control-object shared allocation",
+              uct_ib_device_name(&md->dev));
+    return UCS_OK;
+#else
+    ucs_error("%s: device reports IBV_DEVICE_CC_DMA_BOUNCE but rdma-core lacks CoCo parent-domain APIs",
+              uct_ib_device_name(&md->dev));
+    return UCS_ERR_UNSUPPORTED;
+#endif
+}
+
 ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                                    struct ibv_device *ib_device,
                                    const uct_ib_md_config_t *md_config)
@@ -1319,6 +1356,14 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                                 UCS_STATS_ARG(md->stats));
     if (status != UCS_OK) {
         goto err_release_stats;
+    }
+
+    md->cc_dma_bounce = uct_ib_md_detect_cc_dma_bounce(md);
+    if (md->cc_dma_bounce) {
+        status = uct_ib_md_create_coco_pd(md);
+        if (status != UCS_OK) {
+            goto err_cleanup_device;
+        }
     }
 
     if (strlen(md_config->subnet_prefix) > 0) {
@@ -1437,6 +1482,15 @@ err:
 void uct_ib_md_free(uct_ib_md_t *md)
 {
     int ret;
+
+    if (md->coco_pd != NULL) {
+        ret = ibv_dealloc_pd(md->coco_pd);
+        /* Do not print a warning if PD deallocation failed with EINVAL, because
+         * it fails from time to time on BF/ARM (TODO: investigate) */
+        if ((ret != 0) && (errno != EINVAL)) {
+            ucs_warn("ibv_dealloc_pd(coco_pd) failed: %m");
+        }
+    }
 
     ret = ibv_dealloc_pd(md->pd);
     /* Do not print a warning if PD deallocation failed with EINVAL, because

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1309,7 +1309,7 @@ static ucs_status_t uct_ib_md_create_coco_pd(uct_ib_md_t *md)
 
     md->coco_pd = ibv_alloc_parent_domain(md->dev.ibv_context, &attr);
     if (md->coco_pd == NULL) {
-        ucs_error("%s: ibv_alloc_parent_domain() with CoCo unprotected allocation failed: %m",
+        ucs_debug("%s: ibv_alloc_parent_domain() with CoCo unprotected allocation failed: %m",
                   uct_ib_device_name(&md->dev));
         return UCS_ERR_UNSUPPORTED;
     }
@@ -1318,7 +1318,7 @@ static ucs_status_t uct_ib_md_create_coco_pd(uct_ib_md_t *md)
               uct_ib_device_name(&md->dev));
     return UCS_OK;
 #else
-    ucs_error("%s: device reports IBV_DEVICE_CC_DMA_BOUNCE but rdma-core lacks CoCo parent-domain APIs",
+    ucs_debug("%s: device reports IBV_DEVICE_CC_DMA_BOUNCE but rdma-core lacks CoCo parent-domain APIs",
               uct_ib_device_name(&md->dev));
     return UCS_ERR_UNSUPPORTED;
 #endif
@@ -1340,10 +1340,10 @@ static ucs_status_t uct_ib_md_probe_coco_control_cq(uct_ib_md_t *md)
     cq_ex = ibv_create_cq_ex(md->dev.ibv_context, &cq_attr);
     if (cq_ex == NULL) {
         saved_errno = errno;
-        errno       = saved_errno;
         if ((saved_errno == EOPNOTSUPP) || (saved_errno == ENOSYS) ||
             (saved_errno == EINVAL)) {
-            ucs_error("%s: CoCo control CQ probe requires ibv_create_cq_ex() "
+            errno = saved_errno;
+            ucs_debug("%s: CoCo control CQ probe requires ibv_create_cq_ex() "
                       "parent-domain support: %m",
                       uct_ib_device_name(&md->dev));
             return UCS_ERR_UNSUPPORTED;
@@ -1362,11 +1362,29 @@ static ucs_status_t uct_ib_md_probe_coco_control_cq(uct_ib_md_t *md)
               uct_ib_device_name(&md->dev));
     return UCS_OK;
 #else
-    ucs_error("%s: device reports IBV_DEVICE_CC_DMA_BOUNCE but rdma-core lacks "
+    ucs_debug("%s: device reports IBV_DEVICE_CC_DMA_BOUNCE but rdma-core lacks "
               "CoCo CQ parent-domain APIs",
               uct_ib_device_name(&md->dev));
     return UCS_ERR_UNSUPPORTED;
 #endif
+}
+
+static void uct_ib_md_dealloc_coco_pd(uct_ib_md_t *md)
+{
+    int ret;
+
+    if (md->coco_pd == NULL) {
+        return;
+    }
+
+    ret = ibv_dealloc_pd(md->coco_pd);
+    /* Do not print a warning if PD deallocation failed with EINVAL, because
+     * it fails from time to time on BF/ARM (TODO: investigate) */
+    if ((ret != 0) && (errno != EINVAL)) {
+        ucs_warn("ibv_dealloc_pd(coco_pd) failed: %m");
+    }
+
+    md->coco_pd = NULL;
 }
 
 ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
@@ -1407,7 +1425,7 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
 
         status = uct_ib_md_probe_coco_control_cq(md);
         if (status != UCS_OK) {
-            goto err_cleanup_device;
+            goto err_dealloc_coco_pd;
         }
     }
 
@@ -1416,7 +1434,7 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                                                &md->subnet_filter);
 
         if (status != UCS_OK) {
-            goto err_cleanup_device;
+            goto err_dealloc_coco_pd;
         }
 
         md->check_subnet_filter = 1;
@@ -1463,7 +1481,7 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                   "installed correctly, or dmabuf is supported.",
                   uct_ib_device_name(&md->dev));
         status = UCS_ERR_UNSUPPORTED;
-        goto err_cleanup_device;
+        goto err_dealloc_coco_pd;
     }
 
     md->dev.max_zcopy_log_sge = INT_MAX;
@@ -1475,6 +1493,8 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
 
     return UCS_OK;
 
+err_dealloc_coco_pd:
+    uct_ib_md_dealloc_coco_pd(md);
 err_cleanup_device:
     uct_ib_device_cleanup(&md->dev);
 err_release_stats:
@@ -1528,14 +1548,7 @@ void uct_ib_md_free(uct_ib_md_t *md)
 {
     int ret;
 
-    if (md->coco_pd != NULL) {
-        ret = ibv_dealloc_pd(md->coco_pd);
-        /* Do not print a warning if PD deallocation failed with EINVAL, because
-         * it fails from time to time on BF/ARM (TODO: investigate) */
-        if ((ret != 0) && (errno != EINVAL)) {
-            ucs_warn("ibv_dealloc_pd(coco_pd) failed: %m");
-        }
-    }
+    uct_ib_md_dealloc_coco_pd(md);
 
     ret = ibv_dealloc_pd(md->pd);
     /* Do not print a warning if PD deallocation failed with EINVAL, because

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1294,12 +1294,7 @@ void uct_ib_md_check_odp(uct_ib_md_t *md, const uct_ib_md_config_t *md_config)
 
 static int uct_ib_md_detect_cc_dma_bounce(uct_ib_md_t *md)
 {
-#if HAVE_DECL_IBV_DEVICE_CC_DMA_BOUNCE && HAVE_DECL_IBV_QUERY_DEVICE_EX
-    return !!(md->dev.dev_attr.device_cap_flags_ex &
-              IBV_DEVICE_CC_DMA_BOUNCE);
-#else
-    return 0;
-#endif
+    return uct_ib_device_is_cc_dma_bounce(&md->dev);
 }
 
 static ucs_status_t uct_ib_md_create_coco_pd(uct_ib_md_t *md)
@@ -1324,6 +1319,51 @@ static ucs_status_t uct_ib_md_create_coco_pd(uct_ib_md_t *md)
     return UCS_OK;
 #else
     ucs_error("%s: device reports IBV_DEVICE_CC_DMA_BOUNCE but rdma-core lacks CoCo parent-domain APIs",
+              uct_ib_device_name(&md->dev));
+    return UCS_ERR_UNSUPPORTED;
+#endif
+}
+
+static ucs_status_t uct_ib_md_probe_coco_control_cq(uct_ib_md_t *md)
+{
+#if HAVE_DECL_IBV_CREATE_CQ_EX && HAVE_DECL_IBV_CQ_INIT_ATTR_MASK_PD && \
+    HAVE_STRUCT_IBV_CQ_INIT_ATTR_EX_PARENT_DOMAIN
+    struct ibv_cq_init_attr_ex cq_attr = {
+        .cqe           = 1,
+        .comp_mask     = IBV_CQ_INIT_ATTR_MASK_PD,
+        .parent_domain = md->coco_pd
+    };
+    struct ibv_cq_ex *cq_ex;
+    struct ibv_cq *cq;
+    int saved_errno;
+
+    cq_ex = ibv_create_cq_ex(md->dev.ibv_context, &cq_attr);
+    if (cq_ex == NULL) {
+        saved_errno = errno;
+        errno       = saved_errno;
+        if ((saved_errno == EOPNOTSUPP) || (saved_errno == ENOSYS) ||
+            (saved_errno == EINVAL)) {
+            ucs_error("%s: CoCo control CQ probe requires ibv_create_cq_ex() "
+                      "parent-domain support: %m",
+                      uct_ib_device_name(&md->dev));
+            return UCS_ERR_UNSUPPORTED;
+        }
+
+        errno = saved_errno;
+        uct_ib_check_memlock_limit_msg(md->dev.ibv_context,
+                                       UCS_LOG_LEVEL_ERROR,
+                                       "ibv_create_cq_ex(cqe=%d)", 1);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    cq = ibv_cq_ex_to_cq(cq_ex);
+    ibv_destroy_cq(cq);
+    ucs_debug("%s: CoCo control CQ probe succeeded",
+              uct_ib_device_name(&md->dev));
+    return UCS_OK;
+#else
+    ucs_error("%s: device reports IBV_DEVICE_CC_DMA_BOUNCE but rdma-core lacks "
+              "CoCo CQ parent-domain APIs",
               uct_ib_device_name(&md->dev));
     return UCS_ERR_UNSUPPORTED;
 #endif
@@ -1361,6 +1401,11 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
     md->cc_dma_bounce = uct_ib_md_detect_cc_dma_bounce(md);
     if (md->cc_dma_bounce) {
         status = uct_ib_md_create_coco_pd(md);
+        if (status != UCS_OK) {
+            goto err_cleanup_device;
+        }
+
+        status = uct_ib_md_probe_coco_control_cq(md);
         if (status != UCS_OK) {
             goto err_cleanup_device;
         }

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -147,6 +147,8 @@ typedef enum {
 typedef struct uct_ib_md {
     uct_md_t                 super;
     struct ibv_pd            *pd;       /**< IB memory domain */
+    struct ibv_pd            *coco_pd;  /**< CoCo parent PD for control objects */
+    int                      cc_dma_bounce; /**< Device requires CoCo DMA bounce */
     uct_ib_device_t          dev;       /**< IB device */
     ucs_linear_func_t        reg_cost;  /**< Memory registration cost */
     UCS_STATS_NODE_DECLARE(stats)
@@ -179,6 +181,19 @@ typedef struct uct_ib_md {
         uint32_t             size;
     } mkey_by_name_reserve;
 } uct_ib_md_t;
+
+
+static UCS_F_ALWAYS_INLINE int uct_ib_md_is_cc_dma_bounce(const uct_ib_md_t *md)
+{
+    return md->cc_dma_bounce;
+}
+
+static UCS_F_ALWAYS_INLINE struct ibv_pd*
+uct_ib_md_control_pd(const uct_ib_md_t *md)
+{
+    ucs_assert(!md->cc_dma_bounce || (md->coco_pd != NULL));
+    return (md->cc_dma_bounce && (md->coco_pd != NULL)) ? md->coco_pd : md->pd;
+}
 
 
 typedef struct {

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -199,6 +199,19 @@ static UCS_F_ALWAYS_INLINE int uct_ib_md_is_cc_dma_bounce(const uct_ib_md_t *md)
     return md->cc_dma_bounce;
 }
 
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_ib_md_check_cc_dma_bounce_supported(const uct_ib_md_t *md,
+                                        const char *transport_name)
+{
+    if (!uct_ib_md_is_cc_dma_bounce(md)) {
+        return UCS_OK;
+    }
+
+    ucs_error("%s: %s does not support CoCo control-object allocation",
+              uct_ib_device_name(&md->dev), transport_name);
+    return UCS_ERR_UNSUPPORTED;
+}
+
 static UCS_F_ALWAYS_INLINE struct ibv_pd*
 uct_ib_md_control_pd(const uct_ib_md_t *md)
 {

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -183,6 +183,17 @@ typedef struct uct_ib_md {
 } uct_ib_md_t;
 
 
+static UCS_F_ALWAYS_INLINE int
+uct_ib_device_is_cc_dma_bounce(const uct_ib_device_t *dev)
+{
+#if HAVE_DECL_IBV_DEVICE_CC_DMA_BOUNCE && HAVE_DECL_IBV_QUERY_DEVICE_EX
+    return !!(dev->dev_attr.device_cap_flags_ex &
+              IBV_DEVICE_CC_DMA_BOUNCE);
+#else
+    return 0;
+#endif
+}
+
 static UCS_F_ALWAYS_INLINE int uct_ib_md_is_cc_dma_bounce(const uct_ib_md_t *md)
 {
     return md->cc_dma_bounce;

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -150,6 +150,17 @@ AS_IF([test "x$with_ib" = "xyes"],
        AC_CHECK_DECLS([IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN],
                       [have_cq_io=yes], [], [[#include <infiniband/verbs.h>]])
 
+       AC_CHECK_HEADERS([linux/dma-heap.h])
+
+       AC_CHECK_DECLS([IBV_DEVICE_CC_DMA_BOUNCE,
+                       IBV_PARENT_DOMAIN_INIT_ATTR_ALLOW_CC_UNPROTECTED_ALLOC,
+                       IBV_CQ_INIT_ATTR_MASK_PD,
+                       ibv_alloc_parent_domain],
+                      [], [], [[#include <infiniband/verbs.h>]])
+
+       AC_CHECK_MEMBERS([struct ibv_cq_init_attr_ex.parent_domain],
+                        [], [], [[#include <infiniband/verbs.h>]])
+
        AS_IF([test "x$with_mlx5" != xno], [
               have_mlx5=yes
 
@@ -178,8 +189,11 @@ AS_IF([test "x$with_ib" = "xyes"],
                            MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE,
                            MLX5DV_QP_CREATE_ALLOW_SCATTER_TO_CQE,
                            MLX5DV_UMEM_MASK_DMABUF,
+                           mlx5dv_devx_umem_reg_ex,
                            MLX5DV_UAR_ALLOC_TYPE_BF,
                            MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED],
+                                  [], [], [[#include <infiniband/mlx5dv.h>]])
+                       AC_CHECK_TYPES([struct mlx5dv_devx_umem_in],
                                   [], [], [[#include <infiniband/mlx5dv.h>]])
                        AC_CHECK_MEMBERS([struct mlx5dv_cq.cq_uar],
                                   [], [], [[#include <infiniband/mlx5dv.h>]])

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1586,6 +1586,12 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
 
     ucs_trace_func("");
 
+    if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
+        ucs_error("%s: %s is not CoCo control-object safe in this milestone",
+                  uct_ib_device_name(&md->super.dev), "dc_mlx5");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     self->tx.policy = config->tx_policy;
     self->tx.ndci   = uct_dc_mlx5_iface_is_hw_dcs(self) ? 1 : config->ndci;
 

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1586,10 +1586,9 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
 
     ucs_trace_func("");
 
-    if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
-        ucs_error("%s: %s is not CoCo control-object safe in this milestone",
-                  uct_ib_device_name(&md->super.dev), "dc_mlx5");
-        return UCS_ERR_UNSUPPORTED;
+    status = uct_ib_md_check_cc_dma_bounce_supported(&md->super, "dc_mlx5");
+    if (status != UCS_OK) {
+        return status;
     }
 
     self->tx.policy = config->tx_policy;

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1915,19 +1915,25 @@ struct ibv_context* uct_ib_mlx5_devx_open_device(struct ibv_device *ibv_device)
 }
 
 static ucs_status_t
-uct_ib_mlx5_devx_check_event_channel(struct ibv_context *ctx)
+uct_ib_mlx5_devx_check_event_channel(struct ibv_context *ctx,
+                                     int is_coco_context)
 {
     struct mlx5dv_devx_event_channel *event_channel;
     struct ibv_cq *cq;
 
-    cq = ibv_create_cq(ctx, 1, NULL, NULL, 0);
-    if (cq == NULL) {
-        uct_ib_check_memlock_limit_msg(ctx, UCS_LOG_LEVEL_DEBUG,
-                                       "ibv_create_cq()");
-        return UCS_ERR_UNSUPPORTED;
-    }
+    if (!is_coco_context) {
+        cq = ibv_create_cq(ctx, 1, NULL, NULL, 0);
+        if (cq == NULL) {
+            uct_ib_check_memlock_limit_msg(ctx, UCS_LOG_LEVEL_DEBUG,
+                                           "ibv_create_cq()");
+            return UCS_ERR_UNSUPPORTED;
+        }
 
-    ibv_destroy_cq(cq);
+        ibv_destroy_cq(cq);
+    } else {
+        ucs_debug("%s: skipping plain CQ DEVX probe in CoCo DMA-bounce mode",
+                  ibv_get_device_name(ctx->device));
+    }
 
     event_channel = mlx5dv_devx_create_event_channel(
             ctx, MLX5_IB_UAPI_DEVX_CR_EV_CH_FLAGS_OMIT_DATA);
@@ -2345,11 +2351,6 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
         goto err_free_buffer;
     }
 
-    status = uct_ib_mlx5_devx_check_event_channel(ctx);
-    if (status != UCS_OK) {
-        goto err_free_context;
-    }
-
     md = ucs_derived_of(uct_ib_md_alloc(size, name, ctx), uct_ib_mlx5_md_t);
     if (md == NULL) {
         status = UCS_ERR_NO_MEMORY;
@@ -2366,6 +2367,12 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
     uct_ib_mlx5_devx_mr_lru_init(md);
 
     status = uct_ib_device_query(dev, ibv_device);
+    if (status != UCS_OK) {
+        goto err_lru_cleanup;
+    }
+
+    status = uct_ib_mlx5_devx_check_event_channel(
+            ctx, uct_ib_device_is_cc_dma_bounce(dev));
     if (status != UCS_OK) {
         goto err_lru_cleanup;
     }

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -13,6 +13,7 @@
 #include <uct/api/device/uct_device_types.h>
 
 #include <ucs/arch/bitops.h>
+#include <ucs/datastruct/mpool.inl>
 #include <ucs/profile/profile.h>
 #include <ucs/sys/ptr_arith.h>
 #include <ucs/time/time.h>
@@ -93,6 +94,8 @@ static const char uct_ib_mkey_token[] = "uct_ib_mkey_token";
 
 typedef struct uct_ib_mlx5_dbrec_page {
     uct_ib_mlx5_devx_umem_t    mem;
+    volatile uint32_t          *db;
+    unsigned                   num_dbrecs;
 } uct_ib_mlx5_dbrec_page_t;
 
 
@@ -1697,36 +1700,58 @@ static ucs_status_t uct_ib_mlx5_add_page(ucs_mpool_t *mp, size_t *size_p, void *
 {
     uct_ib_mlx5_md_t *md = ucs_container_of(mp, uct_ib_mlx5_md_t, dbrec_pool);
     uct_ib_mlx5_dbrec_page_t *page;
-    size_t size = ucs_align_up(*size_p + sizeof(*page), ucs_get_page_size());
-    uct_ib_mlx5_devx_umem_t mem;
+    size_t private_size = *size_p;
+    size_t db_size;
+    void *db;
     ucs_status_t status;
 
-    status = uct_ib_mlx5_md_buf_alloc(md, size, 1, (void**)&page, &mem, 0,
-                                      "devx dbrec");
-    if (status != UCS_OK) {
-        return status;
+    page = ucs_calloc(1, private_size + sizeof(*page),
+                      "devx dbrec private page");
+    if (page == NULL) {
+        return UCS_ERR_NO_MEMORY;
     }
 
-    page->mem = mem;
-    *size_p   = size - sizeof(*page);
-    *page_p   = page + 1;
+    page->num_dbrecs = ucs_mpool_num_elems_per_chunk(
+            mp, (ucs_mpool_chunk_t*)(page + 1), private_size);
+    db_size          = ucs_align_up(page->num_dbrecs * 2 * sizeof(*page->db),
+                                    ucs_get_page_size());
+
+    status = uct_ib_mlx5_md_buf_alloc(md, db_size, 1, &db, &page->mem, 0,
+                                      "devx dbrec");
+    if (status != UCS_OK) {
+        goto err_free_page;
+    }
+
+    page->db = db;
+    *page_p  = page + 1;
     return UCS_OK;
+
+err_free_page:
+    ucs_free(page);
+    return status;
 }
 
 static void uct_ib_mlx5_init_dbrec(ucs_mpool_t *mp, void *obj, void *chunk)
 {
+    ucs_mpool_chunk_t *mpool_chunk = chunk;
     uct_ib_mlx5_dbrec_page_t *page = (uct_ib_mlx5_dbrec_page_t*)chunk - 1;
     uct_ib_mlx5_dbrec_t *dbrec     = obj;
+    size_t index;
 
+    index        = UCS_PTR_BYTE_DIFF(mpool_chunk->elems, obj) /
+                   ucs_mpool_elem_total_size(mp->data);
+    ucs_assert(index < page->num_dbrecs);
+    dbrec->db     = page->db + (index * 2);
     dbrec->mem_id = page->mem.mem->umem_id;
-    dbrec->offset = UCS_PTR_BYTE_DIFF(chunk, obj) + sizeof(*page);
+    dbrec->offset = index * 2 * sizeof(*page->db);
 }
 
 static void uct_ib_mlx5_free_page(ucs_mpool_t *mp, void *chunk)
 {
     uct_ib_mlx5_md_t *md = ucs_container_of(mp, uct_ib_mlx5_md_t, dbrec_pool);
     uct_ib_mlx5_dbrec_page_t *page = (uct_ib_mlx5_dbrec_page_t*)chunk - 1;
-    uct_ib_mlx5_md_buf_free(md, page, &page->mem);
+    uct_ib_mlx5_md_buf_free(md, (void*)page->db, &page->mem);
+    ucs_free(page);
 }
 
 static ucs_mpool_ops_t uct_ib_mlx5_dbrec_ops = {

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -273,13 +273,19 @@ uct_ib_mlx5_res_domain_init(uct_ib_mlx5_res_domain_t *res_domain,
     if (res_domain->td == NULL) {
         ucs_debug("ibv_alloc_td() on %s failed: %m",
                   uct_ib_device_name(&md->dev));
-        res_domain->pd = md->pd;
+        res_domain->pd = uct_ib_md_control_pd(md);
         return UCS_OK;
     }
 
-    attr.td = res_domain->td;
-    attr.pd = md->pd;
+    attr.td        = res_domain->td;
+    attr.pd        = md->pd;
     attr.comp_mask = 0;
+#if HAVE_DECL_IBV_PARENT_DOMAIN_INIT_ATTR_ALLOW_CC_UNPROTECTED_ALLOC
+    if (uct_ib_md_is_cc_dma_bounce(md)) {
+        attr.comp_mask |=
+            IBV_PARENT_DOMAIN_INIT_ATTR_ALLOW_CC_UNPROTECTED_ALLOC;
+    }
+#endif
     res_domain->pd = ibv_alloc_parent_domain(md->dev.ibv_context, &attr);
     if (res_domain->pd == NULL) {
         ucs_error("ibv_alloc_parent_domain() on %s failed: %m",

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -495,7 +495,7 @@ typedef struct uct_ib_mlx5_iface_config {
  * MLX5 DoorBell record
  */
 typedef struct uct_ib_mlx5_dbrec {
-   volatile uint32_t  db[2];
+   volatile uint32_t  *db;
    uint32_t           mem_id;
    size_t             offset;
    uct_ib_mlx5_md_t   *md;

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -39,8 +39,15 @@
 
 #include <infiniband/mlx5dv.h>
 #include <netinet/in.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
 #include <endian.h>
+#include <fcntl.h>
 #include <string.h>
+#include <unistd.h>
+#if HAVE_LINUX_DMA_HEAP_H
+#  include <linux/dma-heap.h>
+#endif
 
 
 #define UCT_IB_MLX5_WQE_SEG_SIZE         16 /* Size of a segment in a WQE */
@@ -335,6 +342,9 @@ typedef struct {
 typedef struct {
     struct mlx5dv_devx_umem  *mem;
     size_t                   size;
+    size_t                   mmap_size;
+    int                      dmabuf_fd;
+    int                      is_dmabuf;
 } uct_ib_mlx5_devx_umem_t;
 
 
@@ -1090,6 +1100,154 @@ void uct_ib_mlx5_cq_calc_sizes(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                                const uct_ib_iface_init_attr_t *init_attr,
                                size_t inl, uct_ib_mlx5_cq_attr_t *attr);
 
+#define UCT_IB_MLX5_CC_DMA_HEAP "/dev/dma_heap/system_cc_shared"
+#define UCT_IB_MLX5_INVALID_DMABUF_FD (-1)
+
+static UCS_F_ALWAYS_INLINE void
+uct_ib_mlx5_devx_umem_reset(uct_ib_mlx5_devx_umem_t *mem)
+{
+    mem->mem       = NULL;
+    mem->size      = 0;
+    mem->mmap_size = 0;
+    mem->dmabuf_fd = UCT_IB_MLX5_INVALID_DMABUF_FD;
+    mem->is_dmabuf = 0;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_ib_mlx5_devx_umem_reg_status(int sys_errno)
+{
+    if ((sys_errno == EOPNOTSUPP) || (sys_errno == EPROTONOSUPPORT) ||
+        (sys_errno == EINVAL)
+#ifdef ENOTSUP
+        || (sys_errno == ENOTSUP)
+#endif
+        ) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    return (sys_errno == ENOMEM) ? UCS_ERR_NO_MEMORY : UCS_ERR_IO_ERROR;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_ib_mlx5_md_buf_alloc_shared(uct_ib_mlx5_md_t *md, size_t size, int silent,
+                                void **buf_p, uct_ib_mlx5_devx_umem_t *mem,
+                                int access_mode, char *name)
+{
+    const ucs_log_level_t level = silent ? UCS_LOG_LEVEL_DEBUG :
+                                           UCS_LOG_LEVEL_ERROR;
+    const char *alloc_name      = (name != NULL) ? name : "unknown";
+#if HAVE_LINUX_DMA_HEAP_H && HAVE_DECL_MLX5DV_DEVX_UMEM_REG_EX && \
+    HAVE_DECL_MLX5DV_UMEM_MASK_DMABUF && HAVE_STRUCT_MLX5DV_DEVX_UMEM_IN
+    struct ibv_context *ibv_context = md->super.dev.ibv_context;
+    struct mlx5dv_devx_umem_in umem_in;
+    struct dma_heap_allocation_data heap_data;
+    ucs_status_t status;
+    void *buf = NULL;
+    size_t mmap_size;
+    int reg_errno;
+    int heap_fd;
+    int ret;
+
+    uct_ib_mlx5_devx_umem_reset(mem);
+    *buf_p = NULL;
+
+    mmap_size = ucs_align_up(size, ucs_get_page_size());
+    heap_fd   = open(UCT_IB_MLX5_CC_DMA_HEAP, O_RDWR | O_CLOEXEC);
+    if (heap_fd < 0) {
+        status = (errno == ENOENT) ? UCS_ERR_UNSUPPORTED : UCS_ERR_IO_ERROR;
+        ucs_log(level, "failed to open %s for %s: %m",
+                UCT_IB_MLX5_CC_DMA_HEAP, alloc_name);
+        uct_ib_mlx5_devx_umem_reset(mem);
+        return status;
+    }
+
+    memset(&heap_data, 0, sizeof(heap_data));
+    heap_data.len      = mmap_size;
+    heap_data.fd_flags = O_RDWR | O_CLOEXEC;
+
+    ret = ioctl(heap_fd, DMA_HEAP_IOCTL_ALLOC, &heap_data);
+    if (ret != 0) {
+        status = (errno == ENOMEM) ? UCS_ERR_NO_MEMORY : UCS_ERR_IO_ERROR;
+        ucs_log(level, "DMA_HEAP_IOCTL_ALLOC(%s, name=%s size=%zu) failed: %m",
+                UCT_IB_MLX5_CC_DMA_HEAP, alloc_name, mmap_size);
+        ret = close(heap_fd);
+        if (ret != 0) {
+            ucs_warn("close(dma_heap_fd=%d) failed: %m", heap_fd);
+        }
+        uct_ib_mlx5_devx_umem_reset(mem);
+        return status;
+    }
+
+    ret = close(heap_fd);
+    if (ret != 0) {
+        ucs_warn("close(dma_heap_fd=%d) failed: %m", heap_fd);
+    }
+
+    mem->dmabuf_fd = heap_data.fd;
+    buf = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+               mem->dmabuf_fd, 0);
+    if (buf == MAP_FAILED) {
+        status = (errno == ENOMEM) ? UCS_ERR_NO_MEMORY : UCS_ERR_IO_ERROR;
+        ucs_log(level, "mmap(name=%s dmabuf_fd=%d size=%zu) failed: %m",
+                alloc_name, mem->dmabuf_fd, mmap_size);
+        buf = NULL;
+        ret = close(mem->dmabuf_fd);
+        if (ret != 0) {
+            ucs_warn("close(dmabuf_fd=%d) failed: %m", mem->dmabuf_fd);
+        }
+        uct_ib_mlx5_devx_umem_reset(mem);
+        return status;
+    }
+
+    memset(buf, 0, mmap_size);
+
+    memset(&umem_in, 0, sizeof(umem_in));
+    umem_in.addr        = NULL;
+    umem_in.size        = mmap_size;
+    umem_in.access      = access_mode;
+    umem_in.pgsz_bitmap = UINT64_MAX & ~(ucs_get_page_size() - 1);
+    umem_in.comp_mask   = MLX5DV_UMEM_MASK_DMABUF;
+    umem_in.dmabuf_fd   = mem->dmabuf_fd;
+
+    mem->mem = mlx5dv_devx_umem_reg_ex(ibv_context, &umem_in);
+    if (mem->mem == NULL) {
+        reg_errno = errno;
+        status    = uct_ib_mlx5_devx_umem_reg_status(reg_errno);
+        errno     = reg_errno;
+        uct_ib_check_memlock_limit_msg(
+                ibv_context, level,
+                "mlx5dv_devx_umem_reg_ex(name=%s dmabuf_fd=%d size=%zu access=0x%x)",
+                alloc_name, mem->dmabuf_fd, mmap_size, access_mode);
+        ret = munmap(buf, mmap_size);
+        if (ret != 0) {
+            ucs_warn("munmap(buf=%p, len=%zu) failed: %m", buf, mmap_size);
+        }
+        ret = close(mem->dmabuf_fd);
+        if (ret != 0) {
+            ucs_warn("close(dmabuf_fd=%d) failed: %m", mem->dmabuf_fd);
+        }
+        uct_ib_mlx5_devx_umem_reset(mem);
+        return status;
+    }
+
+    mem->size      = size;
+    mem->mmap_size = mmap_size;
+    mem->is_dmabuf = 1;
+    *buf_p         = buf;
+    return UCS_OK;
+#else
+    (void)md;
+    (void)size;
+    (void)access_mode;
+
+    ucs_log(level, "shared DEVX UMEM allocation for %s is unsupported",
+            alloc_name);
+    *buf_p = NULL;
+    uct_ib_mlx5_devx_umem_reset(mem);
+    return UCS_ERR_UNSUPPORTED;
+#endif
+}
+
 static inline ucs_status_t
 uct_ib_mlx5_md_buf_alloc(uct_ib_mlx5_md_t *md, size_t size, int silent,
                          void **buf_p, uct_ib_mlx5_devx_umem_t *mem,
@@ -1101,6 +1259,15 @@ uct_ib_mlx5_md_buf_alloc(uct_ib_mlx5_md_t *md, size_t size, int silent,
     ucs_status_t status;
     void *buf;
     int ret;
+
+    if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
+        return uct_ib_mlx5_md_buf_alloc_shared(md, size, silent, buf_p, mem,
+                                               access_mode, name);
+    }
+
+    mem->mmap_size = size;
+    mem->dmabuf_fd = UCT_IB_MLX5_INVALID_DMABUF_FD;
+    mem->is_dmabuf = 0;
 
     ret = ucs_posix_memalign(&buf, ucs_get_page_size(), size, name);
     if (ret != 0) {
@@ -1144,17 +1311,46 @@ err_free:
 static inline void
 uct_ib_mlx5_md_buf_free(uct_ib_mlx5_md_t *md, void *buf, uct_ib_mlx5_devx_umem_t *mem)
 {
+    struct mlx5dv_devx_umem *umem;
+    size_t mmap_size;
+    size_t size;
+    int dmabuf_fd;
+    int is_dmabuf;
     int ret;
 
     if (buf == NULL) {
         return;
     }
 
-    mlx5dv_devx_umem_dereg(mem->mem);
-    if (md->super.fork_init) {
-        ret = madvise(buf, mem->size, MADV_DOFORK);
+    umem       = mem->mem;
+    mmap_size  = mem->mmap_size;
+    size       = mem->size;
+    dmabuf_fd  = mem->dmabuf_fd;
+    is_dmabuf  = mem->is_dmabuf;
+
+    mlx5dv_devx_umem_dereg(umem);
+    if (is_dmabuf) {
+        uct_ib_mlx5_devx_umem_reset(mem);
+
+        ret = munmap(buf, mmap_size);
         if (ret != 0) {
-            ucs_warn("madvise(DOFORK, buf=%p, len=%zu) failed: %m", buf, mem->size);
+            ucs_warn("munmap(buf=%p, len=%zu) failed: %m", buf,
+                     mmap_size);
+        }
+
+        if (dmabuf_fd != UCT_IB_MLX5_INVALID_DMABUF_FD) {
+            ret = close(dmabuf_fd);
+            if (ret != 0) {
+                ucs_warn("close(dmabuf_fd=%d) failed: %m", dmabuf_fd);
+            }
+        }
+        return;
+    }
+
+    if (md->super.fork_init) {
+        ret = madvise(buf, size, MADV_DOFORK);
+        if (ret != 0) {
+            ucs_warn("madvise(DOFORK, buf=%p, len=%zu) failed: %m", buf, size);
         }
     }
     ucs_free(buf);

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -1157,7 +1157,6 @@ uct_ib_mlx5_md_buf_alloc_shared(uct_ib_mlx5_md_t *md, size_t size, int silent,
         status = (errno == ENOENT) ? UCS_ERR_UNSUPPORTED : UCS_ERR_IO_ERROR;
         ucs_log(level, "failed to open %s for %s: %m",
                 UCT_IB_MLX5_CC_DMA_HEAP, alloc_name);
-        uct_ib_mlx5_devx_umem_reset(mem);
         return status;
     }
 
@@ -1174,7 +1173,6 @@ uct_ib_mlx5_md_buf_alloc_shared(uct_ib_mlx5_md_t *md, size_t size, int silent,
         if (ret != 0) {
             ucs_warn("close(dma_heap_fd=%d) failed: %m", heap_fd);
         }
-        uct_ib_mlx5_devx_umem_reset(mem);
         return status;
     }
 
@@ -1201,6 +1199,26 @@ uct_ib_mlx5_md_buf_alloc_shared(uct_ib_mlx5_md_t *md, size_t size, int silent,
 
     memset(buf, 0, mmap_size);
 
+    if (md->super.fork_init) {
+        ret = madvise(buf, mmap_size, MADV_DONTFORK);
+        if (ret != 0) {
+            status = UCS_ERR_IO_ERROR;
+            ucs_log(level, "madvise(DONTFORK, buf=%p, len=%zu) failed: %m",
+                    buf, mmap_size);
+            ret = munmap(buf, mmap_size);
+            if (ret != 0) {
+                ucs_warn("munmap(buf=%p, len=%zu) failed: %m", buf,
+                         mmap_size);
+            }
+            ret = close(mem->dmabuf_fd);
+            if (ret != 0) {
+                ucs_warn("close(dmabuf_fd=%d) failed: %m", mem->dmabuf_fd);
+            }
+            uct_ib_mlx5_devx_umem_reset(mem);
+            return status;
+        }
+    }
+
     memset(&umem_in, 0, sizeof(umem_in));
     umem_in.addr        = NULL;
     umem_in.size        = mmap_size;
@@ -1218,6 +1236,13 @@ uct_ib_mlx5_md_buf_alloc_shared(uct_ib_mlx5_md_t *md, size_t size, int silent,
                 ibv_context, level,
                 "mlx5dv_devx_umem_reg_ex(name=%s dmabuf_fd=%d size=%zu access=0x%x)",
                 alloc_name, mem->dmabuf_fd, mmap_size, access_mode);
+        if (md->super.fork_init) {
+            ret = madvise(buf, mmap_size, MADV_DOFORK);
+            if (ret != 0) {
+                ucs_warn("madvise(DOFORK, buf=%p, len=%zu) failed: %m", buf,
+                         mmap_size);
+            }
+        }
         ret = munmap(buf, mmap_size);
         if (ret != 0) {
             ucs_warn("munmap(buf=%p, len=%zu) failed: %m", buf, mmap_size);
@@ -1332,6 +1357,13 @@ uct_ib_mlx5_md_buf_free(uct_ib_mlx5_md_t *md, void *buf, uct_ib_mlx5_devx_umem_t
     if (is_dmabuf) {
         uct_ib_mlx5_devx_umem_reset(mem);
 
+        if (md->super.fork_init) {
+            ret = madvise(buf, mmap_size, MADV_DOFORK);
+            if (ret != 0) {
+                ucs_warn("madvise(DOFORK, buf=%p, len=%zu) failed: %m", buf,
+                         mmap_size);
+            }
+        }
         ret = munmap(buf, mmap_size);
         if (ret != 0) {
             ucs_warn("munmap(buf=%p, len=%zu) failed: %m", buf,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -347,7 +347,8 @@ uct_rc_mlx5_verbs_create_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
     qp_init_attr.srq                 = iface->rx.srq.verbs.srq;
     qp_init_attr.cap.max_send_wr     = iface->tm.cmd_qp_len;
 
-    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp, md->pd, &qp_init_attr);
+    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp, uct_ib_md_control_pd(md),
+                                 &qp_init_attr);
     if (qp == NULL) {
         ucs_error("failed to create TM control QP: %m");
         goto err_rd;
@@ -951,7 +952,7 @@ ucs_status_t uct_rc_mlx5_init_rx_tm(uct_rc_mlx5_iface_common_t *iface,
     srq_attr->attr.srq_limit      = 0;
     srq_attr->srq_context         = iface;
     srq_attr->srq_type            = IBV_SRQT_TM;
-    srq_attr->pd                  = md->pd;
+    srq_attr->pd                  = uct_ib_md_control_pd(md);
     srq_attr->cq                  = iface->super.super.cq[UCT_IB_DIR_RX];
     srq_attr->tm_cap.max_num_tags = iface->tm.num_tags;
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -548,12 +548,10 @@ uct_rc_mlx5_iface_init_rx(uct_rc_iface_t *rc_iface,
 
     if (UCT_RC_MLX5_TM_ENABLED(iface)) {
         if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ) {
-            if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
-                ucs_error("%s: %s is not CoCo control-object safe in this "
-                          "milestone",
-                          uct_ib_device_name(&md->super.dev),
-                          "rc_mlx5 tag-matching DEVX");
-                return UCS_ERR_UNSUPPORTED;
+            status = uct_ib_md_check_cc_dma_bounce_supported(
+                    &md->super, "rc_mlx5 tag-matching DEVX");
+            if (status != UCS_OK) {
+                return status;
             }
 
             status = uct_rc_mlx5_devx_init_rx_tm(iface, rc_config, 0,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -548,6 +548,14 @@ uct_rc_mlx5_iface_init_rx(uct_rc_iface_t *rc_iface,
 
     if (UCT_RC_MLX5_TM_ENABLED(iface)) {
         if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ) {
+            if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
+                ucs_error("%s: %s is not CoCo control-object safe in this "
+                          "milestone",
+                          uct_ib_device_name(&md->super.dev),
+                          "rc_mlx5 tag-matching DEVX");
+                return UCS_ERR_UNSUPPORTED;
+            }
+
             status = uct_rc_mlx5_devx_init_rx_tm(iface, rc_config, 0,
                                                  UCT_RC_RNDV_HDR_LEN);
         } else {

--- a/src/uct/ib/mlx5/ud/ud_mlx5.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.c
@@ -989,10 +989,9 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t, uct_md_h tl_md,
 
     ucs_trace_func("");
 
-    if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
-        ucs_error("%s: %s is not CoCo control-object safe in this milestone",
-                  uct_ib_device_name(&md->super.dev), "ud_mlx5");
-        return UCS_ERR_UNSUPPORTED;
+    status = uct_ib_md_check_cc_dma_bounce_supported(&md->super, "ud_mlx5");
+    if (status != UCS_OK) {
+        return status;
     }
 
     status = uct_ud_mlx5dv_calc_tx_wqe_ratio(md);

--- a/src/uct/ib/mlx5/ud/ud_mlx5.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.c
@@ -989,6 +989,12 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t, uct_md_h tl_md,
 
     ucs_trace_func("");
 
+    if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
+        ucs_error("%s: %s is not CoCo control-object safe in this milestone",
+                  uct_ib_device_name(&md->super.dev), "ud_mlx5");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     status = uct_ud_mlx5dv_calc_tx_wqe_ratio(md);
     if (status != UCS_OK) {
         return status;

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -508,7 +508,7 @@ ucs_status_t uct_rc_iface_init_rx(uct_rc_iface_t *iface,
                                   struct ibv_srq **srq_p)
 {
     struct ibv_srq_init_attr srq_init_attr;
-    struct ibv_pd *pd = uct_ib_iface_md(&iface->super)->pd;
+    struct ibv_pd *pd = uct_ib_md_control_pd(uct_ib_iface_md(&iface->super));
     struct ibv_srq *srq;
 
     srq_init_attr.attr.max_sge   = 1;

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -19,6 +19,7 @@
 #include <ucs/arch/bitops.h>
 #include <ucs/arch/cpu.h>
 #include <ucs/debug/log.h>
+#include <errno.h>
 #include <string.h>
 
 
@@ -519,8 +520,57 @@ static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
     .ep_vfs_populate = uct_rc_verbs_ep_vfs_populate
 };
 
-static ucs_status_t uct_rc_verbs_can_create_qp(struct ibv_pd *pd)
+static ucs_status_t
+uct_rc_verbs_create_probe_cq(uct_ib_md_t *ib_md, struct ibv_cq **cq_p)
 {
+    struct ibv_pd *pd = uct_ib_md_control_pd(ib_md);
+
+#if HAVE_DECL_IBV_CREATE_CQ_EX && HAVE_DECL_IBV_CQ_INIT_ATTR_MASK_PD && \
+    HAVE_STRUCT_IBV_CQ_INIT_ATTR_EX_PARENT_DOMAIN
+    struct ibv_cq_init_attr_ex cq_attr = {
+        .cqe           = 1,
+        .comp_mask     = IBV_CQ_INIT_ATTR_MASK_PD,
+        .parent_domain = pd
+    };
+
+    if (uct_ib_md_is_cc_dma_bounce(ib_md)) {
+        *cq_p = ibv_cq_ex_to_cq(ibv_create_cq_ex(pd->context, &cq_attr));
+        if (*cq_p != NULL) {
+            return UCS_OK;
+        }
+
+        if ((errno == EOPNOTSUPP) || (errno == ENOSYS) ||
+            (errno == EINVAL)) {
+            ucs_debug("CoCo RC verbs QP probe requires ibv_create_cq_ex() "
+                      "parent-domain support");
+            return UCS_ERR_UNSUPPORTED;
+        }
+
+        uct_ib_check_memlock_limit_msg(pd->context, UCS_LOG_LEVEL_DEBUG,
+                                       "ibv_create_cq_ex(cqe=%d)", 1);
+        return UCS_ERR_IO_ERROR;
+    }
+#else
+    if (uct_ib_md_is_cc_dma_bounce(ib_md)) {
+        ucs_debug("CoCo RC verbs QP probe requires ibv_create_cq_ex() "
+                  "parent-domain support");
+        return UCS_ERR_UNSUPPORTED;
+    }
+#endif
+
+    *cq_p = ibv_create_cq(pd->context, 1, NULL, NULL, 0);
+    if (*cq_p == NULL) {
+        uct_ib_check_memlock_limit_msg(pd->context, UCS_LOG_LEVEL_DEBUG,
+                                       "ibv_create_cq()");
+        return UCS_ERR_IO_ERROR;
+    }
+
+    return UCS_OK;
+}
+
+static ucs_status_t uct_rc_verbs_can_create_qp(uct_ib_md_t *ib_md)
+{
+    struct ibv_pd *pd = uct_ib_md_control_pd(ib_md);
     struct ibv_qp_init_attr qp_init_attr = {
         .qp_type             = IBV_QPT_RC,
         .sq_sig_all          = 0,
@@ -534,11 +584,8 @@ static ucs_status_t uct_rc_verbs_can_create_qp(struct ibv_pd *pd)
     struct ibv_qp *qp;
     ucs_status_t status;
 
-    cq = ibv_create_cq(pd->context, 1, NULL, NULL, 0);
-    if (cq == NULL) {
-        uct_ib_check_memlock_limit_msg(pd->context, UCS_LOG_LEVEL_DEBUG,
-                                       "ibv_create_cq()");
-        status = UCS_ERR_IO_ERROR;
+    status = uct_rc_verbs_create_probe_cq(ib_md, &cq);
+    if (status != UCS_OK) {
         goto err;
     }
 
@@ -571,7 +618,7 @@ uct_rc_verbs_query_tl_devices(uct_md_h md,
     ucs_status_t status;
 
     /* device does not support RC if we cannot create an RC QP */
-    status = uct_rc_verbs_can_create_qp(ib_md->pd);
+    status = uct_rc_verbs_can_create_qp(ib_md);
     if (status != UCS_OK) {
         return status;
     }

--- a/test/gtest/uct/ib/test_devx.cc
+++ b/test/gtest/uct/ib/test_devx.cc
@@ -41,11 +41,52 @@ public:
 
 UCS_TEST_P(test_devx, dbrec)
 {
-    uct_ib_mlx5_dbrec_t *dbrec;
+    uct_ib_mlx5_dbrec_t *dbrec1;
+    uct_ib_mlx5_dbrec_t *dbrec2;
+    uct_ib_mlx5_dbrec_t *dbrec3;
+    uintptr_t db1;
+    uintptr_t db2;
+    ptrdiff_t db_delta;
+    ptrdiff_t offset_delta;
+    uint32_t mem_id;
+    uint64_t offset;
 
-    dbrec = (uct_ib_mlx5_dbrec_t *)ucs_mpool_get_inline(&md()->dbrec_pool);
-    ASSERT_FALSE(dbrec == NULL);
-    ucs_mpool_put_inline(dbrec);
+    dbrec1 = uct_ib_mlx5_get_dbrec(md());
+    ASSERT_NE(nullptr, dbrec1);
+    dbrec2 = uct_ib_mlx5_get_dbrec(md());
+    ASSERT_NE(nullptr, dbrec2);
+
+    EXPECT_NE(nullptr, dbrec1->db);
+    EXPECT_NE(nullptr, dbrec2->db);
+    EXPECT_EQ(dbrec1->mem_id, dbrec2->mem_id);
+    EXPECT_NE(dbrec1->offset, dbrec2->offset);
+
+    db1          = (uintptr_t)dbrec1->db;
+    db2          = (uintptr_t)dbrec2->db;
+    db_delta     = (db1 > db2) ? (db1 - db2) : (db2 - db1);
+    offset_delta = (dbrec1->offset > dbrec2->offset) ?
+                   (dbrec1->offset - dbrec2->offset) :
+                   (dbrec2->offset - dbrec1->offset);
+    EXPECT_GT(db_delta, 0);
+    EXPECT_EQ(db_delta, offset_delta);
+    EXPECT_EQ(0ul, db_delta % sizeof(*dbrec1->db));
+
+    mem_id = dbrec1->mem_id;
+    offset = dbrec1->offset;
+    dbrec1->db[MLX5_SND_DBR] = 0xdeadbeef;
+    dbrec1->db[MLX5_RCV_DBR] = 0xcafef00d;
+    EXPECT_EQ(mem_id, dbrec1->mem_id);
+    EXPECT_EQ(offset, dbrec1->offset);
+    EXPECT_EQ(md(), dbrec1->md);
+
+    uct_ib_mlx5_put_dbrec(dbrec1);
+    uct_ib_mlx5_put_dbrec(dbrec2);
+
+    dbrec3 = uct_ib_mlx5_get_dbrec(md());
+    ASSERT_NE(nullptr, dbrec3);
+    EXPECT_EQ(0u, dbrec3->db[MLX5_SND_DBR]);
+    EXPECT_EQ(0u, dbrec3->db[MLX5_RCV_DBR]);
+    uct_ib_mlx5_put_dbrec(dbrec3);
 }
 
 UCT_INSTANTIATE_IB_TEST_CASE(test_devx);

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -16,20 +16,6 @@
 #include <common/mem_buffer.h>
 #include <uct/test_md.h>
 
-#include <string>
-#include <type_traits>
-
-#if HAVE_DEVX
-class test_ib_mlx5_dbrec : public ucs::test {
-};
-
-UCS_TEST_F(test_ib_mlx5_dbrec, metadata_uses_external_db_pointer)
-{
-    EXPECT_TRUE(std::is_pointer<
-                decltype(((uct_ib_mlx5_dbrec_t*)nullptr)->db)>::value);
-}
-#endif
-
 class test_ib_md : public test_md
 {
 protected:

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -16,6 +16,8 @@
 #include <common/mem_buffer.h>
 #include <uct/test_md.h>
 
+#include <string>
+
 class test_ib_md : public test_md
 {
 protected:

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -17,6 +17,18 @@
 #include <uct/test_md.h>
 
 #include <string>
+#include <type_traits>
+
+#if HAVE_DEVX
+class test_ib_mlx5_dbrec : public ucs::test {
+};
+
+UCS_TEST_F(test_ib_mlx5_dbrec, metadata_uses_external_db_pointer)
+{
+    EXPECT_TRUE(std::is_pointer<
+                decltype(((uct_ib_mlx5_dbrec_t*)nullptr)->db)>::value);
+}
+#endif
 
 class test_ib_md : public test_md
 {


### PR DESCRIPTION
## What?
- Detect confidential computing environments with an untrusted NIC.
- Allocate UCX-owned IB/mlx5 control objects through the CoCo shared-memory control path.
- Keep DEVX doorbell record metadata private while exposing only the doorbell record page to DEVX.

## Why?
UCX must avoid exposing private guest control metadata to an untrusted device in CoCo RDMA mode. This PR adds the base detection and control-object allocation support required before enabling the DEVX hardening pieces.

## How?
- Detect CoCo RDMA capability and route verbs/DEVX control object allocation through the CoCo control PD/shared-memory flow.
- Avoid the plain DEVX CQ probe in CoCo and use the CoCo-aware probe path.
- Add focused validation for the control-object allocation and dbrec metadata handling.