### PR TITLE
UCT/IB/MLX5: harden CoCo DEVX validators

### DIFF
--- a/docs/hardening/coco-security-properties.md
+++ b/docs/hardening/coco-security-properties.md
@@ -11,11 +11,11 @@ preserve object lifetime, descriptor ownership, queue bounds, slot bounds, and
 non-CoCo behavior.
 
 The device and firmware are not trusted to provide authoritative metadata for
-control-object safety. DEVX/FW output is hostile. private UCX request state is
+control-object safety. DEVX/FW output is hostile. Private UCX request state is
 the authority for descriptor identity, operation ownership, object lifetime,
 queue placement, and completion interpretation.
 
-capability queries are availability hints, not security facts. A reported
+Capability queries are availability hints, not security facts. A reported
 device capability can decide whether a feature can be attempted, but it cannot
 prove that untrusted device output is safe to consume without UCX-side checks.
 

--- a/docs/hardening/coco-security-properties.md
+++ b/docs/hardening/coco-security-properties.md
@@ -1,0 +1,40 @@
+# UCX CoCo Hardening Security Properties
+
+This document defines the security boundary for UCX CoCo hardening in the IB
+and mlx5 transports.
+
+## Claimed Properties
+
+When `uct_ib_md_is_coco_hardened()` is true, CoCo hardening is intended to
+protect local memory safety for UCX-owned control paths. The hardened path must
+preserve object lifetime, descriptor ownership, queue bounds, slot bounds, and
+non-CoCo behavior.
+
+The device and firmware are not trusted to provide authoritative metadata for
+control-object safety. DEVX/FW output is hostile. private UCX request state is
+the authority for descriptor identity, operation ownership, object lifetime,
+queue placement, and completion interpretation.
+
+capability queries are availability hints, not security facts. A reported
+device capability can decide whether a feature can be attempted, but it cannot
+prove that untrusted device output is safe to consume without UCX-side checks.
+
+## Non-Properties
+
+CoCo hardening does not claim payload authenticity, RDMA READ data integrity,
+AM payload integrity, atomic return integrity, or denial-of-service resistance.
+
+Untrusted device behavior can still drop work, delay progress, corrupt payload
+bytes, reorder externally visible effects within device semantics, or return
+syntactically valid but malicious metadata. Hardening must contain those effects
+so they do not become local control-object memory corruption or unauthorized
+descriptor/object reuse.
+
+## Policy Boundary
+
+`uct_ib_md_is_cc_dma_bounce()` reports the raw device/parent-domain condition
+used for CoCo DMA-bounce allocation paths. `uct_ib_md_is_coco_hardened()` is the
+policy predicate that gates hardened transport behavior.
+
+Non-CoCo behavior must remain unchanged. Any CoCo-specific rejection, feature
+masking, or validation must be conditional on `uct_ib_md_is_coco_hardened()`.

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -1300,7 +1300,8 @@ void uct_ib_iface_fill_attr(uct_ib_iface_t *iface, uct_ib_qp_attr_t *attr)
 #if HAVE_DECL_IBV_CREATE_QP_EX
     if (!(attr->ibv.comp_mask & IBV_QP_INIT_ATTR_PD)) {
         attr->ibv.comp_mask       = IBV_QP_INIT_ATTR_PD;
-        attr->ibv.pd              = uct_ib_iface_md(iface)->pd;
+        attr->ibv.pd              =
+                uct_ib_md_control_pd(uct_ib_iface_md(iface));
     }
 #endif
 
@@ -1320,7 +1321,8 @@ ucs_status_t uct_ib_iface_create_qp(uct_ib_iface_t *iface,
     qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp_ex, dev->ibv_context,
                                  &attr->ibv);
 #else
-    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp, uct_ib_iface_md(iface)->pd,
+    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp,
+                                 uct_ib_md_control_pd(uct_ib_iface_md(iface)),
                                  &attr->ibv);
 #endif
     if (qp == NULL) {
@@ -1359,10 +1361,35 @@ ucs_status_t uct_ib_verbs_create_cq(uct_ib_iface_t *iface, uct_ib_dir_t dir,
     struct ibv_cq *cq;
 #if HAVE_DECL_IBV_CREATE_CQ_EX
     struct ibv_cq_init_attr_ex cq_attr = {};
+#endif
+#if !HAVE_DECL_IBV_CREATE_CQ_EX || \
+    !HAVE_DECL_IBV_CQ_INIT_ATTR_MASK_PD || \
+    !HAVE_STRUCT_IBV_CQ_INIT_ATTR_EX_PARENT_DOMAIN
+    if (uct_ib_md_is_cc_dma_bounce(uct_ib_iface_md(iface))) {
+        ucs_error("CoCo CQ creation requires ibv_create_cq_ex() "
+                  "parent-domain support");
+        return UCS_ERR_UNSUPPORTED;
+    }
+#endif
 
+#if HAVE_DECL_IBV_CREATE_CQ_EX
     uct_ib_fill_cq_attr(&cq_attr, init_attr, iface, preferred_cpu, cq_size);
 
     cq = ibv_cq_ex_to_cq(ibv_create_cq_ex(ibv_context, &cq_attr));
+    if ((cq == NULL) &&
+        uct_ib_md_is_cc_dma_bounce(uct_ib_iface_md(iface))) {
+        if ((errno == EOPNOTSUPP) || (errno == ENOSYS) ||
+            (errno == EINVAL)) {
+            ucs_error("CoCo CQ creation requires ibv_create_cq_ex() "
+                      "parent-domain support");
+            return UCS_ERR_UNSUPPORTED;
+        }
+
+        uct_ib_check_memlock_limit_msg(ibv_context, UCS_LOG_LEVEL_ERROR,
+                                       "ibv_create_cq_ex(cqe=%d)", cq_size);
+        return UCS_ERR_IO_ERROR;
+    }
+
     if (!cq && ((errno == EOPNOTSUPP) || (errno == ENOSYS)))
 #endif
     {

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -789,6 +789,14 @@ uct_ib_fill_cq_attr(struct ibv_cq_init_attr_ex *cq_attr,
         cq_attr->flags     = IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN;
     }
 #endif /* HAVE_DECL_IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN */
+
+#if HAVE_DECL_IBV_CQ_INIT_ATTR_MASK_PD && \
+    HAVE_STRUCT_IBV_CQ_INIT_ATTR_EX_PARENT_DOMAIN
+    if (uct_ib_md_is_cc_dma_bounce(uct_ib_iface_md(iface))) {
+        cq_attr->comp_mask    |= IBV_CQ_INIT_ATTR_MASK_PD;
+        cq_attr->parent_domain = uct_ib_md_control_pd(uct_ib_iface_md(iface));
+    }
+#endif
 }
 #endif /* HAVE_DECL_IBV_CREATE_CQ_EX */
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1292,6 +1292,43 @@ void uct_ib_md_check_odp(uct_ib_md_t *md, const uct_ib_md_config_t *md_config)
     ucs_debug("%s: ODP is supported", device_name);
 }
 
+static int uct_ib_md_detect_cc_dma_bounce(uct_ib_md_t *md)
+{
+#if HAVE_DECL_IBV_DEVICE_CC_DMA_BOUNCE && HAVE_DECL_IBV_QUERY_DEVICE_EX
+    return !!(md->dev.dev_attr.device_cap_flags_ex &
+              IBV_DEVICE_CC_DMA_BOUNCE);
+#else
+    return 0;
+#endif
+}
+
+static ucs_status_t uct_ib_md_create_coco_pd(uct_ib_md_t *md)
+{
+#if HAVE_DECL_IBV_ALLOC_PARENT_DOMAIN && \
+    HAVE_DECL_IBV_PARENT_DOMAIN_INIT_ATTR_ALLOW_CC_UNPROTECTED_ALLOC
+    struct ibv_parent_domain_init_attr attr = {};
+
+    attr.pd        = md->pd;
+    attr.td        = NULL;
+    attr.comp_mask = IBV_PARENT_DOMAIN_INIT_ATTR_ALLOW_CC_UNPROTECTED_ALLOC;
+
+    md->coco_pd = ibv_alloc_parent_domain(md->dev.ibv_context, &attr);
+    if (md->coco_pd == NULL) {
+        ucs_error("%s: ibv_alloc_parent_domain() with CoCo unprotected allocation failed: %m",
+                  uct_ib_device_name(&md->dev));
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    ucs_debug("%s: enabled CoCo RDMA control-object shared allocation",
+              uct_ib_device_name(&md->dev));
+    return UCS_OK;
+#else
+    ucs_error("%s: device reports IBV_DEVICE_CC_DMA_BOUNCE but rdma-core lacks CoCo parent-domain APIs",
+              uct_ib_device_name(&md->dev));
+    return UCS_ERR_UNSUPPORTED;
+#endif
+}
+
 ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                                    struct ibv_device *ib_device,
                                    const uct_ib_md_config_t *md_config)
@@ -1319,6 +1356,14 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                                 UCS_STATS_ARG(md->stats));
     if (status != UCS_OK) {
         goto err_release_stats;
+    }
+
+    md->cc_dma_bounce = uct_ib_md_detect_cc_dma_bounce(md);
+    if (md->cc_dma_bounce) {
+        status = uct_ib_md_create_coco_pd(md);
+        if (status != UCS_OK) {
+            goto err_cleanup_device;
+        }
     }
 
     if (strlen(md_config->subnet_prefix) > 0) {
@@ -1437,6 +1482,15 @@ err:
 void uct_ib_md_free(uct_ib_md_t *md)
 {
     int ret;
+
+    if (md->coco_pd != NULL) {
+        ret = ibv_dealloc_pd(md->coco_pd);
+        /* Do not print a warning if PD deallocation failed with EINVAL, because
+         * it fails from time to time on BF/ARM (TODO: investigate) */
+        if ((ret != 0) && (errno != EINVAL)) {
+            ucs_warn("ibv_dealloc_pd(coco_pd) failed: %m");
+        }
+    }
 
     ret = ibv_dealloc_pd(md->pd);
     /* Do not print a warning if PD deallocation failed with EINVAL, because

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1309,7 +1309,7 @@ static ucs_status_t uct_ib_md_create_coco_pd(uct_ib_md_t *md)
 
     md->coco_pd = ibv_alloc_parent_domain(md->dev.ibv_context, &attr);
     if (md->coco_pd == NULL) {
-        ucs_error("%s: ibv_alloc_parent_domain() with CoCo unprotected allocation failed: %m",
+        ucs_debug("%s: ibv_alloc_parent_domain() with CoCo unprotected allocation failed: %m",
                   uct_ib_device_name(&md->dev));
         return UCS_ERR_UNSUPPORTED;
     }
@@ -1318,7 +1318,7 @@ static ucs_status_t uct_ib_md_create_coco_pd(uct_ib_md_t *md)
               uct_ib_device_name(&md->dev));
     return UCS_OK;
 #else
-    ucs_error("%s: device reports IBV_DEVICE_CC_DMA_BOUNCE but rdma-core lacks CoCo parent-domain APIs",
+    ucs_debug("%s: device reports IBV_DEVICE_CC_DMA_BOUNCE but rdma-core lacks CoCo parent-domain APIs",
               uct_ib_device_name(&md->dev));
     return UCS_ERR_UNSUPPORTED;
 #endif
@@ -1340,10 +1340,10 @@ static ucs_status_t uct_ib_md_probe_coco_control_cq(uct_ib_md_t *md)
     cq_ex = ibv_create_cq_ex(md->dev.ibv_context, &cq_attr);
     if (cq_ex == NULL) {
         saved_errno = errno;
-        errno       = saved_errno;
         if ((saved_errno == EOPNOTSUPP) || (saved_errno == ENOSYS) ||
             (saved_errno == EINVAL)) {
-            ucs_error("%s: CoCo control CQ probe requires ibv_create_cq_ex() "
+            errno = saved_errno;
+            ucs_debug("%s: CoCo control CQ probe requires ibv_create_cq_ex() "
                       "parent-domain support: %m",
                       uct_ib_device_name(&md->dev));
             return UCS_ERR_UNSUPPORTED;
@@ -1362,11 +1362,29 @@ static ucs_status_t uct_ib_md_probe_coco_control_cq(uct_ib_md_t *md)
               uct_ib_device_name(&md->dev));
     return UCS_OK;
 #else
-    ucs_error("%s: device reports IBV_DEVICE_CC_DMA_BOUNCE but rdma-core lacks "
+    ucs_debug("%s: device reports IBV_DEVICE_CC_DMA_BOUNCE but rdma-core lacks "
               "CoCo CQ parent-domain APIs",
               uct_ib_device_name(&md->dev));
     return UCS_ERR_UNSUPPORTED;
 #endif
+}
+
+static void uct_ib_md_dealloc_coco_pd(uct_ib_md_t *md)
+{
+    int ret;
+
+    if (md->coco_pd == NULL) {
+        return;
+    }
+
+    ret = ibv_dealloc_pd(md->coco_pd);
+    /* Do not print a warning if PD deallocation failed with EINVAL, because
+     * it fails from time to time on BF/ARM (TODO: investigate) */
+    if ((ret != 0) && (errno != EINVAL)) {
+        ucs_warn("ibv_dealloc_pd(coco_pd) failed: %m");
+    }
+
+    md->coco_pd = NULL;
 }
 
 ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
@@ -1407,7 +1425,7 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
 
         status = uct_ib_md_probe_coco_control_cq(md);
         if (status != UCS_OK) {
-            goto err_cleanup_device;
+            goto err_dealloc_coco_pd;
         }
     }
 
@@ -1416,7 +1434,7 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                                                &md->subnet_filter);
 
         if (status != UCS_OK) {
-            goto err_cleanup_device;
+            goto err_dealloc_coco_pd;
         }
 
         md->check_subnet_filter = 1;
@@ -1463,7 +1481,7 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                   "installed correctly, or dmabuf is supported.",
                   uct_ib_device_name(&md->dev));
         status = UCS_ERR_UNSUPPORTED;
-        goto err_cleanup_device;
+        goto err_dealloc_coco_pd;
     }
 
     md->dev.max_zcopy_log_sge = INT_MAX;
@@ -1475,6 +1493,8 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
 
     return UCS_OK;
 
+err_dealloc_coco_pd:
+    uct_ib_md_dealloc_coco_pd(md);
 err_cleanup_device:
     uct_ib_device_cleanup(&md->dev);
 err_release_stats:
@@ -1528,14 +1548,7 @@ void uct_ib_md_free(uct_ib_md_t *md)
 {
     int ret;
 
-    if (md->coco_pd != NULL) {
-        ret = ibv_dealloc_pd(md->coco_pd);
-        /* Do not print a warning if PD deallocation failed with EINVAL, because
-         * it fails from time to time on BF/ARM (TODO: investigate) */
-        if ((ret != 0) && (errno != EINVAL)) {
-            ucs_warn("ibv_dealloc_pd(coco_pd) failed: %m");
-        }
-    }
+    uct_ib_md_dealloc_coco_pd(md);
 
     ret = ibv_dealloc_pd(md->pd);
     /* Do not print a warning if PD deallocation failed with EINVAL, because

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1294,12 +1294,7 @@ void uct_ib_md_check_odp(uct_ib_md_t *md, const uct_ib_md_config_t *md_config)
 
 static int uct_ib_md_detect_cc_dma_bounce(uct_ib_md_t *md)
 {
-#if HAVE_DECL_IBV_DEVICE_CC_DMA_BOUNCE && HAVE_DECL_IBV_QUERY_DEVICE_EX
-    return !!(md->dev.dev_attr.device_cap_flags_ex &
-              IBV_DEVICE_CC_DMA_BOUNCE);
-#else
-    return 0;
-#endif
+    return uct_ib_device_is_cc_dma_bounce(&md->dev);
 }
 
 static ucs_status_t uct_ib_md_create_coco_pd(uct_ib_md_t *md)
@@ -1324,6 +1319,51 @@ static ucs_status_t uct_ib_md_create_coco_pd(uct_ib_md_t *md)
     return UCS_OK;
 #else
     ucs_error("%s: device reports IBV_DEVICE_CC_DMA_BOUNCE but rdma-core lacks CoCo parent-domain APIs",
+              uct_ib_device_name(&md->dev));
+    return UCS_ERR_UNSUPPORTED;
+#endif
+}
+
+static ucs_status_t uct_ib_md_probe_coco_control_cq(uct_ib_md_t *md)
+{
+#if HAVE_DECL_IBV_CREATE_CQ_EX && HAVE_DECL_IBV_CQ_INIT_ATTR_MASK_PD && \
+    HAVE_STRUCT_IBV_CQ_INIT_ATTR_EX_PARENT_DOMAIN
+    struct ibv_cq_init_attr_ex cq_attr = {
+        .cqe           = 1,
+        .comp_mask     = IBV_CQ_INIT_ATTR_MASK_PD,
+        .parent_domain = md->coco_pd
+    };
+    struct ibv_cq_ex *cq_ex;
+    struct ibv_cq *cq;
+    int saved_errno;
+
+    cq_ex = ibv_create_cq_ex(md->dev.ibv_context, &cq_attr);
+    if (cq_ex == NULL) {
+        saved_errno = errno;
+        errno       = saved_errno;
+        if ((saved_errno == EOPNOTSUPP) || (saved_errno == ENOSYS) ||
+            (saved_errno == EINVAL)) {
+            ucs_error("%s: CoCo control CQ probe requires ibv_create_cq_ex() "
+                      "parent-domain support: %m",
+                      uct_ib_device_name(&md->dev));
+            return UCS_ERR_UNSUPPORTED;
+        }
+
+        errno = saved_errno;
+        uct_ib_check_memlock_limit_msg(md->dev.ibv_context,
+                                       UCS_LOG_LEVEL_ERROR,
+                                       "ibv_create_cq_ex(cqe=%d)", 1);
+        return UCS_ERR_IO_ERROR;
+    }
+
+    cq = ibv_cq_ex_to_cq(cq_ex);
+    ibv_destroy_cq(cq);
+    ucs_debug("%s: CoCo control CQ probe succeeded",
+              uct_ib_device_name(&md->dev));
+    return UCS_OK;
+#else
+    ucs_error("%s: device reports IBV_DEVICE_CC_DMA_BOUNCE but rdma-core lacks "
+              "CoCo CQ parent-domain APIs",
               uct_ib_device_name(&md->dev));
     return UCS_ERR_UNSUPPORTED;
 #endif
@@ -1361,6 +1401,11 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
     md->cc_dma_bounce = uct_ib_md_detect_cc_dma_bounce(md);
     if (md->cc_dma_bounce) {
         status = uct_ib_md_create_coco_pd(md);
+        if (status != UCS_OK) {
+            goto err_cleanup_device;
+        }
+
+        status = uct_ib_md_probe_coco_control_cq(md);
         if (status != UCS_OK) {
             goto err_cleanup_device;
         }

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -147,6 +147,8 @@ typedef enum {
 typedef struct uct_ib_md {
     uct_md_t                 super;
     struct ibv_pd            *pd;       /**< IB memory domain */
+    struct ibv_pd            *coco_pd;  /**< CoCo parent PD for control objects */
+    int                      cc_dma_bounce; /**< Device requires CoCo DMA bounce */
     uct_ib_device_t          dev;       /**< IB device */
     ucs_linear_func_t        reg_cost;  /**< Memory registration cost */
     UCS_STATS_NODE_DECLARE(stats)
@@ -179,6 +181,19 @@ typedef struct uct_ib_md {
         uint32_t             size;
     } mkey_by_name_reserve;
 } uct_ib_md_t;
+
+
+static UCS_F_ALWAYS_INLINE int uct_ib_md_is_cc_dma_bounce(const uct_ib_md_t *md)
+{
+    return md->cc_dma_bounce;
+}
+
+static UCS_F_ALWAYS_INLINE struct ibv_pd*
+uct_ib_md_control_pd(const uct_ib_md_t *md)
+{
+    ucs_assert(!md->cc_dma_bounce || (md->coco_pd != NULL));
+    return (md->cc_dma_bounce && (md->coco_pd != NULL)) ? md->coco_pd : md->pd;
+}
 
 
 typedef struct {

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -199,6 +199,19 @@ static UCS_F_ALWAYS_INLINE int uct_ib_md_is_cc_dma_bounce(const uct_ib_md_t *md)
     return md->cc_dma_bounce;
 }
 
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_ib_md_check_cc_dma_bounce_supported(const uct_ib_md_t *md,
+                                        const char *transport_name)
+{
+    if (!uct_ib_md_is_cc_dma_bounce(md)) {
+        return UCS_OK;
+    }
+
+    ucs_error("%s: %s does not support CoCo control-object allocation",
+              uct_ib_device_name(&md->dev), transport_name);
+    return UCS_ERR_UNSUPPORTED;
+}
+
 static UCS_F_ALWAYS_INLINE struct ibv_pd*
 uct_ib_md_control_pd(const uct_ib_md_t *md)
 {

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -183,6 +183,17 @@ typedef struct uct_ib_md {
 } uct_ib_md_t;
 
 
+static UCS_F_ALWAYS_INLINE int
+uct_ib_device_is_cc_dma_bounce(const uct_ib_device_t *dev)
+{
+#if HAVE_DECL_IBV_DEVICE_CC_DMA_BOUNCE && HAVE_DECL_IBV_QUERY_DEVICE_EX
+    return !!(dev->dev_attr.device_cap_flags_ex &
+              IBV_DEVICE_CC_DMA_BOUNCE);
+#else
+    return 0;
+#endif
+}
+
 static UCS_F_ALWAYS_INLINE int uct_ib_md_is_cc_dma_bounce(const uct_ib_md_t *md)
 {
     return md->cc_dma_bounce;

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -13,6 +13,7 @@
 
 #include <uct/base/uct_md.h>
 #include <ucs/stats/stats.h>
+#include <string.h>
 
 #define UCT_IB_MD_MAX_MR_SIZE        0x80000000UL
 #define UCT_IB_MD_PACKED_RKEY_SIZE   sizeof(uint64_t)
@@ -199,6 +200,12 @@ static UCS_F_ALWAYS_INLINE int uct_ib_md_is_cc_dma_bounce(const uct_ib_md_t *md)
     return md->cc_dma_bounce;
 }
 
+static UCS_F_ALWAYS_INLINE int
+uct_ib_md_is_coco_hardened(const uct_ib_md_t *md)
+{
+    return md->cc_dma_bounce && (md->coco_pd != NULL);
+}
+
 static UCS_F_ALWAYS_INLINE ucs_status_t
 uct_ib_md_check_cc_dma_bounce_supported(const uct_ib_md_t *md,
                                         const char *transport_name)
@@ -215,8 +222,7 @@ uct_ib_md_check_cc_dma_bounce_supported(const uct_ib_md_t *md,
 static UCS_F_ALWAYS_INLINE struct ibv_pd*
 uct_ib_md_control_pd(const uct_ib_md_t *md)
 {
-    ucs_assert(!md->cc_dma_bounce || (md->coco_pd != NULL));
-    return (md->cc_dma_bounce && (md->coco_pd != NULL)) ? md->coco_pd : md->pd;
+    return uct_ib_md_is_coco_hardened(md) ? md->coco_pd : md->pd;
 }
 
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -13,7 +13,6 @@
 
 #include <uct/base/uct_md.h>
 #include <ucs/stats/stats.h>
-#include <string.h>
 
 #define UCT_IB_MD_MAX_MR_SIZE        0x80000000UL
 #define UCT_IB_MD_PACKED_RKEY_SIZE   sizeof(uint64_t)

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -189,10 +189,13 @@ AS_IF([test "x$with_ib" = "xyes"],
                            MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE,
                            MLX5DV_QP_CREATE_ALLOW_SCATTER_TO_CQE,
                            MLX5DV_UMEM_MASK_DMABUF,
-                           mlx5dv_devx_umem_reg_ex,
                            MLX5DV_UAR_ALLOC_TYPE_BF,
                            MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED],
                                   [], [], [[#include <infiniband/mlx5dv.h>]])
+                       save_LIBS="$LIBS"
+                       LIBS="$LIB_MLX5 $LIBS"
+                       AC_CHECK_FUNCS([mlx5dv_devx_umem_reg_ex])
+                       LIBS="$save_LIBS"
                        AC_CHECK_TYPES([struct mlx5dv_devx_umem_in],
                                   [], [], [[#include <infiniband/mlx5dv.h>]])
                        AC_CHECK_MEMBERS([struct mlx5dv_cq.cq_uar],

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -150,6 +150,17 @@ AS_IF([test "x$with_ib" = "xyes"],
        AC_CHECK_DECLS([IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN],
                       [have_cq_io=yes], [], [[#include <infiniband/verbs.h>]])
 
+       AC_CHECK_HEADERS([linux/dma-heap.h])
+
+       AC_CHECK_DECLS([IBV_DEVICE_CC_DMA_BOUNCE,
+                       IBV_PARENT_DOMAIN_INIT_ATTR_ALLOW_CC_UNPROTECTED_ALLOC,
+                       IBV_CQ_INIT_ATTR_MASK_PD,
+                       ibv_alloc_parent_domain],
+                      [], [], [[#include <infiniband/verbs.h>]])
+
+       AC_CHECK_MEMBERS([struct ibv_cq_init_attr_ex.parent_domain],
+                        [], [], [[#include <infiniband/verbs.h>]])
+
        AS_IF([test "x$with_mlx5" != xno], [
               have_mlx5=yes
 
@@ -178,8 +189,11 @@ AS_IF([test "x$with_ib" = "xyes"],
                            MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE,
                            MLX5DV_QP_CREATE_ALLOW_SCATTER_TO_CQE,
                            MLX5DV_UMEM_MASK_DMABUF,
+                           mlx5dv_devx_umem_reg_ex,
                            MLX5DV_UAR_ALLOC_TYPE_BF,
                            MLX5DV_UAR_ALLOC_TYPE_NC_DEDICATED],
+                                  [], [], [[#include <infiniband/mlx5dv.h>]])
+                       AC_CHECK_TYPES([struct mlx5dv_devx_umem_in],
                                   [], [], [[#include <infiniband/mlx5dv.h>]])
                        AC_CHECK_MEMBERS([struct mlx5dv_cq.cq_uar],
                                   [], [], [[#include <infiniband/mlx5dv.h>]])

--- a/src/uct/ib/mlx5/Makefile.am
+++ b/src/uct/ib/mlx5/Makefile.am
@@ -30,6 +30,14 @@ noinst_HEADERS = \
 	dv/ib_mlx5_dv.h \
 	dv/ib_mlx5_ifc.h
 
+if HAVE_DEVX
+noinst_HEADERS += \
+	ib_mlx5_coco.h
+
+libuct_ib_mlx5_la_SOURCES += \
+	ib_mlx5_coco.c
+endif # HAVE_DEVX
+
 if HAVE_TL_RC
 noinst_HEADERS += \
 	rc/rc_mlx5.h \

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1586,6 +1586,12 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
 
     ucs_trace_func("");
 
+    if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
+        ucs_error("%s: %s is not CoCo control-object safe in this milestone",
+                  uct_ib_device_name(&md->super.dev), "dc_mlx5");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     self->tx.policy = config->tx_policy;
     self->tx.ndci   = uct_dc_mlx5_iface_is_hw_dcs(self) ? 1 : config->ndci;
 

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1812,7 +1812,7 @@ uct_dc_mlx5_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_
         return UCS_ERR_NO_DEVICE;
     }
 
-    if (!uct_ib_md_coco_transport_allowed(ib_md, "dc_mlx5")) {
+    if (uct_ib_md_is_coco_hardened(ib_md)) {
         return UCS_ERR_NO_DEVICE;
     }
 

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1586,10 +1586,9 @@ static UCS_CLASS_INIT_FUNC(uct_dc_mlx5_iface_t, uct_md_h tl_md, uct_worker_h wor
 
     ucs_trace_func("");
 
-    if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
-        ucs_error("%s: %s is not CoCo control-object safe in this milestone",
-                  uct_ib_device_name(&md->super.dev), "dc_mlx5");
-        return UCS_ERR_UNSUPPORTED;
+    status = uct_ib_md_check_cc_dma_bounce_supported(&md->super, "dc_mlx5");
+    if (status != UCS_OK) {
+        return status;
     }
 
     self->tx.policy = config->tx_policy;

--- a/src/uct/ib/mlx5/dc/dc_mlx5.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5.c
@@ -1812,6 +1812,10 @@ uct_dc_mlx5_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_
         return UCS_ERR_NO_DEVICE;
     }
 
+    if (!uct_ib_md_coco_transport_allowed(ib_md, "dc_mlx5")) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
     flags = UCT_IB_DEVICE_FLAG_SRQ | UCT_IB_DEVICE_FLAG_MLX5_PRM |
             UCT_IB_DEVICE_FLAG_DC |
             (ib_md->config.eth_pause ? 0 : UCT_IB_DEVICE_FLAG_LINK_IB);

--- a/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_dv.c
@@ -141,6 +141,9 @@ ucs_status_t uct_ib_mlx5_devx_create_qp_common(uct_ib_iface_t *iface,
     uct_ib_mlx5_mmio_mode_t mmio_mode;
     uct_ib_mlx5_devx_uar_t *uar;
     ucs_status_t status;
+    uct_ib_mlx5_coco_qp_req_t coco_req;
+    uint32_t wq_umem_id;
+    uint32_t qpn;
     void *qpc;
 
     uct_ib_iface_fill_attr(iface, &attr->super);
@@ -206,10 +209,12 @@ ucs_status_t uct_ib_mlx5_devx_create_qp_common(uct_ib_iface_t *iface,
         UCT_IB_MLX5DV_SET(qpc, qpc, no_sq, true);
         UCT_IB_MLX5DV_SET(qpc, qpc, offload_type, true);
         UCT_IB_MLX5DV_SET(create_qp_in, in, wq_umem_id, md->zero_mem.mem->umem_id);
+        wq_umem_id = md->zero_mem.mem->umem_id;
     } else {
         UCT_IB_MLX5DV_SET(create_qp_in, in, wq_umem_id, qp->devx.mem.mem->umem_id);
         UCT_IB_MLX5DV_SET64(create_qp_in, in, wq_umem_offset,
                             attr->umem_offset);
+        wq_umem_id = qp->devx.mem.mem->umem_id;
     }
 
     if (md->super.ece_enable) {
@@ -217,6 +222,21 @@ ucs_status_t uct_ib_mlx5_devx_create_qp_common(uct_ib_iface_t *iface,
                           UCT_IB_MLX5_DEVX_ECE_TRIG_RESP);
     }
 
+    coco_req.qp_type      = attr->super.qp_type;
+    coco_req.send_cqn     = send_cq->cq_num;
+    coco_req.recv_cqn     = recv_cq->cq_num;
+    coco_req.rmpn         = attr->super.srq_num;
+    coco_req.wq_umem_id   = wq_umem_id;
+    coco_req.dbr_umem_id  = qp->devx.dbrec->mem_id;
+    coco_req.sq_wqe_count = (attr->max_tx == 0) ? 1 : attr->max_tx;
+    coco_req.rq_wqe_count = 0;
+    if (uct_ib_md_is_coco_hardened(&md->super) &&
+        (attr->super.qp_type != IBV_QPT_RC)) {
+        status = UCS_ERR_UNSUPPORTED;
+        goto err_uar;
+    }
+
+    qp->qp_num   = 0;
     qp->devx.obj = uct_ib_mlx5_devx_obj_create(dev->ibv_context, in,
                                                sizeof(in), out, sizeof(out),
                                                "QP", UCS_LOG_LEVEL_ERROR);
@@ -225,7 +245,16 @@ ucs_status_t uct_ib_mlx5_devx_create_qp_common(uct_ib_iface_t *iface,
         goto err_uar;
     }
 
-    qp->qp_num = UCT_IB_MLX5DV_GET(create_qp_out, out, qpn);
+    if (uct_ib_md_is_coco_hardened(&md->super)) {
+        status = uct_ib_mlx5_coco_validate_qp_output(md, &coco_req, out,
+                                                     sizeof(out), &qpn);
+        if (status != UCS_OK) {
+            goto err_free;
+        }
+    } else {
+        qpn = UCT_IB_MLX5DV_GET(create_qp_out, out, qpn);
+    }
+    qp->qp_num = qpn;
 
     if (attr->super.qp_type == IBV_QPT_RC) {
         qpc = UCT_IB_MLX5DV_ADDR_OF(rst2init_qp_in, in_2init, qpc);
@@ -269,6 +298,9 @@ ucs_status_t uct_ib_mlx5_devx_create_qp_common(uct_ib_iface_t *iface,
     return UCS_OK;
 
 err_free:
+    if (uct_ib_md_is_coco_hardened(&md->super) && (qp->qp_num != 0)) {
+        (void)uct_ib_mlx5_coco_qpn_record_remove(md->coco, qp->qp_num);
+    }
     uct_ib_mlx5_devx_obj_destroy(qp->devx.obj, "QP");
 err_uar:
     uct_worker_tl_data_put(uar, uct_ib_mlx5_devx_uar_cleanup);
@@ -420,6 +452,7 @@ void uct_ib_mlx5_devx_destroy_qp_common(uct_ib_mlx5_qp_t *qp)
 void uct_ib_mlx5_devx_destroy_qp(uct_ib_mlx5_md_t *md, uct_ib_mlx5_qp_t *qp)
 {
     uct_ib_mlx5_devx_destroy_qp_common(qp);
+    (void)uct_ib_mlx5_coco_qpn_record_remove(md->coco, qp->qp_num);
     uct_ib_mlx5_put_dbrec(qp->devx.dbrec);
     uct_ib_mlx5_md_buf_free(md, qp->devx.wq_buf, &qp->devx.mem);
 }
@@ -574,7 +607,9 @@ uct_ib_mlx5_devx_create_cq_common(uct_ib_iface_t *iface, uct_ib_dir_t dir,
     int num_comp_vectors = dev->ibv_context->num_comp_vectors;
     int log_cq_size;
     ucs_status_t status;
+    uct_ib_mlx5_coco_cq_req_t coco_req;
     uint32_t eqn;
+    uint32_t cqn;
 
     log_cq_size = ucs_ilog2(attr->cq_size);
     UCT_IB_MLX5DV_SET(create_cq_in, in, opcode, UCT_IB_MLX5_CMD_OP_CREATE_CQ);
@@ -622,6 +657,15 @@ uct_ib_mlx5_devx_create_cq_common(uct_ib_iface_t *iface, uct_ib_dir_t dir,
         UCT_IB_MLX5DV_SET(cqc, cqctx, oi, 1);
     }
 
+    coco_req.cq_len         = attr->cq_size;
+    coco_req.cqe_size       = attr->cqe_size;
+    coco_req.cq_umem_id     = cq->devx.mem.mem->umem_id;
+    coco_req.cq_umem_offset = attr->umem_offset;
+    coco_req.dbr_umem_id    = cq->devx.dbrec->mem_id;
+    coco_req.dbr_offset     = cq->devx.dbrec->offset;
+    coco_req.eqn            = eqn;
+    coco_req.uar_page       = cq->devx.uar->uar->page_id;
+
     cq->devx.obj = uct_ib_mlx5_devx_obj_create(dev->ibv_context, in,
                                                sizeof(in), out, sizeof(out),
                                                "CQ", UCS_LOG_LEVEL_ERROR);
@@ -630,9 +674,19 @@ uct_ib_mlx5_devx_create_cq_common(uct_ib_iface_t *iface, uct_ib_dir_t dir,
         goto err_uar;
     }
 
+    if (uct_ib_md_is_coco_hardened(&md->super)) {
+        status = uct_ib_mlx5_coco_validate_cq_output(md, &coco_req, out,
+                                                     sizeof(out), &cqn);
+        if (status != UCS_OK) {
+            goto err_obj;
+        }
+    } else {
+        cqn = UCT_IB_MLX5DV_GET(create_cq_out, out, cqn);
+    }
+
     uct_ib_mlx5_init_cq_common(cq, attr->cq_size, attr->cqe_size,
-                               UCT_IB_MLX5DV_GET(create_cq_out, out, cqn),
-                               cq->devx.cq_buf, cq->devx.uar->uar->base_addr,
+                               cqn, cq->devx.cq_buf,
+                               cq->devx.uar->uar->base_addr,
                                cq->devx.dbrec->db,
                                !!(attr->flags & UCT_IB_MLX5_CQ_CQE_ZIP));
 
@@ -641,6 +695,8 @@ uct_ib_mlx5_devx_create_cq_common(uct_ib_iface_t *iface, uct_ib_dir_t dir,
     cq->type                       = UCT_IB_MLX5_OBJ_TYPE_DEVX;
     return UCS_OK;
 
+err_obj:
+    uct_ib_mlx5_devx_obj_destroy(cq->devx.obj, "CQ");
 err_uar:
     uct_worker_tl_data_put(cq->devx.uar, uct_ib_mlx5_devx_uar_cleanup);
 err:
@@ -706,6 +762,7 @@ void uct_ib_mlx5_devx_destroy_cq_common(uct_ib_mlx5_cq_t *cq)
 void uct_ib_mlx5_devx_destroy_cq(uct_ib_mlx5_md_t *md, uct_ib_mlx5_cq_t *cq)
 {
     uct_ib_mlx5_devx_destroy_cq_common(cq);
+    (void)uct_ib_mlx5_coco_cqn_record_remove(md->coco, cq->cq_num);
     uct_ib_mlx5_put_dbrec(cq->devx.dbrec);
     uct_ib_mlx5_md_buf_free(md, cq->devx.cq_buf, &cq->devx.mem);
 }

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -685,6 +685,8 @@ uct_ib_mlx5_devx_reg_mt(uct_ib_mlx5_md_t *md, void *address, size_t length,
         goto err_dereg;
     }
 
+    ksm_data->lkey = *mkey_p;
+    ksm_data->rkey = *mkey_p;
     *ksm_data_p = ksm_data;
     return UCS_OK;
 
@@ -838,6 +840,10 @@ uct_ib_mlx5_devx_reg_mr(uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mem_t *memh,
     ucs_status_t status;
     uint32_t mkey;
 
+    if (uct_ib_md_is_coco_hardened(&md->super)) {
+        access_flags = uct_ib_mlx5_coco_mkey_sanitize_access(access_flags);
+    }
+
     if ((length >= md->super.config.min_mt_reg) &&
         !(access_flags & IBV_ACCESS_ON_DEMAND) &&
         !uct_ib_mlx5_devx_symmetric_rkey(md, flags)) {
@@ -850,6 +856,13 @@ uct_ib_mlx5_devx_reg_mr(uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mem_t *memh,
         if (status == UCS_OK) {
             *rkey_p = *lkey_p = mkey;
             memh->super.flags |= UCT_IB_MEM_MULTITHREADED;
+            status = uct_ib_mlx5_coco_mkey_record_add(
+                    md->coco, *lkey_p, *rkey_p, address, length, access_flags);
+            if (status != UCS_OK) {
+                (void)uct_ib_mlx5_devx_dereg_mt(
+                        md, memh->mrs[mr_type].ksm_data);
+                return status;
+            }
             return UCS_OK;
         } else if (status != UCS_ERR_UNSUPPORTED) {
             return status;
@@ -875,6 +888,13 @@ uct_ib_mlx5_devx_reg_mr(uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mem_t *memh,
 out:
     *lkey_p = memh->mrs[mr_type].super.ib->lkey;
     *rkey_p = memh->mrs[mr_type].super.ib->rkey;
+    status = uct_ib_mlx5_coco_mkey_record_add(md->coco, *lkey_p, *rkey_p,
+                                              address, length, access_flags);
+    if (status != UCS_OK) {
+        (void)uct_ib_dereg_mr(memh->mrs[mr_type].super.ib);
+        return status;
+    }
+
     return UCS_OK;
 }
 
@@ -882,10 +902,26 @@ static ucs_status_t uct_ib_mlx5_devx_dereg_mr(uct_ib_mlx5_md_t *md,
                                               uct_ib_mlx5_devx_mem_t *memh,
                                               uct_ib_mr_type_t mr_type)
 {
+    ucs_status_t status;
+
     if (memh->super.flags & UCT_IB_MEM_MULTITHREADED) {
-        return uct_ib_mlx5_devx_dereg_mt(md, memh->mrs[mr_type].ksm_data);
+        uint32_t lkey = memh->mrs[mr_type].ksm_data->lkey;
+        uint32_t rkey = memh->mrs[mr_type].ksm_data->rkey;
+
+        status = uct_ib_mlx5_devx_dereg_mt(md, memh->mrs[mr_type].ksm_data);
+        if (status == UCS_OK) {
+            (void)uct_ib_mlx5_coco_mkey_record_remove(md->coco, lkey, rkey);
+        }
+        return status;
     } else {
-        return uct_ib_dereg_mr(memh->mrs[mr_type].super.ib);
+        uint32_t lkey = memh->mrs[mr_type].super.ib->lkey;
+        uint32_t rkey = memh->mrs[mr_type].super.ib->rkey;
+
+        status = uct_ib_dereg_mr(memh->mrs[mr_type].super.ib);
+        if (status == UCS_OK) {
+            (void)uct_ib_mlx5_coco_mkey_record_remove(md->coco, lkey, rkey);
+        }
+        return status;
     }
 }
 
@@ -2591,6 +2627,11 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
         goto err_lru_cleanup;
     }
 
+    status = uct_ib_mlx5_coco_state_init(md);
+    if (status != UCS_OK) {
+        goto err_md_close_common;
+    }
+
     uct_ib_mlx5_md_port_counter_set_id_init(md);
     ucs_recursive_spinlock_init(&md->dbrec_lock, 0);
     ucs_mpool_params_reset(&mp_params);
@@ -2679,6 +2720,8 @@ err_dbrec_mpool_cleanup:
     ucs_mpool_cleanup(&md->dbrec_pool, 0);
 err_lock_destroy:
     ucs_recursive_spinlock_destroy(&md->dbrec_lock);
+    uct_ib_mlx5_coco_state_cleanup(md);
+err_md_close_common:
     uct_ib_md_close_common(&md->super);
 err_lru_cleanup:
     uct_ib_mlx5_devx_mr_lru_cleanup(md);
@@ -2731,6 +2774,7 @@ void uct_ib_mlx5_devx_md_close(uct_md_h tl_md)
     ucs_mpool_cleanup(&md->dbrec_pool, 1);
     ucs_recursive_spinlock_destroy(&md->dbrec_lock);
     uct_ib_mlx5_devx_umr_cleanup(md);
+    uct_ib_mlx5_coco_state_cleanup(md);
     uct_ib_md_close_common(&md->super);
     uct_ib_mlx5_devx_mr_lru_cleanup(md);
     uct_ib_md_free(&md->super);
@@ -2956,6 +3000,13 @@ uct_ib_mlx5_devx_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
 
     flags = UCS_PARAM_VALUE(UCT_MD_MKEY_PACK_FIELD, params, flags, FLAGS, 0);
     if (flags & UCT_MD_MKEY_PACK_FLAG_EXPORT) {
+        if (uct_ib_md_is_coco_hardened(&md->super)) {
+            ucs_error("%s: exporting CoCo memory keys requires bounded "
+                      "metadata and is disabled",
+                      uct_ib_device_name(&md->super.dev));
+            return UCS_ERR_UNSUPPORTED;
+        }
+
         if (uct_ib_mlx5_devx_has_dm(memh)) {
             ucs_error("%s: cannot export memory allocated on the device "
                       "(address %p length %zu)",
@@ -3001,6 +3052,7 @@ uct_ib_mlx5_devx_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
          uct_ib_mlx5_devx_memh_has_ro(md, memh)) &&
         !(memh->super.flags & UCT_IB_MEM_IMPORTED) &&
         !(memh->super.flags & UCT_IB_MEM_DIRECT_NIC) &&
+        !uct_ib_md_is_coco_hardened(&md->super) &&
         md->super.config.enable_indirect_atomic &&
         ucs_test_all_flags(md->flags,
                            UCT_IB_MLX5_MD_FLAG_KSM |
@@ -3077,6 +3129,12 @@ ucs_status_t uct_ib_mlx5_devx_mem_attach(uct_md_h uct_md,
     ucs_status_t status;
     void *access_key;
     int ret;
+
+    if (uct_ib_md_is_coco_hardened(&md->super)) {
+        ucs_error("%s: importing CoCo memory keys requires bounded metadata "
+                  "and is disabled", uct_ib_device_name(&md->super.dev));
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     status = uct_ib_mlx5_devx_memh_alloc(md, 0, 0, 0, &memh);
     if (status != UCS_OK) {

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1915,19 +1915,25 @@ struct ibv_context* uct_ib_mlx5_devx_open_device(struct ibv_device *ibv_device)
 }
 
 static ucs_status_t
-uct_ib_mlx5_devx_check_event_channel(struct ibv_context *ctx)
+uct_ib_mlx5_devx_check_event_channel(struct ibv_context *ctx,
+                                     int is_coco_context)
 {
     struct mlx5dv_devx_event_channel *event_channel;
     struct ibv_cq *cq;
 
-    cq = ibv_create_cq(ctx, 1, NULL, NULL, 0);
-    if (cq == NULL) {
-        uct_ib_check_memlock_limit_msg(ctx, UCS_LOG_LEVEL_DEBUG,
-                                       "ibv_create_cq()");
-        return UCS_ERR_UNSUPPORTED;
-    }
+    if (!is_coco_context) {
+        cq = ibv_create_cq(ctx, 1, NULL, NULL, 0);
+        if (cq == NULL) {
+            uct_ib_check_memlock_limit_msg(ctx, UCS_LOG_LEVEL_DEBUG,
+                                           "ibv_create_cq()");
+            return UCS_ERR_UNSUPPORTED;
+        }
 
-    ibv_destroy_cq(cq);
+        ibv_destroy_cq(cq);
+    } else {
+        ucs_debug("%s: skipping plain CQ DEVX probe in CoCo DMA-bounce mode",
+                  ibv_get_device_name(ctx->device));
+    }
 
     event_channel = mlx5dv_devx_create_event_channel(
             ctx, MLX5_IB_UAPI_DEVX_CR_EV_CH_FLAGS_OMIT_DATA);
@@ -2345,11 +2351,6 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
         goto err_free_buffer;
     }
 
-    status = uct_ib_mlx5_devx_check_event_channel(ctx);
-    if (status != UCS_OK) {
-        goto err_free_context;
-    }
-
     md = ucs_derived_of(uct_ib_md_alloc(size, name, ctx), uct_ib_mlx5_md_t);
     if (md == NULL) {
         status = UCS_ERR_NO_MEMORY;
@@ -2366,6 +2367,12 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
     uct_ib_mlx5_devx_mr_lru_init(md);
 
     status = uct_ib_device_query(dev, ibv_device);
+    if (status != UCS_OK) {
+        goto err_lru_cleanup;
+    }
+
+    status = uct_ib_mlx5_devx_check_event_channel(
+            ctx, uct_ib_device_is_cc_dma_bounce(dev));
     if (status != UCS_OK) {
         goto err_lru_cleanup;
     }

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -13,6 +13,7 @@
 #include <uct/api/device/uct_device_types.h>
 
 #include <ucs/arch/bitops.h>
+#include <ucs/datastruct/mpool.inl>
 #include <ucs/profile/profile.h>
 #include <ucs/sys/ptr_arith.h>
 #include <ucs/time/time.h>
@@ -93,6 +94,8 @@ static const char uct_ib_mkey_token[] = "uct_ib_mkey_token";
 
 typedef struct uct_ib_mlx5_dbrec_page {
     uct_ib_mlx5_devx_umem_t    mem;
+    volatile uint32_t          *db;
+    unsigned                   num_dbrecs;
 } uct_ib_mlx5_dbrec_page_t;
 
 
@@ -1697,36 +1700,58 @@ static ucs_status_t uct_ib_mlx5_add_page(ucs_mpool_t *mp, size_t *size_p, void *
 {
     uct_ib_mlx5_md_t *md = ucs_container_of(mp, uct_ib_mlx5_md_t, dbrec_pool);
     uct_ib_mlx5_dbrec_page_t *page;
-    size_t size = ucs_align_up(*size_p + sizeof(*page), ucs_get_page_size());
-    uct_ib_mlx5_devx_umem_t mem;
+    size_t private_size = *size_p;
+    size_t db_size;
+    void *db;
     ucs_status_t status;
 
-    status = uct_ib_mlx5_md_buf_alloc(md, size, 1, (void**)&page, &mem, 0,
-                                      "devx dbrec");
-    if (status != UCS_OK) {
-        return status;
+    page = ucs_calloc(1, private_size + sizeof(*page),
+                      "devx dbrec private page");
+    if (page == NULL) {
+        return UCS_ERR_NO_MEMORY;
     }
 
-    page->mem = mem;
-    *size_p   = size - sizeof(*page);
-    *page_p   = page + 1;
+    page->num_dbrecs = ucs_mpool_num_elems_per_chunk(
+            mp, (ucs_mpool_chunk_t*)(page + 1), private_size);
+    db_size          = ucs_align_up(page->num_dbrecs * 2 * sizeof(*page->db),
+                                    ucs_get_page_size());
+
+    status = uct_ib_mlx5_md_buf_alloc(md, db_size, 1, &db, &page->mem, 0,
+                                      "devx dbrec");
+    if (status != UCS_OK) {
+        goto err_free_page;
+    }
+
+    page->db = db;
+    *page_p  = page + 1;
     return UCS_OK;
+
+err_free_page:
+    ucs_free(page);
+    return status;
 }
 
 static void uct_ib_mlx5_init_dbrec(ucs_mpool_t *mp, void *obj, void *chunk)
 {
+    ucs_mpool_chunk_t *mpool_chunk = chunk;
     uct_ib_mlx5_dbrec_page_t *page = (uct_ib_mlx5_dbrec_page_t*)chunk - 1;
     uct_ib_mlx5_dbrec_t *dbrec     = obj;
+    size_t index;
 
+    index        = UCS_PTR_BYTE_DIFF(mpool_chunk->elems, obj) /
+                   ucs_mpool_elem_total_size(mp->data);
+    ucs_assert(index < page->num_dbrecs);
+    dbrec->db     = page->db + (index * 2);
     dbrec->mem_id = page->mem.mem->umem_id;
-    dbrec->offset = UCS_PTR_BYTE_DIFF(chunk, obj) + sizeof(*page);
+    dbrec->offset = index * 2 * sizeof(*page->db);
 }
 
 static void uct_ib_mlx5_free_page(ucs_mpool_t *mp, void *chunk)
 {
     uct_ib_mlx5_md_t *md = ucs_container_of(mp, uct_ib_mlx5_md_t, dbrec_pool);
     uct_ib_mlx5_dbrec_page_t *page = (uct_ib_mlx5_dbrec_page_t*)chunk - 1;
-    uct_ib_mlx5_md_buf_free(md, page, &page->mem);
+    uct_ib_mlx5_md_buf_free(md, (void*)page->db, &page->mem);
+    ucs_free(page);
 }
 
 static ucs_mpool_ops_t uct_ib_mlx5_dbrec_ops = {

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -273,13 +273,19 @@ uct_ib_mlx5_res_domain_init(uct_ib_mlx5_res_domain_t *res_domain,
     if (res_domain->td == NULL) {
         ucs_debug("ibv_alloc_td() on %s failed: %m",
                   uct_ib_device_name(&md->dev));
-        res_domain->pd = md->pd;
+        res_domain->pd = uct_ib_md_control_pd(md);
         return UCS_OK;
     }
 
-    attr.td = res_domain->td;
-    attr.pd = md->pd;
+    attr.td        = res_domain->td;
+    attr.pd        = md->pd;
     attr.comp_mask = 0;
+#if HAVE_DECL_IBV_PARENT_DOMAIN_INIT_ATTR_ALLOW_CC_UNPROTECTED_ALLOC
+    if (uct_ib_md_is_cc_dma_bounce(md)) {
+        attr.comp_mask |=
+            IBV_PARENT_DOMAIN_INIT_ATTR_ALLOW_CC_UNPROTECTED_ALLOC;
+    }
+#endif
     res_domain->pd = ibv_alloc_parent_domain(md->dev.ibv_context, &attr);
     if (res_domain->pd == NULL) {
         ucs_error("ibv_alloc_parent_domain() on %s failed: %m",

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -495,7 +495,7 @@ typedef struct uct_ib_mlx5_iface_config {
  * MLX5 DoorBell record
  */
 typedef struct uct_ib_mlx5_dbrec {
-   volatile uint32_t  db[2];
+   volatile uint32_t  *db;
    uint32_t           mem_id;
    size_t             offset;
    uct_ib_mlx5_md_t   *md;

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -13,6 +13,7 @@
 #include <uct/base/uct_worker.h>
 #include <uct/ib/base/ib_log.h>
 #include <uct/ib/base/ib_device.h>
+#include <uct/ib/mlx5/ib_mlx5_coco.h>
 #include <uct/ib/mlx5/dv/ib_mlx5_ifc.h>
 #include <ucs/arch/cpu.h>
 #include <ucs/debug/log.h>
@@ -278,6 +279,8 @@ typedef struct uct_ib_mlx5_dma_seg {
 #if HAVE_DEVX
 typedef struct {
     struct mlx5dv_devx_obj *dvmr;
+    uint32_t               lkey;
+    uint32_t               rkey;
     int                    mr_num;
     size_t                 length;
     struct ibv_mr          *mrs[];
@@ -339,12 +342,13 @@ typedef struct {
 } uct_ib_mlx5_devx_mem_t;
 
 
-typedef struct {
+typedef struct uct_ib_mlx5_devx_umem {
     struct mlx5dv_devx_umem  *mem;
     size_t                   size;
     size_t                   mmap_size;
     int                      dmabuf_fd;
     int                      is_dmabuf;
+    uct_ib_mlx5_coco_shared_alloc_t *coco_shared;
 } uct_ib_mlx5_devx_umem_t;
 
 
@@ -412,6 +416,7 @@ typedef struct uct_ib_mlx5_md {
     uint32_t                  flags;
     ucs_mpool_t               dbrec_pool;
     ucs_recursive_spinlock_t  dbrec_lock;
+    uct_ib_mlx5_coco_state_t  *coco;
     uct_ib_port_select_mode_t port_select_mode;
     ucs_sys_device_t          direct_nic_sys_dev;
 #if HAVE_DEVX
@@ -1111,6 +1116,7 @@ uct_ib_mlx5_devx_umem_reset(uct_ib_mlx5_devx_umem_t *mem)
     mem->mmap_size = 0;
     mem->dmabuf_fd = UCT_IB_MLX5_INVALID_DMABUF_FD;
     mem->is_dmabuf = 0;
+    mem->coco_shared = NULL;
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
@@ -1128,151 +1134,6 @@ uct_ib_mlx5_devx_umem_reg_status(int sys_errno)
     return (sys_errno == ENOMEM) ? UCS_ERR_NO_MEMORY : UCS_ERR_IO_ERROR;
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
-uct_ib_mlx5_md_buf_alloc_shared(uct_ib_mlx5_md_t *md, size_t size, int silent,
-                                void **buf_p, uct_ib_mlx5_devx_umem_t *mem,
-                                int access_mode, char *name)
-{
-    const ucs_log_level_t level = silent ? UCS_LOG_LEVEL_DEBUG :
-                                           UCS_LOG_LEVEL_ERROR;
-    const char *alloc_name      = (name != NULL) ? name : "unknown";
-#if HAVE_LINUX_DMA_HEAP_H && HAVE_DECL_MLX5DV_DEVX_UMEM_REG_EX && \
-    HAVE_DECL_MLX5DV_UMEM_MASK_DMABUF && HAVE_STRUCT_MLX5DV_DEVX_UMEM_IN
-    struct ibv_context *ibv_context = md->super.dev.ibv_context;
-    struct mlx5dv_devx_umem_in umem_in;
-    struct dma_heap_allocation_data heap_data;
-    ucs_status_t status;
-    void *buf = NULL;
-    size_t mmap_size;
-    int reg_errno;
-    int heap_fd;
-    int ret;
-
-    uct_ib_mlx5_devx_umem_reset(mem);
-    *buf_p = NULL;
-
-    mmap_size = ucs_align_up(size, ucs_get_page_size());
-    heap_fd   = open(UCT_IB_MLX5_CC_DMA_HEAP, O_RDWR | O_CLOEXEC);
-    if (heap_fd < 0) {
-        status = (errno == ENOENT) ? UCS_ERR_UNSUPPORTED : UCS_ERR_IO_ERROR;
-        ucs_log(level, "failed to open %s for %s: %m",
-                UCT_IB_MLX5_CC_DMA_HEAP, alloc_name);
-        return status;
-    }
-
-    memset(&heap_data, 0, sizeof(heap_data));
-    heap_data.len      = mmap_size;
-    heap_data.fd_flags = O_RDWR | O_CLOEXEC;
-
-    ret = ioctl(heap_fd, DMA_HEAP_IOCTL_ALLOC, &heap_data);
-    if (ret != 0) {
-        status = (errno == ENOMEM) ? UCS_ERR_NO_MEMORY : UCS_ERR_IO_ERROR;
-        ucs_log(level, "DMA_HEAP_IOCTL_ALLOC(%s, name=%s size=%zu) failed: %m",
-                UCT_IB_MLX5_CC_DMA_HEAP, alloc_name, mmap_size);
-        ret = close(heap_fd);
-        if (ret != 0) {
-            ucs_warn("close(dma_heap_fd=%d) failed: %m", heap_fd);
-        }
-        return status;
-    }
-
-    ret = close(heap_fd);
-    if (ret != 0) {
-        ucs_warn("close(dma_heap_fd=%d) failed: %m", heap_fd);
-    }
-
-    mem->dmabuf_fd = heap_data.fd;
-    buf = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED,
-               mem->dmabuf_fd, 0);
-    if (buf == MAP_FAILED) {
-        status = (errno == ENOMEM) ? UCS_ERR_NO_MEMORY : UCS_ERR_IO_ERROR;
-        ucs_log(level, "mmap(name=%s dmabuf_fd=%d size=%zu) failed: %m",
-                alloc_name, mem->dmabuf_fd, mmap_size);
-        buf = NULL;
-        ret = close(mem->dmabuf_fd);
-        if (ret != 0) {
-            ucs_warn("close(dmabuf_fd=%d) failed: %m", mem->dmabuf_fd);
-        }
-        uct_ib_mlx5_devx_umem_reset(mem);
-        return status;
-    }
-
-    memset(buf, 0, mmap_size);
-
-    if (md->super.fork_init) {
-        ret = madvise(buf, mmap_size, MADV_DONTFORK);
-        if (ret != 0) {
-            status = UCS_ERR_IO_ERROR;
-            ucs_log(level, "madvise(DONTFORK, buf=%p, len=%zu) failed: %m",
-                    buf, mmap_size);
-            ret = munmap(buf, mmap_size);
-            if (ret != 0) {
-                ucs_warn("munmap(buf=%p, len=%zu) failed: %m", buf,
-                         mmap_size);
-            }
-            ret = close(mem->dmabuf_fd);
-            if (ret != 0) {
-                ucs_warn("close(dmabuf_fd=%d) failed: %m", mem->dmabuf_fd);
-            }
-            uct_ib_mlx5_devx_umem_reset(mem);
-            return status;
-        }
-    }
-
-    memset(&umem_in, 0, sizeof(umem_in));
-    umem_in.addr        = NULL;
-    umem_in.size        = mmap_size;
-    umem_in.access      = access_mode;
-    umem_in.pgsz_bitmap = UINT64_MAX & ~(ucs_get_page_size() - 1);
-    umem_in.comp_mask   = MLX5DV_UMEM_MASK_DMABUF;
-    umem_in.dmabuf_fd   = mem->dmabuf_fd;
-
-    mem->mem = mlx5dv_devx_umem_reg_ex(ibv_context, &umem_in);
-    if (mem->mem == NULL) {
-        reg_errno = errno;
-        status    = uct_ib_mlx5_devx_umem_reg_status(reg_errno);
-        errno     = reg_errno;
-        uct_ib_check_memlock_limit_msg(
-                ibv_context, level,
-                "mlx5dv_devx_umem_reg_ex(name=%s dmabuf_fd=%d size=%zu access=0x%x)",
-                alloc_name, mem->dmabuf_fd, mmap_size, access_mode);
-        if (md->super.fork_init) {
-            ret = madvise(buf, mmap_size, MADV_DOFORK);
-            if (ret != 0) {
-                ucs_warn("madvise(DOFORK, buf=%p, len=%zu) failed: %m", buf,
-                         mmap_size);
-            }
-        }
-        ret = munmap(buf, mmap_size);
-        if (ret != 0) {
-            ucs_warn("munmap(buf=%p, len=%zu) failed: %m", buf, mmap_size);
-        }
-        ret = close(mem->dmabuf_fd);
-        if (ret != 0) {
-            ucs_warn("close(dmabuf_fd=%d) failed: %m", mem->dmabuf_fd);
-        }
-        uct_ib_mlx5_devx_umem_reset(mem);
-        return status;
-    }
-
-    mem->size      = size;
-    mem->mmap_size = mmap_size;
-    mem->is_dmabuf = 1;
-    *buf_p         = buf;
-    return UCS_OK;
-#else
-    (void)md;
-    (void)size;
-    (void)access_mode;
-
-    ucs_log(level, "shared DEVX UMEM allocation for %s is unsupported",
-            alloc_name);
-    *buf_p = NULL;
-    uct_ib_mlx5_devx_umem_reset(mem);
-    return UCS_ERR_UNSUPPORTED;
-#endif
-}
-
 static inline ucs_status_t
 uct_ib_mlx5_md_buf_alloc(uct_ib_mlx5_md_t *md, size_t size, int silent,
                          void **buf_p, uct_ib_mlx5_devx_umem_t *mem,
@@ -1285,11 +1146,12 @@ uct_ib_mlx5_md_buf_alloc(uct_ib_mlx5_md_t *md, size_t size, int silent,
     void *buf;
     int ret;
 
-    if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
-        return uct_ib_mlx5_md_buf_alloc_shared(md, size, silent, buf_p, mem,
-                                               access_mode, name);
+    if (uct_ib_md_is_coco_hardened(&md->super)) {
+        return uct_ib_mlx5_coco_md_buf_alloc_shared(md, size, silent, buf_p,
+                                                    mem, access_mode, name);
     }
 
+    uct_ib_mlx5_devx_umem_reset(mem);
     mem->mmap_size = size;
     mem->dmabuf_fd = UCT_IB_MLX5_INVALID_DMABUF_FD;
     mem->is_dmabuf = 0;
@@ -1336,53 +1198,23 @@ err_free:
 static inline void
 uct_ib_mlx5_md_buf_free(uct_ib_mlx5_md_t *md, void *buf, uct_ib_mlx5_devx_umem_t *mem)
 {
-    struct mlx5dv_devx_umem *umem;
-    size_t mmap_size;
-    size_t size;
-    int dmabuf_fd;
-    int is_dmabuf;
     int ret;
 
     if (buf == NULL) {
         return;
     }
 
-    umem       = mem->mem;
-    mmap_size  = mem->mmap_size;
-    size       = mem->size;
-    dmabuf_fd  = mem->dmabuf_fd;
-    is_dmabuf  = mem->is_dmabuf;
-
-    mlx5dv_devx_umem_dereg(umem);
-    if (is_dmabuf) {
-        uct_ib_mlx5_devx_umem_reset(mem);
-
-        if (md->super.fork_init) {
-            ret = madvise(buf, mmap_size, MADV_DOFORK);
-            if (ret != 0) {
-                ucs_warn("madvise(DOFORK, buf=%p, len=%zu) failed: %m", buf,
-                         mmap_size);
-            }
-        }
-        ret = munmap(buf, mmap_size);
-        if (ret != 0) {
-            ucs_warn("munmap(buf=%p, len=%zu) failed: %m", buf,
-                     mmap_size);
-        }
-
-        if (dmabuf_fd != UCT_IB_MLX5_INVALID_DMABUF_FD) {
-            ret = close(dmabuf_fd);
-            if (ret != 0) {
-                ucs_warn("close(dmabuf_fd=%d) failed: %m", dmabuf_fd);
-            }
-        }
+    if (mem->coco_shared != NULL) {
+        uct_ib_mlx5_coco_md_buf_free_shared(md, buf, mem);
         return;
     }
 
+    mlx5dv_devx_umem_dereg(mem->mem);
+
     if (md->super.fork_init) {
-        ret = madvise(buf, size, MADV_DOFORK);
+        ret = madvise(buf, mem->size, MADV_DOFORK);
         if (ret != 0) {
-            ucs_warn("madvise(DOFORK, buf=%p, len=%zu) failed: %m", buf, size);
+            ucs_warn("madvise(DOFORK, buf=%p, len=%zu) failed: %m", buf, mem->size);
         }
     }
     ucs_free(buf);

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -39,8 +39,15 @@
 
 #include <infiniband/mlx5dv.h>
 #include <netinet/in.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
 #include <endian.h>
+#include <fcntl.h>
 #include <string.h>
+#include <unistd.h>
+#if HAVE_LINUX_DMA_HEAP_H
+#  include <linux/dma-heap.h>
+#endif
 
 
 #define UCT_IB_MLX5_WQE_SEG_SIZE         16 /* Size of a segment in a WQE */
@@ -335,6 +342,9 @@ typedef struct {
 typedef struct {
     struct mlx5dv_devx_umem  *mem;
     size_t                   size;
+    size_t                   mmap_size;
+    int                      dmabuf_fd;
+    int                      is_dmabuf;
 } uct_ib_mlx5_devx_umem_t;
 
 
@@ -1090,6 +1100,154 @@ void uct_ib_mlx5_cq_calc_sizes(uct_ib_iface_t *iface, uct_ib_dir_t dir,
                                const uct_ib_iface_init_attr_t *init_attr,
                                size_t inl, uct_ib_mlx5_cq_attr_t *attr);
 
+#define UCT_IB_MLX5_CC_DMA_HEAP "/dev/dma_heap/system_cc_shared"
+#define UCT_IB_MLX5_INVALID_DMABUF_FD (-1)
+
+static UCS_F_ALWAYS_INLINE void
+uct_ib_mlx5_devx_umem_reset(uct_ib_mlx5_devx_umem_t *mem)
+{
+    mem->mem       = NULL;
+    mem->size      = 0;
+    mem->mmap_size = 0;
+    mem->dmabuf_fd = UCT_IB_MLX5_INVALID_DMABUF_FD;
+    mem->is_dmabuf = 0;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_ib_mlx5_devx_umem_reg_status(int sys_errno)
+{
+    if ((sys_errno == EOPNOTSUPP) || (sys_errno == EPROTONOSUPPORT) ||
+        (sys_errno == EINVAL)
+#ifdef ENOTSUP
+        || (sys_errno == ENOTSUP)
+#endif
+        ) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    return (sys_errno == ENOMEM) ? UCS_ERR_NO_MEMORY : UCS_ERR_IO_ERROR;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_ib_mlx5_md_buf_alloc_shared(uct_ib_mlx5_md_t *md, size_t size, int silent,
+                                void **buf_p, uct_ib_mlx5_devx_umem_t *mem,
+                                int access_mode, char *name)
+{
+    const ucs_log_level_t level = silent ? UCS_LOG_LEVEL_DEBUG :
+                                           UCS_LOG_LEVEL_ERROR;
+    const char *alloc_name      = (name != NULL) ? name : "unknown";
+#if HAVE_LINUX_DMA_HEAP_H && HAVE_DECL_MLX5DV_DEVX_UMEM_REG_EX && \
+    HAVE_DECL_MLX5DV_UMEM_MASK_DMABUF && HAVE_STRUCT_MLX5DV_DEVX_UMEM_IN
+    struct ibv_context *ibv_context = md->super.dev.ibv_context;
+    struct mlx5dv_devx_umem_in umem_in;
+    struct dma_heap_allocation_data heap_data;
+    ucs_status_t status;
+    void *buf = NULL;
+    size_t mmap_size;
+    int reg_errno;
+    int heap_fd;
+    int ret;
+
+    uct_ib_mlx5_devx_umem_reset(mem);
+    *buf_p = NULL;
+
+    mmap_size = ucs_align_up(size, ucs_get_page_size());
+    heap_fd   = open(UCT_IB_MLX5_CC_DMA_HEAP, O_RDWR | O_CLOEXEC);
+    if (heap_fd < 0) {
+        status = (errno == ENOENT) ? UCS_ERR_UNSUPPORTED : UCS_ERR_IO_ERROR;
+        ucs_log(level, "failed to open %s for %s: %m",
+                UCT_IB_MLX5_CC_DMA_HEAP, alloc_name);
+        uct_ib_mlx5_devx_umem_reset(mem);
+        return status;
+    }
+
+    memset(&heap_data, 0, sizeof(heap_data));
+    heap_data.len      = mmap_size;
+    heap_data.fd_flags = O_RDWR | O_CLOEXEC;
+
+    ret = ioctl(heap_fd, DMA_HEAP_IOCTL_ALLOC, &heap_data);
+    if (ret != 0) {
+        status = (errno == ENOMEM) ? UCS_ERR_NO_MEMORY : UCS_ERR_IO_ERROR;
+        ucs_log(level, "DMA_HEAP_IOCTL_ALLOC(%s, name=%s size=%zu) failed: %m",
+                UCT_IB_MLX5_CC_DMA_HEAP, alloc_name, mmap_size);
+        ret = close(heap_fd);
+        if (ret != 0) {
+            ucs_warn("close(dma_heap_fd=%d) failed: %m", heap_fd);
+        }
+        uct_ib_mlx5_devx_umem_reset(mem);
+        return status;
+    }
+
+    ret = close(heap_fd);
+    if (ret != 0) {
+        ucs_warn("close(dma_heap_fd=%d) failed: %m", heap_fd);
+    }
+
+    mem->dmabuf_fd = heap_data.fd;
+    buf = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+               mem->dmabuf_fd, 0);
+    if (buf == MAP_FAILED) {
+        status = (errno == ENOMEM) ? UCS_ERR_NO_MEMORY : UCS_ERR_IO_ERROR;
+        ucs_log(level, "mmap(name=%s dmabuf_fd=%d size=%zu) failed: %m",
+                alloc_name, mem->dmabuf_fd, mmap_size);
+        buf = NULL;
+        ret = close(mem->dmabuf_fd);
+        if (ret != 0) {
+            ucs_warn("close(dmabuf_fd=%d) failed: %m", mem->dmabuf_fd);
+        }
+        uct_ib_mlx5_devx_umem_reset(mem);
+        return status;
+    }
+
+    memset(buf, 0, mmap_size);
+
+    memset(&umem_in, 0, sizeof(umem_in));
+    umem_in.addr        = NULL;
+    umem_in.size        = mmap_size;
+    umem_in.access      = access_mode;
+    umem_in.pgsz_bitmap = UINT64_MAX & ~(ucs_get_page_size() - 1);
+    umem_in.comp_mask   = MLX5DV_UMEM_MASK_DMABUF;
+    umem_in.dmabuf_fd   = mem->dmabuf_fd;
+
+    mem->mem = mlx5dv_devx_umem_reg_ex(ibv_context, &umem_in);
+    if (mem->mem == NULL) {
+        reg_errno = errno;
+        status    = uct_ib_mlx5_devx_umem_reg_status(reg_errno);
+        errno     = reg_errno;
+        uct_ib_check_memlock_limit_msg(
+                ibv_context, level,
+                "mlx5dv_devx_umem_reg_ex(name=%s dmabuf_fd=%d size=%zu access=0x%x)",
+                alloc_name, mem->dmabuf_fd, mmap_size, access_mode);
+        ret = munmap(buf, mmap_size);
+        if (ret != 0) {
+            ucs_warn("munmap(buf=%p, len=%zu) failed: %m", buf, mmap_size);
+        }
+        ret = close(mem->dmabuf_fd);
+        if (ret != 0) {
+            ucs_warn("close(dmabuf_fd=%d) failed: %m", mem->dmabuf_fd);
+        }
+        uct_ib_mlx5_devx_umem_reset(mem);
+        return status;
+    }
+
+    mem->size      = size;
+    mem->mmap_size = mmap_size;
+    mem->is_dmabuf = 1;
+    *buf_p         = buf;
+    return UCS_OK;
+#else
+    (void)md;
+    (void)size;
+    (void)access_mode;
+
+    ucs_log(level, "shared DEVX UMEM allocation for %s is unsupported",
+            alloc_name);
+    *buf_p = NULL;
+    uct_ib_mlx5_devx_umem_reset(mem);
+    return UCS_ERR_UNSUPPORTED;
+#endif
+}
+
 static inline ucs_status_t
 uct_ib_mlx5_md_buf_alloc(uct_ib_mlx5_md_t *md, size_t size, int silent,
                          void **buf_p, uct_ib_mlx5_devx_umem_t *mem,
@@ -1101,6 +1259,15 @@ uct_ib_mlx5_md_buf_alloc(uct_ib_mlx5_md_t *md, size_t size, int silent,
     ucs_status_t status;
     void *buf;
     int ret;
+
+    if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
+        return uct_ib_mlx5_md_buf_alloc_shared(md, size, silent, buf_p, mem,
+                                               access_mode, name);
+    }
+
+    mem->mmap_size = size;
+    mem->dmabuf_fd = UCT_IB_MLX5_INVALID_DMABUF_FD;
+    mem->is_dmabuf = 0;
 
     ret = ucs_posix_memalign(&buf, ucs_get_page_size(), size, name);
     if (ret != 0) {
@@ -1144,17 +1311,46 @@ err_free:
 static inline void
 uct_ib_mlx5_md_buf_free(uct_ib_mlx5_md_t *md, void *buf, uct_ib_mlx5_devx_umem_t *mem)
 {
+    struct mlx5dv_devx_umem *umem;
+    size_t mmap_size;
+    size_t size;
+    int dmabuf_fd;
+    int is_dmabuf;
     int ret;
 
     if (buf == NULL) {
         return;
     }
 
-    mlx5dv_devx_umem_dereg(mem->mem);
-    if (md->super.fork_init) {
-        ret = madvise(buf, mem->size, MADV_DOFORK);
+    umem       = mem->mem;
+    mmap_size  = mem->mmap_size;
+    size       = mem->size;
+    dmabuf_fd  = mem->dmabuf_fd;
+    is_dmabuf  = mem->is_dmabuf;
+
+    mlx5dv_devx_umem_dereg(umem);
+    if (is_dmabuf) {
+        uct_ib_mlx5_devx_umem_reset(mem);
+
+        ret = munmap(buf, mmap_size);
         if (ret != 0) {
-            ucs_warn("madvise(DOFORK, buf=%p, len=%zu) failed: %m", buf, mem->size);
+            ucs_warn("munmap(buf=%p, len=%zu) failed: %m", buf,
+                     mmap_size);
+        }
+
+        if (dmabuf_fd != UCT_IB_MLX5_INVALID_DMABUF_FD) {
+            ret = close(dmabuf_fd);
+            if (ret != 0) {
+                ucs_warn("close(dmabuf_fd=%d) failed: %m", dmabuf_fd);
+            }
+        }
+        return;
+    }
+
+    if (md->super.fork_init) {
+        ret = madvise(buf, size, MADV_DOFORK);
+        if (ret != 0) {
+            ucs_warn("madvise(DOFORK, buf=%p, len=%zu) failed: %m", buf, size);
         }
     }
     ucs_free(buf);

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -1157,7 +1157,6 @@ uct_ib_mlx5_md_buf_alloc_shared(uct_ib_mlx5_md_t *md, size_t size, int silent,
         status = (errno == ENOENT) ? UCS_ERR_UNSUPPORTED : UCS_ERR_IO_ERROR;
         ucs_log(level, "failed to open %s for %s: %m",
                 UCT_IB_MLX5_CC_DMA_HEAP, alloc_name);
-        uct_ib_mlx5_devx_umem_reset(mem);
         return status;
     }
 
@@ -1174,7 +1173,6 @@ uct_ib_mlx5_md_buf_alloc_shared(uct_ib_mlx5_md_t *md, size_t size, int silent,
         if (ret != 0) {
             ucs_warn("close(dma_heap_fd=%d) failed: %m", heap_fd);
         }
-        uct_ib_mlx5_devx_umem_reset(mem);
         return status;
     }
 
@@ -1201,6 +1199,26 @@ uct_ib_mlx5_md_buf_alloc_shared(uct_ib_mlx5_md_t *md, size_t size, int silent,
 
     memset(buf, 0, mmap_size);
 
+    if (md->super.fork_init) {
+        ret = madvise(buf, mmap_size, MADV_DONTFORK);
+        if (ret != 0) {
+            status = UCS_ERR_IO_ERROR;
+            ucs_log(level, "madvise(DONTFORK, buf=%p, len=%zu) failed: %m",
+                    buf, mmap_size);
+            ret = munmap(buf, mmap_size);
+            if (ret != 0) {
+                ucs_warn("munmap(buf=%p, len=%zu) failed: %m", buf,
+                         mmap_size);
+            }
+            ret = close(mem->dmabuf_fd);
+            if (ret != 0) {
+                ucs_warn("close(dmabuf_fd=%d) failed: %m", mem->dmabuf_fd);
+            }
+            uct_ib_mlx5_devx_umem_reset(mem);
+            return status;
+        }
+    }
+
     memset(&umem_in, 0, sizeof(umem_in));
     umem_in.addr        = NULL;
     umem_in.size        = mmap_size;
@@ -1218,6 +1236,13 @@ uct_ib_mlx5_md_buf_alloc_shared(uct_ib_mlx5_md_t *md, size_t size, int silent,
                 ibv_context, level,
                 "mlx5dv_devx_umem_reg_ex(name=%s dmabuf_fd=%d size=%zu access=0x%x)",
                 alloc_name, mem->dmabuf_fd, mmap_size, access_mode);
+        if (md->super.fork_init) {
+            ret = madvise(buf, mmap_size, MADV_DOFORK);
+            if (ret != 0) {
+                ucs_warn("madvise(DOFORK, buf=%p, len=%zu) failed: %m", buf,
+                         mmap_size);
+            }
+        }
         ret = munmap(buf, mmap_size);
         if (ret != 0) {
             ucs_warn("munmap(buf=%p, len=%zu) failed: %m", buf, mmap_size);
@@ -1332,6 +1357,13 @@ uct_ib_mlx5_md_buf_free(uct_ib_mlx5_md_t *md, void *buf, uct_ib_mlx5_devx_umem_t
     if (is_dmabuf) {
         uct_ib_mlx5_devx_umem_reset(mem);
 
+        if (md->super.fork_init) {
+            ret = madvise(buf, mmap_size, MADV_DOFORK);
+            if (ret != 0) {
+                ucs_warn("madvise(DOFORK, buf=%p, len=%zu) failed: %m", buf,
+                         mmap_size);
+            }
+        }
         ret = munmap(buf, mmap_size);
         if (ret != 0) {
             ucs_warn("munmap(buf=%p, len=%zu) failed: %m", buf,

--- a/src/uct/ib/mlx5/ib_mlx5_coco.c
+++ b/src/uct/ib/mlx5/ib_mlx5_coco.c
@@ -1,0 +1,636 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "ib_mlx5.h"
+#include "ib_mlx5_coco.h"
+
+#include <ucs/debug/memtrack_int.h>
+#include <ucs/debug/log.h>
+
+#include <errno.h>
+#include <string.h>
+
+
+struct uct_ib_mlx5_coco_state {
+    uct_ib_mlx5_coco_umem_record_t *umem_records;
+    size_t                         umem_count;
+    size_t                         umem_capacity;
+    uct_ib_mlx5_coco_mkey_record_t *mkey_records;
+    size_t                         mkey_count;
+    size_t                         mkey_capacity;
+};
+
+typedef struct {
+    uct_ib_mlx5_coco_shared_alloc_ops_t ops;
+    void                                *arg;
+} uct_ib_mlx5_coco_shared_alloc_backend_t;
+
+static ucs_status_t
+uct_ib_mlx5_coco_default_alloc(size_t size, void **addr_p, int *fd_p,
+                               void *arg)
+{
+#if HAVE_LINUX_DMA_HEAP_H
+    struct dma_heap_allocation_data heap_data;
+    ucs_status_t status;
+    int heap_fd;
+    void *addr;
+    int ret;
+
+    heap_fd = open(UCT_IB_MLX5_CC_DMA_HEAP, O_RDWR | O_CLOEXEC);
+    if (heap_fd < 0) {
+        return (errno == ENOENT) ? UCS_ERR_UNSUPPORTED : UCS_ERR_IO_ERROR;
+    }
+
+    memset(&heap_data, 0, sizeof(heap_data));
+    heap_data.len      = size;
+    heap_data.fd_flags = O_RDWR | O_CLOEXEC;
+
+    ret = ioctl(heap_fd, DMA_HEAP_IOCTL_ALLOC, &heap_data);
+    if (ret != 0) {
+        status = (errno == ENOMEM) ? UCS_ERR_NO_MEMORY : UCS_ERR_IO_ERROR;
+        ret = close(heap_fd);
+        if (ret != 0) {
+            ucs_warn("close(dma_heap_fd=%d) failed: %m", heap_fd);
+        }
+        return status;
+    }
+
+    ret = close(heap_fd);
+    if (ret != 0) {
+        ucs_warn("close(dma_heap_fd=%d) failed: %m", heap_fd);
+    }
+
+    addr = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, heap_data.fd, 0);
+    if (addr == MAP_FAILED) {
+        status = (errno == ENOMEM) ? UCS_ERR_NO_MEMORY : UCS_ERR_IO_ERROR;
+        ret = close(heap_data.fd);
+        if (ret != 0) {
+            ucs_warn("close(dmabuf_fd=%d) failed: %m", heap_data.fd);
+        }
+        return status;
+    }
+
+    *addr_p = addr;
+    *fd_p   = heap_data.fd;
+    return UCS_OK;
+#else
+    (void)size;
+    (void)addr_p;
+    (void)fd_p;
+    (void)arg;
+    return UCS_ERR_UNSUPPORTED;
+#endif
+}
+
+static ucs_status_t
+uct_ib_mlx5_coco_default_umem_reg(uct_ib_mlx5_md_t *md,
+                                  const uct_ib_mlx5_coco_shared_alloc_t *alloc,
+                                  int access_mode,
+                                  struct mlx5dv_devx_umem **umem_p,
+                                  void *arg)
+{
+#if HAVE_DECL_MLX5DV_DEVX_UMEM_REG_EX && HAVE_DECL_MLX5DV_UMEM_MASK_DMABUF && \
+    HAVE_STRUCT_MLX5DV_DEVX_UMEM_IN
+    struct mlx5dv_devx_umem_in umem_in;
+
+    memset(&umem_in, 0, sizeof(umem_in));
+    umem_in.addr        = NULL;
+    umem_in.size        = alloc->exposed_size;
+    umem_in.access      = access_mode;
+    umem_in.pgsz_bitmap = UINT64_MAX & ~(ucs_get_page_size() - 1);
+    umem_in.comp_mask   = MLX5DV_UMEM_MASK_DMABUF;
+    umem_in.dmabuf_fd   = alloc->dmabuf_fd;
+
+    *umem_p = mlx5dv_devx_umem_reg_ex(md->super.dev.ibv_context, &umem_in);
+    return (*umem_p == NULL) ? uct_ib_mlx5_devx_umem_reg_status(errno) : UCS_OK;
+#else
+    (void)md;
+    (void)alloc;
+    (void)access_mode;
+    (void)umem_p;
+    (void)arg;
+    return UCS_ERR_UNSUPPORTED;
+#endif
+}
+
+static ucs_status_t
+uct_ib_mlx5_coco_default_umem_dereg(struct mlx5dv_devx_umem *umem, void *arg)
+{
+    return (mlx5dv_devx_umem_dereg(umem) == 0) ? UCS_OK : UCS_ERR_IO_ERROR;
+}
+
+static ucs_status_t uct_ib_mlx5_coco_default_unmap(void *addr, size_t size,
+                                                   void *arg)
+{
+    return (munmap(addr, size) == 0) ? UCS_OK : UCS_ERR_IO_ERROR;
+}
+
+static ucs_status_t uct_ib_mlx5_coco_default_close(int fd, void *arg)
+{
+    return (close(fd) == 0) ? UCS_OK : UCS_ERR_IO_ERROR;
+}
+
+static uct_ib_mlx5_coco_shared_alloc_backend_t
+uct_ib_mlx5_coco_shared_alloc_backend = {
+    {
+        uct_ib_mlx5_coco_default_alloc,
+        uct_ib_mlx5_coco_default_umem_reg,
+        uct_ib_mlx5_coco_default_umem_dereg,
+        uct_ib_mlx5_coco_default_unmap,
+        uct_ib_mlx5_coco_default_close
+    },
+    NULL
+};
+
+void uct_ib_mlx5_coco_set_shared_alloc_ops(
+        const uct_ib_mlx5_coco_shared_alloc_ops_t *ops, void *arg)
+{
+    if (ops == NULL) {
+        uct_ib_mlx5_coco_shared_alloc_backend.ops.alloc =
+                uct_ib_mlx5_coco_default_alloc;
+        uct_ib_mlx5_coco_shared_alloc_backend.ops.umem_reg =
+                uct_ib_mlx5_coco_default_umem_reg;
+        uct_ib_mlx5_coco_shared_alloc_backend.ops.umem_dereg =
+                uct_ib_mlx5_coco_default_umem_dereg;
+        uct_ib_mlx5_coco_shared_alloc_backend.ops.unmap =
+                uct_ib_mlx5_coco_default_unmap;
+        uct_ib_mlx5_coco_shared_alloc_backend.ops.close_fd =
+                uct_ib_mlx5_coco_default_close;
+        uct_ib_mlx5_coco_shared_alloc_backend.arg = NULL;
+        return;
+    }
+
+    uct_ib_mlx5_coco_shared_alloc_backend.ops = *ops;
+    uct_ib_mlx5_coco_shared_alloc_backend.arg = arg;
+}
+
+ucs_status_t uct_ib_mlx5_coco_exposed_size(size_t requested_size,
+                                           size_t *exposed_size_p)
+{
+    if (requested_size == 0) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    *exposed_size_p = ucs_align_up(requested_size, ucs_get_page_size());
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_ib_mlx5_coco_grow(void **records_p, size_t *capacity_p, size_t count,
+                      size_t elem_size, const char *name)
+{
+    size_t capacity = *capacity_p;
+    void *records;
+
+    if (count < capacity) {
+        return UCS_OK;
+    }
+
+    capacity = (capacity == 0) ? 4 : capacity * 2;
+    records  = ucs_realloc(*records_p, capacity * elem_size, name);
+    if (records == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    *records_p  = records;
+    *capacity_p = capacity;
+    return UCS_OK;
+}
+
+ucs_status_t uct_ib_mlx5_coco_state_init(uct_ib_mlx5_md_t *md)
+{
+    if (!uct_ib_md_is_coco_hardened(&md->super)) {
+        md->coco = NULL;
+        return UCS_OK;
+    }
+
+    if (md->coco != NULL) {
+        return UCS_OK;
+    }
+
+    md->coco = ucs_calloc(1, sizeof(*md->coco), "mlx5 CoCo state");
+    return (md->coco == NULL) ? UCS_ERR_NO_MEMORY : UCS_OK;
+}
+
+void uct_ib_mlx5_coco_state_cleanup(uct_ib_mlx5_md_t *md)
+{
+    if (md->coco == NULL) {
+        return;
+    }
+
+    ucs_free(md->coco->umem_records);
+    ucs_free(md->coco->mkey_records);
+    ucs_free(md->coco);
+    md->coco = NULL;
+}
+
+int uct_ib_mlx5_coco_mkey_policy_ready(const uct_ib_mlx5_md_t *md)
+{
+    return !uct_ib_md_is_coco_hardened(&md->super) || (md->coco != NULL);
+}
+
+const uct_ib_mlx5_coco_umem_record_t*
+uct_ib_mlx5_coco_umem_record_find(const uct_ib_mlx5_coco_state_t *state,
+                                  uint32_t umem_id)
+{
+    size_t i;
+
+    if (state == NULL) {
+        return NULL;
+    }
+
+    for (i = 0; i < state->umem_count; ++i) {
+        if (state->umem_records[i].live &&
+            (state->umem_records[i].umem_id == umem_id)) {
+            return &state->umem_records[i];
+        }
+    }
+
+    return NULL;
+}
+
+ucs_status_t
+uct_ib_mlx5_coco_umem_record_add(uct_ib_mlx5_coco_state_t *state,
+                                 uint32_t umem_id, void *addr,
+                                 size_t requested_size, size_t exposed_size,
+                                 uint32_t access_flags)
+{
+    uct_ib_mlx5_coco_umem_record_t *record;
+    ucs_status_t status;
+
+    if (state == NULL) {
+        return UCS_OK;
+    }
+
+    if (uct_ib_mlx5_coco_umem_record_find(state, umem_id) != NULL) {
+        return UCS_ERR_ALREADY_EXISTS;
+    }
+
+    status = uct_ib_mlx5_coco_grow((void**)&state->umem_records,
+                                   &state->umem_capacity, state->umem_count,
+                                   sizeof(*state->umem_records),
+                                   "CoCo UMEM records");
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    record                 = &state->umem_records[state->umem_count++];
+    record->umem_id        = umem_id;
+    record->addr           = addr;
+    record->requested_size = requested_size;
+    record->exposed_size   = exposed_size;
+    record->access_flags   = access_flags;
+    record->live           = 1;
+    return UCS_OK;
+}
+
+ucs_status_t
+uct_ib_mlx5_coco_umem_record_validate(const uct_ib_mlx5_coco_state_t *state,
+                                      uint32_t umem_id, void *addr,
+                                      size_t requested_size,
+                                      size_t exposed_size,
+                                      uint32_t access_flags)
+{
+    const uct_ib_mlx5_coco_umem_record_t *record =
+            uct_ib_mlx5_coco_umem_record_find(state, umem_id);
+
+    if (record == NULL) {
+        return UCS_ERR_NO_ELEM;
+    }
+
+    if ((record->addr != addr) || (requested_size > record->requested_size) ||
+        (exposed_size > record->exposed_size) ||
+        ((access_flags & ~record->access_flags) != 0)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return UCS_OK;
+}
+
+ucs_status_t
+uct_ib_mlx5_coco_umem_record_remove(uct_ib_mlx5_coco_state_t *state,
+                                    uint32_t umem_id)
+{
+    size_t i;
+
+    if (state == NULL) {
+        return UCS_OK;
+    }
+
+    for (i = 0; i < state->umem_count; ++i) {
+        if (state->umem_records[i].live &&
+            (state->umem_records[i].umem_id == umem_id)) {
+            state->umem_records[i].live = 0;
+            return UCS_OK;
+        }
+    }
+
+    return UCS_ERR_NO_ELEM;
+}
+
+uint64_t uct_ib_mlx5_coco_mkey_sanitize_access(uint64_t access_mask)
+{
+    return access_mask & ~((uint64_t)IBV_ACCESS_REMOTE_ATOMIC);
+}
+
+const uct_ib_mlx5_coco_mkey_record_t*
+uct_ib_mlx5_coco_mkey_record_find_lkey(const uct_ib_mlx5_coco_state_t *state,
+                                       uint32_t lkey)
+{
+    size_t i;
+
+    if (state == NULL) {
+        return NULL;
+    }
+
+    for (i = 0; i < state->mkey_count; ++i) {
+        if (state->mkey_records[i].live &&
+            (state->mkey_records[i].lkey == lkey)) {
+            return &state->mkey_records[i];
+        }
+    }
+
+    return NULL;
+}
+
+static const uct_ib_mlx5_coco_mkey_record_t*
+uct_ib_mlx5_coco_mkey_record_find_rkey(const uct_ib_mlx5_coco_state_t *state,
+                                       uint32_t rkey)
+{
+    size_t i;
+
+    if (state == NULL) {
+        return NULL;
+    }
+
+    for (i = 0; i < state->mkey_count; ++i) {
+        if (state->mkey_records[i].live &&
+            (state->mkey_records[i].rkey == rkey)) {
+            return &state->mkey_records[i];
+        }
+    }
+
+    return NULL;
+}
+
+static int uct_ib_mlx5_coco_range_contains(const void *record_base,
+                                           size_t record_length,
+                                           const void *base, size_t length)
+{
+    uintptr_t rec_start = (uintptr_t)record_base;
+    uintptr_t req_start = (uintptr_t)base;
+    uintptr_t rec_end   = rec_start + record_length;
+    uintptr_t req_end   = req_start + length;
+
+    if ((rec_end < rec_start) || (req_end < req_start)) {
+        return 0;
+    }
+
+    return (req_start >= rec_start) && (req_end <= rec_end);
+}
+
+ucs_status_t
+uct_ib_mlx5_coco_mkey_record_add(uct_ib_mlx5_coco_state_t *state,
+                                 uint32_t lkey, uint32_t rkey, void *base,
+                                 size_t length, uint64_t access_mask)
+{
+    uct_ib_mlx5_coco_mkey_record_t *record;
+    ucs_status_t status;
+
+    if (state == NULL) {
+        return UCS_OK;
+    }
+
+    if ((length == 0) ||
+        (uct_ib_mlx5_coco_mkey_record_find_lkey(state, lkey) != NULL) ||
+        (uct_ib_mlx5_coco_mkey_record_find_rkey(state, rkey) != NULL)) {
+        return (length == 0) ? UCS_ERR_INVALID_PARAM :
+                               UCS_ERR_ALREADY_EXISTS;
+    }
+
+    status = uct_ib_mlx5_coco_grow((void**)&state->mkey_records,
+                                   &state->mkey_capacity, state->mkey_count,
+                                   sizeof(*state->mkey_records),
+                                   "CoCo mkey records");
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    record              = &state->mkey_records[state->mkey_count++];
+    record->lkey        = lkey;
+    record->rkey        = rkey;
+    record->base        = base;
+    record->length      = length;
+    record->access_mask = uct_ib_mlx5_coco_mkey_sanitize_access(access_mask);
+    record->live        = 1;
+    return UCS_OK;
+}
+
+ucs_status_t
+uct_ib_mlx5_coco_mkey_record_validate(const uct_ib_mlx5_coco_state_t *state,
+                                      uint32_t lkey, uint32_t rkey,
+                                      void *base, size_t length,
+                                      uint64_t access_mask)
+{
+    const uct_ib_mlx5_coco_mkey_record_t *record =
+            uct_ib_mlx5_coco_mkey_record_find_lkey(state, lkey);
+
+    if ((record == NULL) || (record->rkey != rkey)) {
+        return UCS_ERR_NO_ELEM;
+    }
+
+    if (!uct_ib_mlx5_coco_range_contains(record->base, record->length, base,
+                                         length) ||
+        ((access_mask & ~record->access_mask) != 0)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return UCS_OK;
+}
+
+ucs_status_t
+uct_ib_mlx5_coco_mkey_record_remove(uct_ib_mlx5_coco_state_t *state,
+                                    uint32_t lkey, uint32_t rkey)
+{
+    size_t i;
+
+    if (state == NULL) {
+        return UCS_OK;
+    }
+
+    for (i = 0; i < state->mkey_count; ++i) {
+        if (state->mkey_records[i].live &&
+            (state->mkey_records[i].lkey == lkey) &&
+            (state->mkey_records[i].rkey == rkey)) {
+            state->mkey_records[i].live = 0;
+            return UCS_OK;
+        }
+    }
+
+    return UCS_ERR_NO_ELEM;
+}
+
+ucs_status_t
+uct_ib_mlx5_coco_mkey_record_remove_rkey(uct_ib_mlx5_coco_state_t *state,
+                                         uint32_t rkey)
+{
+    size_t i;
+
+    if (state == NULL) {
+        return UCS_OK;
+    }
+
+    for (i = 0; i < state->mkey_count; ++i) {
+        if (state->mkey_records[i].live &&
+            (state->mkey_records[i].rkey == rkey)) {
+            state->mkey_records[i].live = 0;
+            return UCS_OK;
+        }
+    }
+
+    return UCS_ERR_NO_ELEM;
+}
+
+static void uct_ib_mlx5_coco_scrub(void *addr, size_t size)
+{
+    memset(addr, 0, size);
+}
+
+ucs_status_t
+uct_ib_mlx5_coco_md_buf_alloc_shared(uct_ib_mlx5_md_t *md, size_t size,
+                                     int silent, void **buf_p,
+                                     uct_ib_mlx5_devx_umem_t *mem,
+                                     int access_mode, char *name)
+{
+    const ucs_log_level_t level = silent ? UCS_LOG_LEVEL_DEBUG :
+                                           UCS_LOG_LEVEL_ERROR;
+    const char *alloc_name      = (name != NULL) ? name : "unknown";
+    uct_ib_mlx5_coco_shared_alloc_backend_t *backend =
+            &uct_ib_mlx5_coco_shared_alloc_backend;
+    uct_ib_mlx5_coco_shared_alloc_t *alloc;
+    ucs_status_t status;
+    uint32_t umem_id;
+
+    uct_ib_mlx5_devx_umem_reset(mem);
+    *buf_p = NULL;
+
+    alloc = ucs_calloc(1, sizeof(*alloc), "CoCo shared allocation");
+    if (alloc == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    alloc->dmabuf_fd = UCT_IB_MLX5_INVALID_DMABUF_FD;
+    status = uct_ib_mlx5_coco_exposed_size(size, &alloc->exposed_size);
+    if (status != UCS_OK) {
+        goto err_free_alloc;
+    }
+
+    alloc->requested_size = size;
+    status = backend->ops.alloc(alloc->exposed_size, &alloc->addr,
+                                &alloc->dmabuf_fd, backend->arg);
+    if (status != UCS_OK) {
+        ucs_log(level, "shared allocation for %s size %zu failed: %s",
+                alloc_name, alloc->exposed_size, ucs_status_string(status));
+        goto err_free_alloc;
+    }
+
+    uct_ib_mlx5_coco_scrub(alloc->addr, alloc->exposed_size);
+
+    status = backend->ops.umem_reg(md, alloc, access_mode, &mem->mem,
+                                   backend->arg);
+    if (status != UCS_OK) {
+        ucs_log(level, "shared DEVX UMEM registration for %s failed: %s",
+                alloc_name, ucs_status_string(status));
+        goto err_unmap_close;
+    }
+
+    alloc->umem_registered = 1;
+    umem_id                = mem->mem->umem_id;
+    status = uct_ib_mlx5_coco_umem_record_add(
+            md->coco, umem_id, alloc->addr, alloc->requested_size,
+            alloc->exposed_size, access_mode);
+    if (status != UCS_OK) {
+        goto err_umem_dereg;
+    }
+
+    mem->size        = alloc->requested_size;
+    mem->mmap_size   = alloc->exposed_size;
+    mem->dmabuf_fd   = alloc->dmabuf_fd;
+    mem->is_dmabuf   = 1;
+    mem->coco_shared = alloc;
+    *buf_p           = alloc->addr;
+    return UCS_OK;
+
+err_umem_dereg:
+    (void)backend->ops.umem_dereg(mem->mem, backend->arg);
+err_unmap_close:
+    uct_ib_mlx5_coco_scrub(alloc->addr, alloc->exposed_size);
+    (void)backend->ops.unmap(alloc->addr, alloc->exposed_size, backend->arg);
+    if (alloc->dmabuf_fd != UCT_IB_MLX5_INVALID_DMABUF_FD) {
+        (void)backend->ops.close_fd(alloc->dmabuf_fd, backend->arg);
+    }
+err_free_alloc:
+    uct_ib_mlx5_devx_umem_reset(mem);
+    ucs_free(alloc);
+    return status;
+}
+
+void uct_ib_mlx5_coco_md_buf_free_shared(uct_ib_mlx5_md_t *md, void *buf,
+                                         uct_ib_mlx5_devx_umem_t *mem)
+{
+    uct_ib_mlx5_coco_shared_alloc_backend_t *backend =
+            &uct_ib_mlx5_coco_shared_alloc_backend;
+    uct_ib_mlx5_coco_shared_alloc_t *alloc = mem->coco_shared;
+    struct mlx5dv_devx_umem *umem;
+    size_t mmap_size;
+    int dmabuf_fd;
+    uint32_t umem_id;
+    ucs_status_t status;
+
+    if ((buf == NULL) || (alloc == NULL)) {
+        return;
+    }
+
+    umem      = mem->mem;
+    mmap_size = mem->mmap_size;
+    dmabuf_fd = mem->dmabuf_fd;
+    umem_id   = (umem == NULL) ? 0 : umem->umem_id;
+
+    if (umem != NULL) {
+        status = backend->ops.umem_dereg(umem, backend->arg);
+        if (status != UCS_OK) {
+            ucs_warn("mlx5dv_devx_umem_dereg(mem=%p) failed: %s", umem,
+                     ucs_status_string(status));
+        } else {
+            (void)uct_ib_mlx5_coco_umem_record_remove(md->coco, umem_id);
+        }
+        alloc->umem_registered = 0;
+    }
+
+    alloc->quarantined = 1;
+    uct_ib_mlx5_devx_umem_reset(mem);
+    uct_ib_mlx5_coco_scrub(buf, mmap_size);
+
+    status = backend->ops.unmap(buf, mmap_size, backend->arg);
+    if (status != UCS_OK) {
+        ucs_warn("munmap(buf=%p, len=%zu) failed: %s", buf, mmap_size,
+                 ucs_status_string(status));
+    }
+
+    if (dmabuf_fd != UCT_IB_MLX5_INVALID_DMABUF_FD) {
+        status = backend->ops.close_fd(dmabuf_fd, backend->arg);
+        if (status != UCS_OK) {
+            ucs_warn("close(dmabuf_fd=%d) failed: %s", dmabuf_fd,
+                     ucs_status_string(status));
+        }
+    }
+
+    ucs_free(alloc);
+}

--- a/src/uct/ib/mlx5/ib_mlx5_coco.c
+++ b/src/uct/ib/mlx5/ib_mlx5_coco.c
@@ -25,7 +25,22 @@ struct uct_ib_mlx5_coco_state {
     uct_ib_mlx5_coco_mkey_record_t *mkey_records;
     size_t                         mkey_count;
     size_t                         mkey_capacity;
+    struct uct_ib_mlx5_coco_obj_record *obj_records;
+    size_t                         obj_count;
+    size_t                         obj_capacity;
 };
+
+typedef enum {
+    UCT_IB_MLX5_COCO_OBJ_CQ,
+    UCT_IB_MLX5_COCO_OBJ_QP,
+    UCT_IB_MLX5_COCO_OBJ_RMP
+} uct_ib_mlx5_coco_obj_type_t;
+
+typedef struct uct_ib_mlx5_coco_obj_record {
+    uct_ib_mlx5_coco_obj_type_t type;
+    uint32_t                    id;
+    uint8_t                     live;
+} uct_ib_mlx5_coco_obj_record_t;
 
 typedef struct {
     uct_ib_mlx5_coco_shared_alloc_ops_t ops;
@@ -227,6 +242,7 @@ void uct_ib_mlx5_coco_state_cleanup(uct_ib_mlx5_md_t *md)
 
     ucs_free(md->coco->umem_records);
     ucs_free(md->coco->mkey_records);
+    ucs_free(md->coco->obj_records);
     ucs_free(md->coco);
     md->coco = NULL;
 }
@@ -496,6 +512,329 @@ uct_ib_mlx5_coco_mkey_record_remove_rkey(uct_ib_mlx5_coco_state_t *state,
     }
 
     return UCS_ERR_NO_ELEM;
+}
+
+static const uct_ib_mlx5_coco_obj_record_t*
+uct_ib_mlx5_coco_obj_record_find(const uct_ib_mlx5_coco_state_t *state,
+                                 uct_ib_mlx5_coco_obj_type_t type,
+                                 uint32_t id)
+{
+    size_t i;
+
+    if (state == NULL) {
+        return NULL;
+    }
+
+    for (i = 0; i < state->obj_count; ++i) {
+        if (state->obj_records[i].live &&
+            (state->obj_records[i].type == type) &&
+            (state->obj_records[i].id == id)) {
+            return &state->obj_records[i];
+        }
+    }
+
+    return NULL;
+}
+
+static ucs_status_t
+uct_ib_mlx5_coco_obj_record_add(uct_ib_mlx5_coco_state_t *state,
+                                uct_ib_mlx5_coco_obj_type_t type,
+                                uint32_t id)
+{
+    uct_ib_mlx5_coco_obj_record_t *record;
+    ucs_status_t status;
+
+    if (state == NULL) {
+        return UCS_OK;
+    }
+
+    if (id == 0) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    if (uct_ib_mlx5_coco_obj_record_find(state, type, id) != NULL) {
+        return UCS_ERR_ALREADY_EXISTS;
+    }
+
+    status = uct_ib_mlx5_coco_grow((void**)&state->obj_records,
+                                   &state->obj_capacity, state->obj_count,
+                                   sizeof(*state->obj_records),
+                                   "CoCo DEVX object records");
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    record       = &state->obj_records[state->obj_count++];
+    record->type = type;
+    record->id   = id;
+    record->live = 1;
+    return UCS_OK;
+}
+
+static ucs_status_t
+uct_ib_mlx5_coco_obj_record_remove(uct_ib_mlx5_coco_state_t *state,
+                                   uct_ib_mlx5_coco_obj_type_t type,
+                                   uint32_t id)
+{
+    size_t i;
+
+    if (state == NULL) {
+        return UCS_OK;
+    }
+
+    for (i = 0; i < state->obj_count; ++i) {
+        if (state->obj_records[i].live &&
+            (state->obj_records[i].type == type) &&
+            (state->obj_records[i].id == id)) {
+            state->obj_records[i].live = 0;
+            return UCS_OK;
+        }
+    }
+
+    return UCS_ERR_NO_ELEM;
+}
+
+ucs_status_t uct_ib_mlx5_coco_cqn_record_remove(
+        uct_ib_mlx5_coco_state_t *state, uint32_t cqn)
+{
+    return uct_ib_mlx5_coco_obj_record_remove(
+            state, UCT_IB_MLX5_COCO_OBJ_CQ, cqn);
+}
+
+ucs_status_t uct_ib_mlx5_coco_qpn_record_remove(
+        uct_ib_mlx5_coco_state_t *state, uint32_t qpn)
+{
+    return uct_ib_mlx5_coco_obj_record_remove(
+            state, UCT_IB_MLX5_COCO_OBJ_QP, qpn);
+}
+
+ucs_status_t uct_ib_mlx5_coco_rmpn_record_remove(
+        uct_ib_mlx5_coco_state_t *state, uint32_t rmpn)
+{
+    return uct_ib_mlx5_coco_obj_record_remove(
+            state, UCT_IB_MLX5_COCO_OBJ_RMP, rmpn);
+}
+
+static ucs_status_t
+uct_ib_mlx5_coco_validate_umem_ref(const uct_ib_mlx5_coco_state_t *state,
+                                   uint32_t umem_id, uint64_t offset)
+{
+    const uct_ib_mlx5_coco_umem_record_t *record =
+            uct_ib_mlx5_coco_umem_record_find(state, umem_id);
+
+    if (record == NULL) {
+        return UCS_ERR_NO_ELEM;
+    }
+
+    return (offset < record->exposed_size) ? UCS_OK : UCS_ERR_INVALID_PARAM;
+}
+
+static ucs_status_t
+uct_ib_mlx5_coco_validate_out_header(const void *out, size_t out_len,
+                                     size_t required_len)
+{
+    if ((out == NULL) || (out_len < required_len)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return (UCT_IB_MLX5DV_GET(general_obj_out_cmd_hdr, out, status) == 0) ?
+           UCS_OK : UCS_ERR_IO_ERROR;
+}
+
+static int uct_ib_mlx5_coco_is_pow2(uint32_t value)
+{
+    return (value != 0) && ((value & (value - 1)) == 0);
+}
+
+static ucs_status_t
+uct_ib_mlx5_coco_validate_cq_req(const uct_ib_mlx5_coco_state_t *state,
+                                 const uct_ib_mlx5_coco_cq_req_t *req)
+{
+    ucs_status_t status;
+
+    if ((req == NULL) || !uct_ib_mlx5_coco_is_pow2(req->cq_len) ||
+        ((req->cqe_size != 64) && (req->cqe_size != 128))) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    status = uct_ib_mlx5_coco_validate_umem_ref(
+            state, req->cq_umem_id, req->cq_umem_offset);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    return uct_ib_mlx5_coco_validate_umem_ref(
+            state, req->dbr_umem_id, req->dbr_offset);
+}
+
+static ucs_status_t
+uct_ib_mlx5_coco_validate_qp_req(const uct_ib_mlx5_coco_state_t *state,
+                                 const uct_ib_mlx5_coco_qp_req_t *req)
+{
+    ucs_status_t status;
+
+    if (req == NULL) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    if (req->qp_type != IBV_QPT_RC) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if (!uct_ib_mlx5_coco_is_pow2(req->sq_wqe_count)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    if (uct_ib_mlx5_coco_obj_record_find(
+                state, UCT_IB_MLX5_COCO_OBJ_CQ, req->send_cqn) == NULL) {
+        return UCS_ERR_NO_ELEM;
+    }
+
+    if (uct_ib_mlx5_coco_obj_record_find(
+                state, UCT_IB_MLX5_COCO_OBJ_CQ, req->recv_cqn) == NULL) {
+        return UCS_ERR_NO_ELEM;
+    }
+
+    if ((req->rmpn != 0) &&
+        (uct_ib_mlx5_coco_obj_record_find(
+                state, UCT_IB_MLX5_COCO_OBJ_RMP, req->rmpn) == NULL)) {
+        return UCS_ERR_NO_ELEM;
+    }
+
+    status = uct_ib_mlx5_coco_validate_umem_ref(state, req->wq_umem_id, 0);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    return uct_ib_mlx5_coco_validate_umem_ref(state, req->dbr_umem_id, 0);
+}
+
+static ucs_status_t
+uct_ib_mlx5_coco_validate_rmp_req(const uct_ib_mlx5_coco_state_t *state,
+                                  const uct_ib_mlx5_coco_rmp_req_t *req)
+{
+    ucs_status_t status;
+
+    if ((req == NULL) || !uct_ib_mlx5_coco_is_pow2(req->wq_size) ||
+        !uct_ib_mlx5_coco_is_pow2(req->stride)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    if (!req->cyclic || req->mp_enabled) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    status = uct_ib_mlx5_coco_validate_umem_ref(state, req->wq_umem_id, 0);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    return uct_ib_mlx5_coco_validate_umem_ref(state, req->dbr_umem_id, 0);
+}
+
+ucs_status_t
+uct_ib_mlx5_coco_validate_cq_output(uct_ib_mlx5_md_t *md,
+                                    const uct_ib_mlx5_coco_cq_req_t *req,
+                                    const void *out, size_t out_len,
+                                    uint32_t *cqn_p)
+{
+    ucs_status_t status;
+    uint32_t cqn;
+
+    if ((md == NULL) || (cqn_p == NULL)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    status = uct_ib_mlx5_coco_validate_cq_req(md->coco, req);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_ib_mlx5_coco_validate_out_header(
+            out, out_len, UCT_IB_MLX5DV_ST_SZ_BYTES(create_cq_out));
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    cqn    = UCT_IB_MLX5DV_GET(create_cq_out, out, cqn);
+    status = uct_ib_mlx5_coco_obj_record_add(
+            md->coco, UCT_IB_MLX5_COCO_OBJ_CQ, cqn);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    *cqn_p = cqn;
+    return UCS_OK;
+}
+
+ucs_status_t
+uct_ib_mlx5_coco_validate_qp_output(uct_ib_mlx5_md_t *md,
+                                    const uct_ib_mlx5_coco_qp_req_t *req,
+                                    const void *out, size_t out_len,
+                                    uint32_t *qpn_p)
+{
+    ucs_status_t status;
+    uint32_t qpn;
+
+    if ((md == NULL) || (qpn_p == NULL)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    status = uct_ib_mlx5_coco_validate_qp_req(md->coco, req);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_ib_mlx5_coco_validate_out_header(
+            out, out_len, UCT_IB_MLX5DV_ST_SZ_BYTES(create_qp_out));
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    qpn    = UCT_IB_MLX5DV_GET(create_qp_out, out, qpn);
+    status = uct_ib_mlx5_coco_obj_record_add(
+            md->coco, UCT_IB_MLX5_COCO_OBJ_QP, qpn);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    *qpn_p = qpn;
+    return UCS_OK;
+}
+
+ucs_status_t
+uct_ib_mlx5_coco_validate_rmp_output(uct_ib_mlx5_md_t *md,
+                                     const uct_ib_mlx5_coco_rmp_req_t *req,
+                                     const void *out, size_t out_len,
+                                     uint32_t *rmpn_p)
+{
+    ucs_status_t status;
+    uint32_t rmpn;
+
+    if ((md == NULL) || (rmpn_p == NULL)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    status = uct_ib_mlx5_coco_validate_rmp_req(md->coco, req);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = uct_ib_mlx5_coco_validate_out_header(
+            out, out_len, UCT_IB_MLX5DV_ST_SZ_BYTES(create_rmp_out));
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    rmpn   = UCT_IB_MLX5DV_GET(create_rmp_out, out, rmpn);
+    status = uct_ib_mlx5_coco_obj_record_add(
+            md->coco, UCT_IB_MLX5_COCO_OBJ_RMP, rmpn);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    *rmpn_p = rmpn;
+    return UCS_OK;
 }
 
 static void uct_ib_mlx5_coco_scrub(void *addr, size_t size)

--- a/src/uct/ib/mlx5/ib_mlx5_coco.c
+++ b/src/uct/ib/mlx5/ib_mlx5_coco.c
@@ -111,7 +111,7 @@ uct_ib_mlx5_coco_default_umem_reg(uct_ib_mlx5_md_t *md,
                                   struct mlx5dv_devx_umem **umem_p,
                                   void *arg)
 {
-#if HAVE_DECL_MLX5DV_DEVX_UMEM_REG_EX && HAVE_DECL_MLX5DV_UMEM_MASK_DMABUF && \
+#if HAVE_MLX5DV_DEVX_UMEM_REG_EX && HAVE_DECL_MLX5DV_UMEM_MASK_DMABUF && \
     HAVE_STRUCT_MLX5DV_DEVX_UMEM_IN
     struct mlx5dv_devx_umem_in umem_in;
 
@@ -164,6 +164,9 @@ uct_ib_mlx5_coco_shared_alloc_backend = {
     NULL
 };
 
+/* Unit tests override the process-wide backend before creating MDs and restore
+ * it after the test; production code only uses the default backend.
+ */
 void uct_ib_mlx5_coco_set_shared_alloc_ops(
         const uct_ib_mlx5_coco_shared_alloc_ops_t *ops, void *arg)
 {

--- a/src/uct/ib/mlx5/ib_mlx5_coco.h
+++ b/src/uct/ib/mlx5/ib_mlx5_coco.h
@@ -14,8 +14,8 @@
 
 struct mlx5dv_devx_umem;
 
-typedef struct uct_ib_mlx5_md uct_ib_mlx5_md_t;
-typedef struct uct_ib_mlx5_devx_umem uct_ib_mlx5_devx_umem_t;
+struct uct_ib_mlx5_md;
+struct uct_ib_mlx5_devx_umem;
 typedef struct uct_ib_mlx5_coco_state uct_ib_mlx5_coco_state_t;
 
 typedef struct uct_ib_mlx5_coco_shared_alloc {
@@ -45,9 +45,40 @@ typedef struct uct_ib_mlx5_coco_mkey_record {
     uint8_t  live;
 } uct_ib_mlx5_coco_mkey_record_t;
 
+typedef struct uct_ib_mlx5_coco_cq_req {
+    uint32_t cq_len;
+    uint32_t cqe_size;
+    uint32_t cq_umem_id;
+    uint64_t cq_umem_offset;
+    uint32_t dbr_umem_id;
+    uint64_t dbr_offset;
+    uint32_t eqn;
+    uint32_t uar_page;
+} uct_ib_mlx5_coco_cq_req_t;
+
+typedef struct uct_ib_mlx5_coco_qp_req {
+    uint8_t  qp_type;
+    uint32_t send_cqn;
+    uint32_t recv_cqn;
+    uint32_t rmpn;
+    uint32_t wq_umem_id;
+    uint32_t dbr_umem_id;
+    uint32_t sq_wqe_count;
+    uint32_t rq_wqe_count;
+} uct_ib_mlx5_coco_qp_req_t;
+
+typedef struct uct_ib_mlx5_coco_rmp_req {
+    uint32_t wq_umem_id;
+    uint32_t dbr_umem_id;
+    uint32_t wq_size;
+    uint32_t stride;
+    uint8_t  cyclic;
+    uint8_t  mp_enabled;
+} uct_ib_mlx5_coco_rmp_req_t;
+
 typedef struct uct_ib_mlx5_coco_shared_alloc_ops {
     ucs_status_t (*alloc)(size_t size, void **addr_p, int *fd_p, void *arg);
-    ucs_status_t (*umem_reg)(uct_ib_mlx5_md_t *md,
+    ucs_status_t (*umem_reg)(struct uct_ib_mlx5_md *md,
                              const uct_ib_mlx5_coco_shared_alloc_t *alloc,
                              int access_mode,
                              struct mlx5dv_devx_umem **umem_p, void *arg);
@@ -59,23 +90,24 @@ typedef struct uct_ib_mlx5_coco_shared_alloc_ops {
 ucs_status_t uct_ib_mlx5_coco_exposed_size(size_t requested_size,
                                            size_t *exposed_size_p);
 
-ucs_status_t uct_ib_mlx5_coco_state_init(uct_ib_mlx5_md_t *md);
+ucs_status_t uct_ib_mlx5_coco_state_init(struct uct_ib_mlx5_md *md);
 
-void uct_ib_mlx5_coco_state_cleanup(uct_ib_mlx5_md_t *md);
+void uct_ib_mlx5_coco_state_cleanup(struct uct_ib_mlx5_md *md);
 
-int uct_ib_mlx5_coco_mkey_policy_ready(const uct_ib_mlx5_md_t *md);
+int uct_ib_mlx5_coco_mkey_policy_ready(const struct uct_ib_mlx5_md *md);
 
 void uct_ib_mlx5_coco_set_shared_alloc_ops(
         const uct_ib_mlx5_coco_shared_alloc_ops_t *ops, void *arg);
 
 ucs_status_t
-uct_ib_mlx5_coco_md_buf_alloc_shared(uct_ib_mlx5_md_t *md, size_t size,
+uct_ib_mlx5_coco_md_buf_alloc_shared(struct uct_ib_mlx5_md *md, size_t size,
                                      int silent, void **buf_p,
-                                     uct_ib_mlx5_devx_umem_t *mem,
+                                     struct uct_ib_mlx5_devx_umem *mem,
                                      int access_mode, char *name);
 
-void uct_ib_mlx5_coco_md_buf_free_shared(uct_ib_mlx5_md_t *md, void *buf,
-                                         uct_ib_mlx5_devx_umem_t *mem);
+void
+uct_ib_mlx5_coco_md_buf_free_shared(struct uct_ib_mlx5_md *md, void *buf,
+                                    struct uct_ib_mlx5_devx_umem *mem);
 
 ucs_status_t
 uct_ib_mlx5_coco_umem_record_add(uct_ib_mlx5_coco_state_t *state,
@@ -122,5 +154,35 @@ uct_ib_mlx5_coco_mkey_record_remove_rkey(uct_ib_mlx5_coco_state_t *state,
 const uct_ib_mlx5_coco_mkey_record_t*
 uct_ib_mlx5_coco_mkey_record_find_lkey(const uct_ib_mlx5_coco_state_t *state,
                                        uint32_t lkey);
+
+ucs_status_t
+uct_ib_mlx5_coco_validate_cq_output(struct uct_ib_mlx5_md *md,
+                                    const uct_ib_mlx5_coco_cq_req_t *req,
+                                    const void *out, size_t out_len,
+                                    uint32_t *cqn_p);
+
+ucs_status_t
+uct_ib_mlx5_coco_validate_qp_output(struct uct_ib_mlx5_md *md,
+                                    const uct_ib_mlx5_coco_qp_req_t *req,
+                                    const void *out, size_t out_len,
+                                    uint32_t *qpn_p);
+
+ucs_status_t
+uct_ib_mlx5_coco_validate_rmp_output(struct uct_ib_mlx5_md *md,
+                                     const uct_ib_mlx5_coco_rmp_req_t *req,
+                                     const void *out, size_t out_len,
+                                     uint32_t *rmpn_p);
+
+ucs_status_t
+uct_ib_mlx5_coco_cqn_record_remove(uct_ib_mlx5_coco_state_t *state,
+                                   uint32_t cqn);
+
+ucs_status_t
+uct_ib_mlx5_coco_qpn_record_remove(uct_ib_mlx5_coco_state_t *state,
+                                   uint32_t qpn);
+
+ucs_status_t
+uct_ib_mlx5_coco_rmpn_record_remove(uct_ib_mlx5_coco_state_t *state,
+                                    uint32_t rmpn);
 
 #endif

--- a/src/uct/ib/mlx5/ib_mlx5_coco.h
+++ b/src/uct/ib/mlx5/ib_mlx5_coco.h
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCT_IB_MLX5_COCO_H_
+#define UCT_IB_MLX5_COCO_H_
+
+#include <ucs/type/status.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct mlx5dv_devx_umem;
+
+typedef struct uct_ib_mlx5_md uct_ib_mlx5_md_t;
+typedef struct uct_ib_mlx5_devx_umem uct_ib_mlx5_devx_umem_t;
+typedef struct uct_ib_mlx5_coco_state uct_ib_mlx5_coco_state_t;
+
+typedef struct uct_ib_mlx5_coco_shared_alloc {
+    void   *addr;
+    size_t requested_size;
+    size_t exposed_size;
+    int    dmabuf_fd;
+    int    umem_registered;
+    int    quarantined;
+} uct_ib_mlx5_coco_shared_alloc_t;
+
+typedef struct uct_ib_mlx5_coco_umem_record {
+    uint32_t umem_id;
+    void     *addr;
+    size_t   requested_size;
+    size_t   exposed_size;
+    uint32_t access_flags;
+    uint8_t  live;
+} uct_ib_mlx5_coco_umem_record_t;
+
+typedef struct uct_ib_mlx5_coco_mkey_record {
+    uint32_t lkey;
+    uint32_t rkey;
+    void     *base;
+    size_t   length;
+    uint64_t access_mask;
+    uint8_t  live;
+} uct_ib_mlx5_coco_mkey_record_t;
+
+typedef struct uct_ib_mlx5_coco_shared_alloc_ops {
+    ucs_status_t (*alloc)(size_t size, void **addr_p, int *fd_p, void *arg);
+    ucs_status_t (*umem_reg)(uct_ib_mlx5_md_t *md,
+                             const uct_ib_mlx5_coco_shared_alloc_t *alloc,
+                             int access_mode,
+                             struct mlx5dv_devx_umem **umem_p, void *arg);
+    ucs_status_t (*umem_dereg)(struct mlx5dv_devx_umem *umem, void *arg);
+    ucs_status_t (*unmap)(void *addr, size_t size, void *arg);
+    ucs_status_t (*close_fd)(int fd, void *arg);
+} uct_ib_mlx5_coco_shared_alloc_ops_t;
+
+ucs_status_t uct_ib_mlx5_coco_exposed_size(size_t requested_size,
+                                           size_t *exposed_size_p);
+
+ucs_status_t uct_ib_mlx5_coco_state_init(uct_ib_mlx5_md_t *md);
+
+void uct_ib_mlx5_coco_state_cleanup(uct_ib_mlx5_md_t *md);
+
+int uct_ib_mlx5_coco_mkey_policy_ready(const uct_ib_mlx5_md_t *md);
+
+void uct_ib_mlx5_coco_set_shared_alloc_ops(
+        const uct_ib_mlx5_coco_shared_alloc_ops_t *ops, void *arg);
+
+ucs_status_t
+uct_ib_mlx5_coco_md_buf_alloc_shared(uct_ib_mlx5_md_t *md, size_t size,
+                                     int silent, void **buf_p,
+                                     uct_ib_mlx5_devx_umem_t *mem,
+                                     int access_mode, char *name);
+
+void uct_ib_mlx5_coco_md_buf_free_shared(uct_ib_mlx5_md_t *md, void *buf,
+                                         uct_ib_mlx5_devx_umem_t *mem);
+
+ucs_status_t
+uct_ib_mlx5_coco_umem_record_add(uct_ib_mlx5_coco_state_t *state,
+                                 uint32_t umem_id, void *addr,
+                                 size_t requested_size, size_t exposed_size,
+                                 uint32_t access_flags);
+
+ucs_status_t
+uct_ib_mlx5_coco_umem_record_validate(const uct_ib_mlx5_coco_state_t *state,
+                                      uint32_t umem_id, void *addr,
+                                      size_t requested_size,
+                                      size_t exposed_size,
+                                      uint32_t access_flags);
+
+ucs_status_t
+uct_ib_mlx5_coco_umem_record_remove(uct_ib_mlx5_coco_state_t *state,
+                                    uint32_t umem_id);
+
+const uct_ib_mlx5_coco_umem_record_t*
+uct_ib_mlx5_coco_umem_record_find(const uct_ib_mlx5_coco_state_t *state,
+                                  uint32_t umem_id);
+
+uint64_t uct_ib_mlx5_coco_mkey_sanitize_access(uint64_t access_mask);
+
+ucs_status_t
+uct_ib_mlx5_coco_mkey_record_add(uct_ib_mlx5_coco_state_t *state,
+                                 uint32_t lkey, uint32_t rkey, void *base,
+                                 size_t length, uint64_t access_mask);
+
+ucs_status_t
+uct_ib_mlx5_coco_mkey_record_validate(const uct_ib_mlx5_coco_state_t *state,
+                                      uint32_t lkey, uint32_t rkey,
+                                      void *base, size_t length,
+                                      uint64_t access_mask);
+
+ucs_status_t
+uct_ib_mlx5_coco_mkey_record_remove(uct_ib_mlx5_coco_state_t *state,
+                                    uint32_t lkey, uint32_t rkey);
+
+ucs_status_t
+uct_ib_mlx5_coco_mkey_record_remove_rkey(uct_ib_mlx5_coco_state_t *state,
+                                         uint32_t rkey);
+
+const uct_ib_mlx5_coco_mkey_record_t*
+uct_ib_mlx5_coco_mkey_record_find_lkey(const uct_ib_mlx5_coco_state_t *state,
+                                       uint32_t lkey);
+
+#endif

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -347,7 +347,8 @@ uct_rc_mlx5_verbs_create_cmd_qp(uct_rc_mlx5_iface_common_t *iface)
     qp_init_attr.srq                 = iface->rx.srq.verbs.srq;
     qp_init_attr.cap.max_send_wr     = iface->tm.cmd_qp_len;
 
-    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp, md->pd, &qp_init_attr);
+    qp = UCS_PROFILE_CALL_ALWAYS(ibv_create_qp, uct_ib_md_control_pd(md),
+                                 &qp_init_attr);
     if (qp == NULL) {
         ucs_error("failed to create TM control QP: %m");
         goto err_rd;
@@ -951,7 +952,7 @@ ucs_status_t uct_rc_mlx5_init_rx_tm(uct_rc_mlx5_iface_common_t *iface,
     srq_attr->attr.srq_limit      = 0;
     srq_attr->srq_context         = iface;
     srq_attr->srq_type            = IBV_SRQT_TM;
-    srq_attr->pd                  = md->pd;
+    srq_attr->pd                  = uct_ib_md_control_pd(md);
     srq_attr->cq                  = iface->super.super.cq[UCT_IB_DIR_RX];
     srq_attr->tm_cap.max_num_tags = iface->tm.num_tags;
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -435,6 +435,20 @@ typedef struct uct_rc_mlx5_iface_common_config {
     UCS_CONFIG_STRING_ARRAY_FIELD(types) srq_topo;
 } uct_rc_mlx5_iface_common_config_t;
 
+ucs_status_t
+uct_rc_mlx5_coco_check_config(
+        const uct_ib_mlx5_md_t *md,
+        const uct_rc_iface_common_config_t *rc_config,
+        const uct_rc_mlx5_iface_common_config_t *mlx5_config);
+
+void uct_rc_mlx5_coco_apply_effective_config(
+        const uct_ib_mlx5_md_t *md, uct_rc_iface_common_config_t *rc_config,
+        uct_rc_mlx5_iface_common_config_t *mlx5_config,
+        uct_ib_iface_init_attr_t *init_attr);
+
+void uct_rc_mlx5_coco_mask_capabilities(const uct_ib_mlx5_md_t *md,
+                                        uct_iface_attr_t *iface_attr);
+
 
 UCS_CLASS_DECLARE(uct_rc_mlx5_iface_common_t, uct_iface_ops_t*,
                   uct_rc_iface_ops_t*, uct_md_h, uct_worker_h,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_devx.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_devx.c
@@ -344,7 +344,16 @@ ucs_status_t uct_rc_mlx5_devx_init_rx(uct_rc_mlx5_iface_common_t *iface,
     char in[UCT_IB_MLX5DV_ST_SZ_BYTES(create_rmp_in)]   = {};
     char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_rmp_out)] = {};
     ucs_status_t status;
+    uct_ib_mlx5_coco_rmp_req_t coco_req;
+    int stride, max;
+    uint32_t rmpn;
     void *rmpc;
+
+    if (uct_ib_md_is_coco_hardened(&md->super) &&
+        ((iface->config.srq_topo != UCT_RC_MLX5_SRQ_TOPO_CYCLIC) ||
+         UCT_RC_MLX5_MP_ENABLED(iface))) {
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     UCT_IB_MLX5DV_SET(create_rmp_in, in, opcode, UCT_IB_MLX5_CMD_OP_CREATE_RMP);
     rmpc = UCT_IB_MLX5DV_ADDR_OF(create_rmp_in, in, rmp_context);
@@ -357,6 +366,18 @@ ucs_status_t uct_rc_mlx5_devx_init_rx(uct_rc_mlx5_iface_common_t *iface,
         return status;
     }
 
+    stride = uct_ib_mlx5_srq_stride(iface->tm.mp.num_strides);
+    max    = uct_ib_mlx5_srq_max_wrs(config->super.rx.queue_len,
+                                     iface->tm.mp.num_strides);
+    max    = ucs_roundup_pow2(max);
+
+    coco_req.wq_umem_id  = iface->rx.srq.devx.mem.mem->umem_id;
+    coco_req.dbr_umem_id = iface->rx.srq.devx.dbrec->mem_id;
+    coco_req.wq_size     = max;
+    coco_req.stride      = stride;
+    coco_req.cyclic      = 1;
+    coco_req.mp_enabled  = 0;
+
     iface->rx.srq.devx.obj = uct_ib_mlx5_devx_obj_create(dev->ibv_context, in,
                                                          sizeof(in), out,
                                                          sizeof(out), "RMP",
@@ -366,10 +387,21 @@ ucs_status_t uct_rc_mlx5_devx_init_rx(uct_rc_mlx5_iface_common_t *iface,
         goto err_cleanup_srq;
     }
 
-    iface->rx.srq.srq_num = UCT_IB_MLX5DV_GET(create_rmp_out, out, rmpn);
+    if (uct_ib_md_is_coco_hardened(&md->super)) {
+        status = uct_ib_mlx5_coco_validate_rmp_output(md, &coco_req, out,
+                                                      sizeof(out), &rmpn);
+        if (status != UCS_OK) {
+            goto err_destroy_rmp;
+        }
+    } else {
+        rmpn = UCT_IB_MLX5DV_GET(create_rmp_out, out, rmpn);
+    }
+    iface->rx.srq.srq_num = rmpn;
 
     return UCS_OK;
 
+err_destroy_rmp:
+    uct_ib_mlx5_devx_obj_destroy(iface->rx.srq.devx.obj, "RMP");
 err_cleanup_srq:
     uct_rc_mlx5_devx_cleanup_srq(md, &iface->rx.srq);
     return status;
@@ -377,6 +409,7 @@ err_cleanup_srq:
 
 void uct_rc_mlx5_devx_cleanup_srq(uct_ib_mlx5_md_t *md, uct_ib_mlx5_srq_t *srq)
 {
+    (void)uct_ib_mlx5_coco_rmpn_record_remove(md->coco, srq->srq_num);
     uct_ib_mlx5_put_dbrec(srq->devx.dbrec);
     uct_ib_mlx5_md_buf_free(md, srq->buf, &srq->devx.mem);
 }
@@ -515,4 +548,3 @@ ucs_status_t uct_rc_mlx5_iface_common_devx_connect_qp(
               iface->super.config.max_rd_atomic);
     return UCS_OK;
 }
-

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -548,12 +548,10 @@ uct_rc_mlx5_iface_init_rx(uct_rc_iface_t *rc_iface,
 
     if (UCT_RC_MLX5_TM_ENABLED(iface)) {
         if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ) {
-            if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
-                ucs_error("%s: %s is not CoCo control-object safe in this "
-                          "milestone",
-                          uct_ib_device_name(&md->super.dev),
-                          "rc_mlx5 tag-matching DEVX");
-                return UCS_ERR_UNSUPPORTED;
+            status = uct_ib_md_check_cc_dma_bounce_supported(
+                    &md->super, "rc_mlx5 tag-matching DEVX");
+            if (status != UCS_OK) {
+                return status;
             }
 
             status = uct_rc_mlx5_devx_init_rx_tm(iface, rc_config, 0,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -142,10 +142,14 @@ void uct_rc_mlx5_coco_mask_capabilities(const uct_ib_mlx5_md_t *md,
         return;
     }
 
-    iface_attr->cap.flags &= ~(rma_flags | UCT_IFACE_FLAG_ATOMIC_CPU |
+    iface_attr->cap.flags &= ~(UCT_IFACE_FLAG_ATOMIC_CPU |
                                UCT_IFACE_FLAG_ATOMIC_DEVICE);
-    memset(&iface_attr->cap.put, 0, sizeof(iface_attr->cap.put));
-    memset(&iface_attr->cap.get, 0, sizeof(iface_attr->cap.get));
+    if (md->coco == NULL) {
+        iface_attr->cap.flags &= ~rma_flags;
+        memset(&iface_attr->cap.put, 0, sizeof(iface_attr->cap.put));
+        memset(&iface_attr->cap.get, 0, sizeof(iface_attr->cap.get));
+    }
+
     memset(&iface_attr->cap.atomic32, 0, sizeof(iface_attr->cap.atomic32));
     memset(&iface_attr->cap.atomic64, 0, sizeof(iface_attr->cap.atomic64));
 }

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -548,6 +548,14 @@ uct_rc_mlx5_iface_init_rx(uct_rc_iface_t *rc_iface,
 
     if (UCT_RC_MLX5_TM_ENABLED(iface)) {
         if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ) {
+            if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
+                ucs_error("%s: %s is not CoCo control-object safe in this "
+                          "milestone",
+                          uct_ib_device_name(&md->super.dev),
+                          "rc_mlx5 tag-matching DEVX");
+                return UCS_ERR_UNSUPPORTED;
+            }
+
             status = uct_rc_mlx5_devx_init_rx_tm(iface, rc_config, 0,
                                                  UCT_RC_RNDV_HDR_LEN);
         } else {

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -18,6 +18,7 @@
 #include <ucs/arch/cpu.h>
 #include <ucs/debug/log.h>
 #include <ucs/profile/profile.h>
+#include <string.h>
 
 #include "rc_mlx5.inl"
 
@@ -43,6 +44,121 @@ ucs_config_field_t uct_rc_mlx5_iface_config_table[] = {
 
   {NULL}
 };
+
+
+static int
+uct_rc_mlx5_coco_srq_topo_has(
+        const uct_rc_mlx5_iface_common_config_t *mlx5_config,
+        const char *topo_name)
+{
+    int i;
+
+    for (i = 0; i < mlx5_config->srq_topo.count; ++i) {
+        if (!strcasecmp(mlx5_config->srq_topo.types[i], topo_name)) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static ucs_status_t
+uct_rc_mlx5_coco_reject_config(const char *name)
+{
+    ucs_error("CoCo hardening does not support %s", name);
+    return UCS_ERR_UNSUPPORTED;
+}
+
+ucs_status_t
+uct_rc_mlx5_coco_check_config(
+        const uct_ib_mlx5_md_t *md,
+        const uct_rc_iface_common_config_t *rc_config,
+        const uct_rc_mlx5_iface_common_config_t *mlx5_config)
+{
+    if (!uct_ib_md_is_coco_hardened(&md->super)) {
+        return UCS_OK;
+    }
+
+    if (mlx5_config->tm.enable) {
+        return uct_rc_mlx5_coco_reject_config("TM_ENABLE=y");
+    }
+
+    if (mlx5_config->tm.mp_enable == UCS_YES) {
+        return uct_rc_mlx5_coco_reject_config("TM_MP_SRQ_ENABLE=y");
+    }
+
+    if (mlx5_config->super.cqe_zip_enable[UCT_IB_DIR_TX]) {
+        return uct_rc_mlx5_coco_reject_config("TX_CQE_ZIP_ENABLE=y");
+    }
+
+    if (mlx5_config->super.cqe_zip_enable[UCT_IB_DIR_RX]) {
+        return uct_rc_mlx5_coco_reject_config("RX_CQE_ZIP_ENABLE=y");
+    }
+
+    if (mlx5_config->ddp_enable == UCS_YES) {
+        return uct_rc_mlx5_coco_reject_config("DDP_ENABLE=y");
+    }
+
+    if (!uct_rc_mlx5_coco_srq_topo_has(mlx5_config, "cyclic")) {
+        return uct_rc_mlx5_coco_reject_config("SRQ_TOPO without cyclic");
+    }
+
+    return UCS_OK;
+}
+
+void uct_rc_mlx5_coco_apply_effective_config(
+        const uct_ib_mlx5_md_t *md, uct_rc_iface_common_config_t *rc_config,
+        uct_rc_mlx5_iface_common_config_t *mlx5_config,
+        uct_ib_iface_init_attr_t *init_attr)
+{
+    if (!uct_ib_md_is_coco_hardened(&md->super)) {
+        return;
+    }
+
+    mlx5_config->tm.enable                         = 0;
+    mlx5_config->tm.mp_enable                      = UCS_NO;
+    mlx5_config->ddp_enable                        = UCS_NO;
+    mlx5_config->super.cqe_zip_enable[UCT_IB_DIR_TX] = 0;
+    mlx5_config->super.cqe_zip_enable[UCT_IB_DIR_RX] = 0;
+    rc_config->super.inl[UCT_IB_DIR_TX]            = 0;
+    rc_config->super.inl[UCT_IB_DIR_RX]            = 0;
+    init_attr->flags                              &= ~(UCT_IB_DDP_SUPPORTED |
+                                                       UCT_IB_TM_SUPPORTED);
+    init_attr->cqe_zip_sizes[UCT_IB_DIR_TX]        = 0;
+    init_attr->cqe_zip_sizes[UCT_IB_DIR_RX]        = 0;
+}
+
+void uct_rc_mlx5_coco_mask_capabilities(const uct_ib_mlx5_md_t *md,
+                                        uct_iface_attr_t *iface_attr)
+{
+    const uint64_t rma_flags = UCT_IFACE_FLAG_PUT_SHORT |
+                               UCT_IFACE_FLAG_PUT_BCOPY |
+                               UCT_IFACE_FLAG_PUT_ZCOPY |
+                               UCT_IFACE_FLAG_GET_SHORT |
+                               UCT_IFACE_FLAG_GET_BCOPY |
+                               UCT_IFACE_FLAG_GET_ZCOPY;
+
+    if (!uct_ib_md_is_coco_hardened(&md->super)) {
+        return;
+    }
+
+    iface_attr->cap.flags &= ~(rma_flags | UCT_IFACE_FLAG_ATOMIC_CPU |
+                               UCT_IFACE_FLAG_ATOMIC_DEVICE);
+    memset(&iface_attr->cap.put, 0, sizeof(iface_attr->cap.put));
+    memset(&iface_attr->cap.get, 0, sizeof(iface_attr->cap.get));
+    memset(&iface_attr->cap.atomic32, 0, sizeof(iface_attr->cap.atomic32));
+    memset(&iface_attr->cap.atomic64, 0, sizeof(iface_attr->cap.atomic64));
+}
+
+static void
+uct_rc_mlx5_coco_log_policy(const uct_ib_mlx5_md_t *md, const char *profile)
+{
+    ucs_info("CoCo hardening policy: md=%s cc_dma_bounce=%d hardened=%d "
+             "profile=%s",
+             md->super.name == NULL ? "<unknown>" : md->super.name,
+             md->super.cc_dma_bounce,
+             uct_ib_md_is_coco_hardened(&md->super), profile);
+}
 
 
 static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops;
@@ -181,6 +297,8 @@ static ucs_status_t uct_rc_mlx5_iface_query(uct_iface_h tl_iface, uct_iface_attr
     iface_attr->latency.m     += 1e-9; /* 1 ns per each extra QP */
     iface_attr->ep_addr_len    = ep_addr_len;
     iface_attr->iface_addr_len = sizeof(uint8_t);
+    uct_rc_mlx5_coco_mask_capabilities(uct_ib_mlx5_iface_md(&rc_iface->super),
+                                       iface_attr);
     return UCS_OK;
 }
 
@@ -376,6 +494,23 @@ uct_rc_mlx5_iface_parse_srq_topo(uct_ib_mlx5_md_t *md,
                                          UCT_IB_MLX5_MD_FLAG_DEVX_RC_SRQ);
     ucs_string_buffer_t strb  = UCS_STRING_BUFFER_INITIALIZER;
     int i;
+
+    if (uct_ib_md_is_coco_hardened(&md->super)) {
+        if (!uct_rc_mlx5_coco_srq_topo_has(config, "cyclic")) {
+            ucs_error("%s: CoCo hardening requires cyclic SRQ topology",
+                      uct_ib_device_name(&md->super.dev));
+            return UCS_ERR_INVALID_PARAM;
+        }
+
+        if (ucs_test_all_flags(md->flags, cyclic_srq_flags) && !ddp_enabled) {
+            *topo_p = UCT_RC_MLX5_SRQ_TOPO_CYCLIC;
+            return UCS_OK;
+        }
+
+        ucs_error("%s: CoCo hardening requires real cyclic SRQ support",
+                  uct_ib_device_name(&md->super.dev));
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     for (i = 0; i < config->srq_topo.count; ++i) {
         if (!strcasecmp(config->srq_topo.types[i], "list")) {
@@ -751,6 +886,14 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
     uct_ib_device_t *dev;
     ucs_status_t status;
 
+    status = uct_rc_mlx5_coco_check_config(md, rc_config, mlx5_config);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    uct_rc_mlx5_coco_apply_effective_config(md, rc_config, mlx5_config,
+                                            init_attr);
+
     if (rc_config->super.seg_size > UCT_IB_MLX5_MP_RQ_BYTE_CNT_MASK) {
         ucs_error("IB segment size is too big %ld, it must not exceed %d",
                   rc_config->super.seg_size, UCT_IB_MLX5_MP_RQ_BYTE_CNT_MASK);
@@ -940,10 +1083,23 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_t,
     init_attr.tx_moderation         = config->super.tx_cq_moderation;
     init_attr.dev_name              = params->mode.device.dev_name;
 
-    if ((md->dp_ordering_cap_devx.rc == UCT_IB_MLX5_DP_ORDERING_OOO_ALL) ||
-        md->ddp_support_dv.rc) {
+    uct_rc_mlx5_coco_log_policy(md, "rc_mlx5");
+
+    status = uct_rc_mlx5_coco_check_config(md, &config->super.super,
+                                           &config->rc_mlx5_common);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    if (!uct_ib_md_is_coco_hardened(&md->super) &&
+        ((md->dp_ordering_cap_devx.rc == UCT_IB_MLX5_DP_ORDERING_OOO_ALL) ||
+         md->ddp_support_dv.rc)) {
         init_attr.flags |= UCT_IB_DDP_SUPPORTED;
     }
+
+    uct_rc_mlx5_coco_apply_effective_config(md, &config->super.super,
+                                            &config->rc_mlx5_common,
+                                            &init_attr);
 
     status = uct_rc_mlx5_dp_ordering_ooo_init(md, &self->super,
                                               md->dp_ordering_cap_devx.rc,
@@ -1085,6 +1241,13 @@ uct_rc_mlx5_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_
     if (strcmp(ib_md->name, UCT_IB_MD_NAME(mlx5))) {
         return UCS_ERR_NO_DEVICE;
     }
+
+    if (!uct_ib_md_coco_transport_allowed(ib_md, "rc_mlx5")) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    uct_rc_mlx5_coco_log_policy(ucs_derived_of(md, uct_ib_mlx5_md_t),
+                                "rc_mlx5");
 
     flags = UCT_IB_DEVICE_FLAG_SRQ | UCT_IB_DEVICE_FLAG_MLX5_PRM |
             (ib_md->config.eth_pause ? 0 : UCT_IB_DEVICE_FLAG_LINK_IB);

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -115,6 +115,28 @@ void uct_rc_mlx5_coco_apply_effective_config(
         return;
     }
 
+    if (mlx5_config->tm.enable || (mlx5_config->tm.mp_enable != UCS_NO) ||
+        (init_attr->flags & UCT_IB_TM_SUPPORTED)) {
+        ucs_diag("CoCo hardening disables RC mlx5 tag matching support");
+    }
+
+    if ((mlx5_config->ddp_enable != UCS_NO) ||
+        (init_attr->flags & UCT_IB_DDP_SUPPORTED)) {
+        ucs_diag("CoCo hardening disables RC mlx5 DDP support");
+    }
+
+    if (mlx5_config->super.cqe_zip_enable[UCT_IB_DIR_TX] ||
+        mlx5_config->super.cqe_zip_enable[UCT_IB_DIR_RX] ||
+        init_attr->cqe_zip_sizes[UCT_IB_DIR_TX] ||
+        init_attr->cqe_zip_sizes[UCT_IB_DIR_RX]) {
+        ucs_diag("CoCo hardening disables RC mlx5 CQE zipping support");
+    }
+
+    if (rc_config->super.inl[UCT_IB_DIR_TX] ||
+        rc_config->super.inl[UCT_IB_DIR_RX]) {
+        ucs_diag("CoCo hardening disables RC mlx5 inline send support");
+    }
+
     mlx5_config->tm.enable                         = 0;
     mlx5_config->tm.mp_enable                      = UCS_NO;
     mlx5_config->ddp_enable                        = UCS_NO;
@@ -157,7 +179,7 @@ void uct_rc_mlx5_coco_mask_capabilities(const uct_ib_mlx5_md_t *md,
 static void
 uct_rc_mlx5_coco_log_policy(const uct_ib_mlx5_md_t *md, const char *profile)
 {
-    ucs_info("CoCo hardening policy: md=%s cc_dma_bounce=%d hardened=%d "
+    ucs_debug("CoCo hardening policy: md=%s cc_dma_bounce=%d hardened=%d "
              "profile=%s",
              md->super.name == NULL ? "<unknown>" : md->super.name,
              md->super.cc_dma_bounce,
@@ -1243,10 +1265,6 @@ uct_rc_mlx5_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_
     int flags;
 
     if (strcmp(ib_md->name, UCT_IB_MD_NAME(mlx5))) {
-        return UCS_ERR_NO_DEVICE;
-    }
-
-    if (!uct_ib_md_coco_transport_allowed(ib_md, "rc_mlx5")) {
         return UCS_ERR_NO_DEVICE;
     }
 

--- a/src/uct/ib/mlx5/ud/ud_mlx5.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.c
@@ -989,10 +989,9 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t, uct_md_h tl_md,
 
     ucs_trace_func("");
 
-    if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
-        ucs_error("%s: %s is not CoCo control-object safe in this milestone",
-                  uct_ib_device_name(&md->super.dev), "ud_mlx5");
-        return UCS_ERR_UNSUPPORTED;
+    status = uct_ib_md_check_cc_dma_bounce_supported(&md->super, "ud_mlx5");
+    if (status != UCS_OK) {
+        return status;
     }
 
     status = uct_ud_mlx5dv_calc_tx_wqe_ratio(md);

--- a/src/uct/ib/mlx5/ud/ud_mlx5.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.c
@@ -1090,6 +1090,10 @@ uct_ud_mlx5_query_tl_devices(uct_md_h md,
         return UCS_ERR_NO_DEVICE;
     }
 
+    if (!uct_ib_md_coco_transport_allowed(ib_md, "ud_mlx5")) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
     return uct_ib_device_query_ports(&ib_md->dev, UCT_IB_DEVICE_FLAG_MLX5_PRM,
                                      tl_devices_p, num_tl_devices_p);
 }

--- a/src/uct/ib/mlx5/ud/ud_mlx5.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.c
@@ -1090,7 +1090,7 @@ uct_ud_mlx5_query_tl_devices(uct_md_h md,
         return UCS_ERR_NO_DEVICE;
     }
 
-    if (!uct_ib_md_coco_transport_allowed(ib_md, "ud_mlx5")) {
+    if (uct_ib_md_is_coco_hardened(ib_md)) {
         return UCS_ERR_NO_DEVICE;
     }
 

--- a/src/uct/ib/mlx5/ud/ud_mlx5.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.c
@@ -989,6 +989,12 @@ static UCS_CLASS_INIT_FUNC(uct_ud_mlx5_iface_t, uct_md_h tl_md,
 
     ucs_trace_func("");
 
+    if (uct_ib_md_is_cc_dma_bounce(&md->super)) {
+        ucs_error("%s: %s is not CoCo control-object safe in this milestone",
+                  uct_ib_device_name(&md->super.dev), "ud_mlx5");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     status = uct_ud_mlx5dv_calc_tx_wqe_ratio(md);
     if (status != UCS_OK) {
         return status;

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -508,7 +508,7 @@ ucs_status_t uct_rc_iface_init_rx(uct_rc_iface_t *iface,
                                   struct ibv_srq **srq_p)
 {
     struct ibv_srq_init_attr srq_init_attr;
-    struct ibv_pd *pd = uct_ib_iface_md(&iface->super)->pd;
+    struct ibv_pd *pd = uct_ib_md_control_pd(uct_ib_iface_md(&iface->super));
     struct ibv_srq *srq;
 
     srq_init_attr.attr.max_sge   = 1;

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -19,6 +19,7 @@
 #include <ucs/arch/bitops.h>
 #include <ucs/arch/cpu.h>
 #include <ucs/debug/log.h>
+#include <errno.h>
 #include <string.h>
 
 
@@ -519,8 +520,57 @@ static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
     .ep_vfs_populate = uct_rc_verbs_ep_vfs_populate
 };
 
-static ucs_status_t uct_rc_verbs_can_create_qp(struct ibv_pd *pd)
+static ucs_status_t
+uct_rc_verbs_create_probe_cq(uct_ib_md_t *ib_md, struct ibv_cq **cq_p)
 {
+    struct ibv_pd *pd = uct_ib_md_control_pd(ib_md);
+
+#if HAVE_DECL_IBV_CREATE_CQ_EX && HAVE_DECL_IBV_CQ_INIT_ATTR_MASK_PD && \
+    HAVE_STRUCT_IBV_CQ_INIT_ATTR_EX_PARENT_DOMAIN
+    struct ibv_cq_init_attr_ex cq_attr = {
+        .cqe           = 1,
+        .comp_mask     = IBV_CQ_INIT_ATTR_MASK_PD,
+        .parent_domain = pd
+    };
+
+    if (uct_ib_md_is_cc_dma_bounce(ib_md)) {
+        *cq_p = ibv_cq_ex_to_cq(ibv_create_cq_ex(pd->context, &cq_attr));
+        if (*cq_p != NULL) {
+            return UCS_OK;
+        }
+
+        if ((errno == EOPNOTSUPP) || (errno == ENOSYS) ||
+            (errno == EINVAL)) {
+            ucs_debug("CoCo RC verbs QP probe requires ibv_create_cq_ex() "
+                      "parent-domain support");
+            return UCS_ERR_UNSUPPORTED;
+        }
+
+        uct_ib_check_memlock_limit_msg(pd->context, UCS_LOG_LEVEL_DEBUG,
+                                       "ibv_create_cq_ex(cqe=%d)", 1);
+        return UCS_ERR_IO_ERROR;
+    }
+#else
+    if (uct_ib_md_is_cc_dma_bounce(ib_md)) {
+        ucs_debug("CoCo RC verbs QP probe requires ibv_create_cq_ex() "
+                  "parent-domain support");
+        return UCS_ERR_UNSUPPORTED;
+    }
+#endif
+
+    *cq_p = ibv_create_cq(pd->context, 1, NULL, NULL, 0);
+    if (*cq_p == NULL) {
+        uct_ib_check_memlock_limit_msg(pd->context, UCS_LOG_LEVEL_DEBUG,
+                                       "ibv_create_cq()");
+        return UCS_ERR_IO_ERROR;
+    }
+
+    return UCS_OK;
+}
+
+static ucs_status_t uct_rc_verbs_can_create_qp(uct_ib_md_t *ib_md)
+{
+    struct ibv_pd *pd = uct_ib_md_control_pd(ib_md);
     struct ibv_qp_init_attr qp_init_attr = {
         .qp_type             = IBV_QPT_RC,
         .sq_sig_all          = 0,
@@ -534,11 +584,8 @@ static ucs_status_t uct_rc_verbs_can_create_qp(struct ibv_pd *pd)
     struct ibv_qp *qp;
     ucs_status_t status;
 
-    cq = ibv_create_cq(pd->context, 1, NULL, NULL, 0);
-    if (cq == NULL) {
-        uct_ib_check_memlock_limit_msg(pd->context, UCS_LOG_LEVEL_DEBUG,
-                                       "ibv_create_cq()");
-        status = UCS_ERR_IO_ERROR;
+    status = uct_rc_verbs_create_probe_cq(ib_md, &cq);
+    if (status != UCS_OK) {
         goto err;
     }
 
@@ -571,7 +618,7 @@ uct_rc_verbs_query_tl_devices(uct_md_h md,
     ucs_status_t status;
 
     /* device does not support RC if we cannot create an RC QP */
-    status = uct_rc_verbs_can_create_qp(ib_md->pd);
+    status = uct_rc_verbs_can_create_qp(ib_md);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -617,6 +617,10 @@ uct_rc_verbs_query_tl_devices(uct_md_h md,
     uct_ib_md_t *ib_md = ucs_derived_of(md, uct_ib_md_t);
     ucs_status_t status;
 
+    if (!uct_ib_md_coco_transport_allowed(ib_md, "rc_verbs")) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
     /* device does not support RC if we cannot create an RC QP */
     status = uct_rc_verbs_can_create_qp(ib_md);
     if (status != UCS_OK) {

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -617,7 +617,7 @@ uct_rc_verbs_query_tl_devices(uct_md_h md,
     uct_ib_md_t *ib_md = ucs_derived_of(md, uct_ib_md_t);
     ucs_status_t status;
 
-    if (!uct_ib_md_coco_transport_allowed(ib_md, "rc_verbs")) {
+    if (uct_ib_md_is_coco_hardened(ib_md)) {
         return UCS_ERR_NO_DEVICE;
     }
 

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -881,6 +881,11 @@ uct_ud_verbs_query_tl_devices(uct_md_h md,
                               unsigned *num_tl_devices_p)
 {
     uct_ib_md_t *ib_md = ucs_derived_of(md, uct_ib_md_t);
+
+    if (!uct_ib_md_coco_transport_allowed(ib_md, "ud_verbs")) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
     return uct_ib_device_query_ports(&ib_md->dev, 0, tl_devices_p,
                                      num_tl_devices_p);
 }

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -882,7 +882,7 @@ uct_ud_verbs_query_tl_devices(uct_md_h md,
 {
     uct_ib_md_t *ib_md = ucs_derived_of(md, uct_ib_md_t);
 
-    if (!uct_ib_md_coco_transport_allowed(ib_md, "ud_verbs")) {
+    if (uct_ib_md_is_coco_hardened(ib_md)) {
         return UCS_ERR_NO_DEVICE;
     }
 

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -252,8 +252,10 @@ if HAVE_TL_RC
 gtest_SOURCES += \
 	uct/ib/test_rc.cc
 if HAVE_MLX5_DV
+if HAVE_DEVX
 gtest_SOURCES += \
 	uct/ib/test_coco_hardening.cc
+endif
 endif
 endif
 if HAVE_TL_DC

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -251,6 +251,10 @@ endif
 if HAVE_TL_RC
 gtest_SOURCES += \
 	uct/ib/test_rc.cc
+if HAVE_MLX5_DV
+gtest_SOURCES += \
+	uct/ib/test_coco_hardening.cc
+endif
 endif
 if HAVE_TL_DC
 gtest_SOURCES += \

--- a/test/gtest/uct/ib/test_coco_hardening.cc
+++ b/test/gtest/uct/ib/test_coco_hardening.cc
@@ -1,0 +1,270 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+
+extern "C" {
+#include <uct/ib/base/ib_md.h>
+#include <uct/ib/mlx5/ib_mlx5.h>
+#include <uct/ib/mlx5/rc/rc_mlx5_common.h>
+}
+
+namespace {
+
+void init_coco_rc_mlx5_config(uct_rc_iface_common_config_t *rc_config,
+                              uct_rc_mlx5_iface_common_config_t *mlx5_config)
+{
+    static char cyclic[] = "cyclic";
+    static char *cyclic_topo[] = {cyclic};
+
+    *rc_config                      = {};
+    *mlx5_config                    = {};
+    mlx5_config->srq_topo.types     = cyclic_topo;
+    mlx5_config->srq_topo.count     = 1;
+    mlx5_config->tm.mp_enable       = UCS_TRY;
+    mlx5_config->ddp_enable         = UCS_TRY;
+    rc_config->super.inl[UCT_IB_DIR_TX] = 64;
+}
+
+uct_ib_mlx5_md_t make_mlx5_md(int coco_hardened)
+{
+    uct_ib_mlx5_md_t md = {};
+
+    md.super.cc_dma_bounce = coco_hardened;
+    return md;
+}
+
+}
+
+
+class test_coco_hardening : public ucs::test {
+};
+
+UCS_TEST_F(test_coco_hardening, policy_helper_requires_cc_dma_bounce)
+{
+    uct_ib_md_t md = {};
+
+    md.cc_dma_bounce = 0;
+    EXPECT_FALSE(uct_ib_md_is_coco_hardened(&md));
+
+    md.cc_dma_bounce = 1;
+    EXPECT_TRUE(uct_ib_md_is_coco_hardened(&md));
+}
+
+UCS_TEST_F(test_coco_hardening, policy_transport_rc_mlx5_only)
+{
+    uct_ib_md_t md = {};
+
+    md.cc_dma_bounce = 0;
+    EXPECT_TRUE(uct_ib_md_coco_transport_allowed(&md, "rc_mlx5"));
+    EXPECT_TRUE(uct_ib_md_coco_transport_allowed(&md, "dc_mlx5"));
+    EXPECT_TRUE(uct_ib_md_coco_transport_allowed(&md, "ud_mlx5"));
+    EXPECT_TRUE(uct_ib_md_coco_transport_allowed(&md, "rc_verbs"));
+    EXPECT_TRUE(uct_ib_md_coco_transport_allowed(&md, "ud_verbs"));
+
+    md.cc_dma_bounce = 1;
+    EXPECT_TRUE(uct_ib_md_coco_transport_allowed(&md, "rc_mlx5"));
+    EXPECT_FALSE(uct_ib_md_coco_transport_allowed(&md, "dc_mlx5"));
+    EXPECT_FALSE(uct_ib_md_coco_transport_allowed(&md, "ud_mlx5"));
+    EXPECT_FALSE(uct_ib_md_coco_transport_allowed(&md, "rc_verbs"));
+    EXPECT_FALSE(uct_ib_md_coco_transport_allowed(&md, "ud_verbs"));
+}
+
+UCS_TEST_F(test_coco_hardening, config_rejects_tm)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uct_rc_iface_common_config_t rc_config;
+    uct_rc_mlx5_iface_common_config_t mlx5_config;
+
+    init_coco_rc_mlx5_config(&rc_config, &mlx5_config);
+    mlx5_config.tm.enable = 1;
+
+    scoped_log_handler slh(hide_errors_logger);
+    EXPECT_NE(UCS_OK, uct_rc_mlx5_coco_check_config(&md, &rc_config,
+                                                    &mlx5_config));
+}
+
+UCS_TEST_F(test_coco_hardening, config_rejects_mp)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uct_rc_iface_common_config_t rc_config;
+    uct_rc_mlx5_iface_common_config_t mlx5_config;
+
+    init_coco_rc_mlx5_config(&rc_config, &mlx5_config);
+    mlx5_config.tm.mp_enable = UCS_YES;
+
+    scoped_log_handler slh(hide_errors_logger);
+    EXPECT_NE(UCS_OK, uct_rc_mlx5_coco_check_config(&md, &rc_config,
+                                                    &mlx5_config));
+}
+
+UCS_TEST_F(test_coco_hardening, config_rejects_cqe_zip)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uct_rc_iface_common_config_t rc_config;
+    uct_rc_mlx5_iface_common_config_t mlx5_config;
+
+    init_coco_rc_mlx5_config(&rc_config, &mlx5_config);
+    mlx5_config.super.cqe_zip_enable[UCT_IB_DIR_TX] = 1;
+    scoped_log_handler slh(hide_errors_logger);
+    EXPECT_NE(UCS_OK, uct_rc_mlx5_coco_check_config(&md, &rc_config,
+                                                    &mlx5_config));
+
+    mlx5_config.super.cqe_zip_enable[UCT_IB_DIR_TX] = 0;
+    mlx5_config.super.cqe_zip_enable[UCT_IB_DIR_RX] = 1;
+    EXPECT_NE(UCS_OK, uct_rc_mlx5_coco_check_config(&md, &rc_config,
+                                                    &mlx5_config));
+}
+
+UCS_TEST_F(test_coco_hardening, config_rejects_ddp_yes)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uct_rc_iface_common_config_t rc_config;
+    uct_rc_mlx5_iface_common_config_t mlx5_config;
+
+    init_coco_rc_mlx5_config(&rc_config, &mlx5_config);
+    mlx5_config.ddp_enable = UCS_YES;
+
+    scoped_log_handler slh(hide_errors_logger);
+    EXPECT_NE(UCS_OK, uct_rc_mlx5_coco_check_config(&md, &rc_config,
+                                                    &mlx5_config));
+}
+
+UCS_TEST_F(test_coco_hardening, config_requires_cyclic_srq)
+{
+    static char list[] = "list";
+    static char *list_topo[] = {list};
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uct_rc_iface_common_config_t rc_config;
+    uct_rc_mlx5_iface_common_config_t mlx5_config;
+
+    init_coco_rc_mlx5_config(&rc_config, &mlx5_config);
+    mlx5_config.srq_topo.types = list_topo;
+    mlx5_config.srq_topo.count = 1;
+
+    scoped_log_handler slh(hide_errors_logger);
+    EXPECT_NE(UCS_OK, uct_rc_mlx5_coco_check_config(&md, &rc_config,
+                                                    &mlx5_config));
+}
+
+UCS_TEST_F(test_coco_hardening, config_effective_disables_unsafe_defaults)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uct_rc_iface_common_config_t rc_config;
+    uct_rc_mlx5_iface_common_config_t mlx5_config;
+    uct_ib_iface_init_attr_t init_attr = {};
+
+    init_coco_rc_mlx5_config(&rc_config, &mlx5_config);
+    mlx5_config.tm.enable = 0;
+    mlx5_config.tm.mp_enable = UCS_TRY;
+    mlx5_config.ddp_enable = UCS_TRY;
+    init_attr.flags = UCT_IB_DDP_SUPPORTED | UCT_IB_TM_SUPPORTED;
+    init_attr.cqe_zip_sizes[UCT_IB_DIR_TX] = 64;
+    init_attr.cqe_zip_sizes[UCT_IB_DIR_RX] = 64;
+
+    uct_rc_mlx5_coco_apply_effective_config(&md, &rc_config, &mlx5_config,
+                                            &init_attr);
+
+    EXPECT_EQ(0, mlx5_config.tm.enable);
+    EXPECT_EQ(UCS_NO, mlx5_config.tm.mp_enable);
+    EXPECT_EQ(UCS_NO, mlx5_config.ddp_enable);
+    EXPECT_EQ(0ul, rc_config.super.inl[UCT_IB_DIR_TX]);
+    EXPECT_EQ(0, init_attr.flags & UCT_IB_DDP_SUPPORTED);
+    EXPECT_EQ(0, init_attr.flags & UCT_IB_TM_SUPPORTED);
+    EXPECT_EQ(0, init_attr.cqe_zip_sizes[UCT_IB_DIR_TX]);
+    EXPECT_EQ(0, init_attr.cqe_zip_sizes[UCT_IB_DIR_RX]);
+}
+
+UCS_TEST_F(test_coco_hardening, config_masks_atomics_initially)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uct_iface_attr_t attr = {};
+
+    attr.cap.flags = UCT_IFACE_FLAG_AM_BCOPY |
+                     UCT_IFACE_FLAG_ATOMIC_CPU |
+                     UCT_IFACE_FLAG_ATOMIC_DEVICE;
+    attr.cap.atomic64.op_flags  = UCS_BIT(UCT_ATOMIC_OP_ADD);
+    attr.cap.atomic64.fop_flags = UCS_BIT(UCT_ATOMIC_OP_CSWAP);
+    attr.cap.atomic32.op_flags  = UCS_BIT(UCT_ATOMIC_OP_ADD);
+    attr.cap.atomic32.fop_flags = UCS_BIT(UCT_ATOMIC_OP_CSWAP);
+
+    uct_rc_mlx5_coco_mask_capabilities(&md, &attr);
+
+    EXPECT_EQ(0, attr.cap.flags & UCT_IFACE_FLAG_ATOMIC_CPU);
+    EXPECT_EQ(0, attr.cap.flags & UCT_IFACE_FLAG_ATOMIC_DEVICE);
+    EXPECT_EQ(0ul, attr.cap.atomic64.op_flags);
+    EXPECT_EQ(0ul, attr.cap.atomic64.fop_flags);
+    EXPECT_EQ(0ul, attr.cap.atomic32.op_flags);
+    EXPECT_EQ(0ul, attr.cap.atomic32.fop_flags);
+    EXPECT_NE(0, attr.cap.flags & UCT_IFACE_FLAG_AM_BCOPY);
+}
+
+UCS_TEST_F(test_coco_hardening, config_masks_rma_before_mr_mkey)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uct_iface_attr_t attr = {};
+
+    attr.cap.flags = UCT_IFACE_FLAG_AM_BCOPY |
+                     UCT_IFACE_FLAG_PUT_SHORT |
+                     UCT_IFACE_FLAG_PUT_BCOPY |
+                     UCT_IFACE_FLAG_PUT_ZCOPY |
+                     UCT_IFACE_FLAG_GET_SHORT |
+                     UCT_IFACE_FLAG_GET_BCOPY |
+                     UCT_IFACE_FLAG_GET_ZCOPY;
+
+    uct_rc_mlx5_coco_mask_capabilities(&md, &attr);
+
+    EXPECT_EQ(0, attr.cap.flags & UCT_IFACE_FLAG_PUT_SHORT);
+    EXPECT_EQ(0, attr.cap.flags & UCT_IFACE_FLAG_PUT_BCOPY);
+    EXPECT_EQ(0, attr.cap.flags & UCT_IFACE_FLAG_PUT_ZCOPY);
+    EXPECT_EQ(0, attr.cap.flags & UCT_IFACE_FLAG_GET_SHORT);
+    EXPECT_EQ(0, attr.cap.flags & UCT_IFACE_FLAG_GET_BCOPY);
+    EXPECT_EQ(0, attr.cap.flags & UCT_IFACE_FLAG_GET_ZCOPY);
+    EXPECT_NE(0, attr.cap.flags & UCT_IFACE_FLAG_AM_BCOPY);
+}
+
+UCS_TEST_F(test_coco_hardening, config_non_coco_unchanged)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(0);
+    uct_rc_iface_common_config_t rc_config;
+    uct_rc_mlx5_iface_common_config_t mlx5_config;
+    uct_ib_iface_init_attr_t init_attr = {};
+    uct_iface_attr_t attr = {};
+
+    init_coco_rc_mlx5_config(&rc_config, &mlx5_config);
+    mlx5_config.tm.enable = 1;
+    mlx5_config.tm.mp_enable = UCS_YES;
+    mlx5_config.ddp_enable = UCS_YES;
+    mlx5_config.super.cqe_zip_enable[UCT_IB_DIR_TX] = 1;
+    mlx5_config.super.cqe_zip_enable[UCT_IB_DIR_RX] = 1;
+    init_attr.flags = UCT_IB_DDP_SUPPORTED;
+    init_attr.cqe_zip_sizes[UCT_IB_DIR_TX] = 64;
+    init_attr.cqe_zip_sizes[UCT_IB_DIR_RX] = 128;
+    attr.cap.flags = UCT_IFACE_FLAG_AM_BCOPY |
+                     UCT_IFACE_FLAG_PUT_BCOPY |
+                     UCT_IFACE_FLAG_GET_BCOPY |
+                     UCT_IFACE_FLAG_ATOMIC_CPU;
+
+    EXPECT_EQ(UCS_OK, uct_rc_mlx5_coco_check_config(&md, &rc_config,
+                                                    &mlx5_config));
+    uct_rc_mlx5_coco_apply_effective_config(&md, &rc_config, &mlx5_config,
+                                            &init_attr);
+    uct_rc_mlx5_coco_mask_capabilities(&md, &attr);
+
+    EXPECT_EQ(1, mlx5_config.tm.enable);
+    EXPECT_EQ(UCS_YES, mlx5_config.tm.mp_enable);
+    EXPECT_EQ(UCS_YES, mlx5_config.ddp_enable);
+    EXPECT_EQ(1, mlx5_config.super.cqe_zip_enable[UCT_IB_DIR_TX]);
+    EXPECT_EQ(1, mlx5_config.super.cqe_zip_enable[UCT_IB_DIR_RX]);
+    EXPECT_EQ(64ul, rc_config.super.inl[UCT_IB_DIR_TX]);
+    EXPECT_NE(0, init_attr.flags & UCT_IB_DDP_SUPPORTED);
+    EXPECT_EQ(64, init_attr.cqe_zip_sizes[UCT_IB_DIR_TX]);
+    EXPECT_EQ(128, init_attr.cqe_zip_sizes[UCT_IB_DIR_RX]);
+    EXPECT_NE(0, attr.cap.flags & UCT_IFACE_FLAG_AM_BCOPY);
+    EXPECT_NE(0, attr.cap.flags & UCT_IFACE_FLAG_PUT_BCOPY);
+    EXPECT_NE(0, attr.cap.flags & UCT_IFACE_FLAG_GET_BCOPY);
+    EXPECT_NE(0, attr.cap.flags & UCT_IFACE_FLAG_ATOMIC_CPU);
+}

--- a/test/gtest/uct/ib/test_coco_hardening.cc
+++ b/test/gtest/uct/ib/test_coco_hardening.cc
@@ -6,9 +6,14 @@
 
 #include <common/test.h>
 
+#include <algorithm>
+#include <stdint.h>
+#include <vector>
+
 extern "C" {
 #include <uct/ib/base/ib_md.h>
 #include <uct/ib/mlx5/ib_mlx5.h>
+#include <uct/ib/mlx5/ib_mlx5_coco.h>
 #include <uct/ib/mlx5/rc/rc_mlx5_common.h>
 }
 
@@ -36,6 +41,112 @@ uct_ib_mlx5_md_t make_mlx5_md(int coco_hardened)
     md.super.cc_dma_bounce = coco_hardened;
     return md;
 }
+
+struct fake_shared_backend {
+    std::vector<uint8_t> storage;
+    struct mlx5dv_devx_umem umem;
+    size_t alloc_size;
+    unsigned alloc_count;
+    unsigned umem_reg_count;
+    unsigned umem_dereg_count;
+    unsigned unmap_count;
+    unsigned close_count;
+    int scrubbed_before_unmap;
+    int fd;
+
+    fake_shared_backend() : alloc_size(0), alloc_count(0), umem_reg_count(0),
+                            umem_dereg_count(0), unmap_count(0),
+                            close_count(0), scrubbed_before_unmap(0), fd(17)
+    {
+        memset(&umem, 0, sizeof(umem));
+        umem.umem_id = 0xabcdu;
+    }
+};
+
+static ucs_status_t fake_shared_alloc(size_t size, void **addr_p, int *fd_p,
+                                      void *arg)
+{
+    fake_shared_backend *backend = static_cast<fake_shared_backend*>(arg);
+
+    backend->storage.assign(size, 0x5a);
+    backend->alloc_size = size;
+    backend->alloc_count++;
+    *addr_p = backend->storage.data();
+    *fd_p   = backend->fd;
+    return UCS_OK;
+}
+
+static ucs_status_t
+fake_shared_umem_reg(uct_ib_mlx5_md_t *md,
+                     const uct_ib_mlx5_coco_shared_alloc_t *alloc,
+                     int access_mode, struct mlx5dv_devx_umem **umem_p,
+                     void *arg)
+{
+    fake_shared_backend *backend = static_cast<fake_shared_backend*>(arg);
+
+    EXPECT_TRUE(uct_ib_md_is_coco_hardened(&md->super));
+    EXPECT_EQ(0, access_mode);
+    EXPECT_EQ(backend->storage.data(), alloc->addr);
+    EXPECT_EQ(backend->alloc_size, alloc->exposed_size);
+    EXPECT_TRUE(std::all_of(backend->storage.begin(), backend->storage.end(),
+                            [](uint8_t value) { return value == 0; }));
+    backend->umem_reg_count++;
+    *umem_p = &backend->umem;
+    return UCS_OK;
+}
+
+static ucs_status_t fake_shared_umem_dereg(struct mlx5dv_devx_umem *umem,
+                                           void *arg)
+{
+    fake_shared_backend *backend = static_cast<fake_shared_backend*>(arg);
+
+    EXPECT_EQ(&backend->umem, umem);
+    backend->umem_dereg_count++;
+    return UCS_OK;
+}
+
+static ucs_status_t fake_shared_unmap(void *addr, size_t size, void *arg)
+{
+    fake_shared_backend *backend = static_cast<fake_shared_backend*>(arg);
+
+    EXPECT_EQ(backend->storage.data(), addr);
+    EXPECT_EQ(backend->storage.size(), size);
+    backend->scrubbed_before_unmap = std::all_of(
+        backend->storage.begin(), backend->storage.end(),
+        [](uint8_t value) { return value == 0; });
+    backend->unmap_count++;
+    return UCS_OK;
+}
+
+static ucs_status_t fake_shared_close(int fd, void *arg)
+{
+    fake_shared_backend *backend = static_cast<fake_shared_backend*>(arg);
+
+    EXPECT_EQ(backend->fd, fd);
+    backend->close_count++;
+    return UCS_OK;
+}
+
+class fake_shared_ops_scope {
+public:
+    explicit fake_shared_ops_scope(fake_shared_backend *backend)
+    {
+        ops.alloc      = fake_shared_alloc;
+        ops.umem_reg   = fake_shared_umem_reg;
+        ops.umem_dereg = fake_shared_umem_dereg;
+        ops.unmap      = fake_shared_unmap;
+        ops.close_fd   = fake_shared_close;
+        uct_ib_mlx5_coco_set_shared_alloc_ops(&ops, backend);
+    }
+
+    ~fake_shared_ops_scope()
+    {
+        uct_ib_mlx5_coco_set_shared_alloc_ops(NULL, NULL);
+    }
+
+private:
+    uct_ib_mlx5_coco_shared_alloc_ops_t ops;
+};
 
 }
 
@@ -267,4 +378,259 @@ UCS_TEST_F(test_coco_hardening, config_non_coco_unchanged)
     EXPECT_NE(0, attr.cap.flags & UCT_IFACE_FLAG_PUT_BCOPY);
     EXPECT_NE(0, attr.cap.flags & UCT_IFACE_FLAG_GET_BCOPY);
     EXPECT_NE(0, attr.cap.flags & UCT_IFACE_FLAG_ATOMIC_CPU);
+}
+
+UCS_TEST_F(test_coco_hardening, memory_shared_rounds_to_page)
+{
+    size_t page_size = ucs_get_page_size();
+    size_t exposed_size;
+
+    EXPECT_EQ(UCS_OK, uct_ib_mlx5_coco_exposed_size(page_size + 1,
+                                                    &exposed_size));
+    EXPECT_EQ(2 * page_size, exposed_size);
+}
+
+UCS_TEST_F(test_coco_hardening, memory_shared_zeroes_full_exposed_size)
+{
+    fake_shared_backend backend;
+    fake_shared_ops_scope scope(&backend);
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uct_ib_mlx5_devx_umem_t mem;
+    void *buf;
+
+    EXPECT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    EXPECT_EQ(UCS_OK, uct_ib_mlx5_coco_md_buf_alloc_shared(
+                         &md, ucs_get_page_size() + 37, 0, &buf, &mem, 0,
+                         (char*)"fake shared"));
+
+    EXPECT_EQ(1u, backend.alloc_count);
+    EXPECT_EQ(1u, backend.umem_reg_count);
+    EXPECT_EQ(ucs_get_page_size() + 37, mem.size);
+    EXPECT_EQ(2 * ucs_get_page_size(), mem.mmap_size);
+    EXPECT_EQ(backend.storage.data(), buf);
+    EXPECT_TRUE(std::all_of(backend.storage.begin(), backend.storage.end(),
+                            [](uint8_t value) { return value == 0; }));
+
+    uct_ib_mlx5_coco_md_buf_free_shared(&md, buf, &mem);
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, memory_shared_scrubs_before_release)
+{
+    fake_shared_backend backend;
+    fake_shared_ops_scope scope(&backend);
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uct_ib_mlx5_devx_umem_t mem;
+    void *buf;
+
+    EXPECT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_md_buf_alloc_shared(
+                          &md, 128, 0, &buf, &mem, 0, (char*)"fake shared"));
+    std::fill(backend.storage.begin(), backend.storage.end(), 0x7du);
+
+    uct_ib_mlx5_coco_md_buf_free_shared(&md, buf, &mem);
+
+    EXPECT_EQ(1u, backend.umem_dereg_count);
+    EXPECT_EQ(1u, backend.unmap_count);
+    EXPECT_EQ(1u, backend.close_count);
+    EXPECT_TRUE(backend.scrubbed_before_unmap);
+    EXPECT_EQ(NULL, mem.mem);
+    EXPECT_EQ(UCT_IB_MLX5_INVALID_DMABUF_FD, mem.dmabuf_fd);
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, memory_shared_rejects_zero_size)
+{
+    fake_shared_backend backend;
+    fake_shared_ops_scope scope(&backend);
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uct_ib_mlx5_devx_umem_t mem;
+    void *buf = reinterpret_cast<void*>(0x1);
+
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM,
+              uct_ib_mlx5_coco_md_buf_alloc_shared(&md, 0, 1, &buf, &mem, 0,
+                                                   (char*)"zero shared"));
+    EXPECT_EQ(0u, backend.alloc_count);
+    EXPECT_EQ(NULL, buf);
+}
+
+UCS_TEST_F(test_coco_hardening, memory_umem_rejects_duplicate_id)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t buffer[64];
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    EXPECT_EQ(UCS_OK, uct_ib_mlx5_coco_umem_record_add(
+                         md.coco, 7, buffer, sizeof(buffer),
+                         ucs_get_page_size(), 0));
+    EXPECT_EQ(UCS_ERR_ALREADY_EXISTS, uct_ib_mlx5_coco_umem_record_add(
+                         md.coco, 7, buffer, sizeof(buffer),
+                         ucs_get_page_size(), 0));
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, memory_umem_rejects_widened_length)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t buffer[64];
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_umem_record_add(
+                          md.coco, 8, buffer, sizeof(buffer),
+                          ucs_get_page_size(), 0x3));
+    EXPECT_EQ(UCS_OK, uct_ib_mlx5_coco_umem_record_validate(
+                         md.coco, 8, buffer, sizeof(buffer),
+                         ucs_get_page_size(), 0x3));
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM,
+              uct_ib_mlx5_coco_umem_record_validate(
+                  md.coco, 8, buffer, sizeof(buffer),
+                  2 * ucs_get_page_size(), 0x3));
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, memory_umem_destroy_removes_record)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t buffer[64];
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_umem_record_add(
+                          md.coco, 9, buffer, sizeof(buffer),
+                          ucs_get_page_size(), 0));
+    ASSERT_NE(static_cast<const uct_ib_mlx5_coco_umem_record_t*>(NULL),
+              uct_ib_mlx5_coco_umem_record_find(md.coco, 9));
+    EXPECT_EQ(UCS_OK, uct_ib_mlx5_coco_umem_record_remove(md.coco, 9));
+    EXPECT_EQ(static_cast<const uct_ib_mlx5_coco_umem_record_t*>(NULL),
+              uct_ib_mlx5_coco_umem_record_find(md.coco, 9));
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, memory_non_coco_no_umem_registry)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(0);
+
+    EXPECT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    EXPECT_EQ(NULL, md.coco);
+}
+
+UCS_TEST_F(test_coco_hardening, mr_mkey_registers_bounds)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t buffer[128];
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    EXPECT_EQ(UCS_OK, uct_ib_mlx5_coco_mkey_record_add(
+                         md.coco, 0x101, 0x202, buffer, sizeof(buffer),
+                         IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ));
+    const uct_ib_mlx5_coco_mkey_record_t *record =
+        uct_ib_mlx5_coco_mkey_record_find_lkey(md.coco, 0x101);
+    ASSERT_NE(static_cast<const uct_ib_mlx5_coco_mkey_record_t*>(NULL), record);
+    EXPECT_EQ(buffer, record->base);
+    EXPECT_EQ(sizeof(buffer), record->length);
+    EXPECT_EQ(0x202u, record->rkey);
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, mr_mkey_rejects_duplicate_lkey)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t buffer[128];
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_mkey_record_add(
+                          md.coco, 0x101, 0x202, buffer, 64,
+                          IBV_ACCESS_LOCAL_WRITE));
+    EXPECT_EQ(UCS_ERR_ALREADY_EXISTS, uct_ib_mlx5_coco_mkey_record_add(
+                         md.coco, 0x101, 0x303, buffer, 64,
+                         IBV_ACCESS_LOCAL_WRITE));
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, mr_mkey_rejects_duplicate_rkey)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t buffer[128];
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_mkey_record_add(
+                          md.coco, 0x101, 0x202, buffer, 64,
+                          IBV_ACCESS_LOCAL_WRITE));
+    EXPECT_EQ(UCS_ERR_ALREADY_EXISTS, uct_ib_mlx5_coco_mkey_record_add(
+                         md.coco, 0x303, 0x202, buffer, 64,
+                         IBV_ACCESS_LOCAL_WRITE));
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, mr_mkey_rejects_widened_range)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t buffer[128];
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_mkey_record_add(
+                          md.coco, 0x101, 0x202, buffer + 16, 64,
+                          IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ));
+    EXPECT_EQ(UCS_OK, uct_ib_mlx5_coco_mkey_record_validate(
+                         md.coco, 0x101, 0x202, buffer + 16, 64,
+                         IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ));
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM,
+              uct_ib_mlx5_coco_mkey_record_validate(
+                  md.coco, 0x101, 0x202, buffer + 15, 65,
+                  IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ));
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, mr_mkey_rejects_permission_widening)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t buffer[128];
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_mkey_record_add(
+                          md.coco, 0x101, 0x202, buffer, 64,
+                          IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ));
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM,
+              uct_ib_mlx5_coco_mkey_record_validate(
+                  md.coco, 0x101, 0x202, buffer, 64,
+                  IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+                  IBV_ACCESS_REMOTE_WRITE));
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, mr_mkey_masks_atomics_until_enabled)
+{
+    uint64_t access = uct_ib_mlx5_coco_mkey_sanitize_access(
+        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+        IBV_ACCESS_REMOTE_ATOMIC);
+
+    EXPECT_NE(0ul, access & IBV_ACCESS_LOCAL_WRITE);
+    EXPECT_NE(0ul, access & IBV_ACCESS_REMOTE_READ);
+    EXPECT_EQ(0ul, access & IBV_ACCESS_REMOTE_ATOMIC);
+}
+
+UCS_TEST_F(test_coco_hardening, mr_mkey_unmasks_rma_after_bounds_ready)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uct_iface_attr_t attr = {};
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    attr.cap.flags = UCT_IFACE_FLAG_AM_BCOPY |
+                     UCT_IFACE_FLAG_PUT_BCOPY |
+                     UCT_IFACE_FLAG_GET_BCOPY |
+                     UCT_IFACE_FLAG_ATOMIC_CPU;
+
+    uct_rc_mlx5_coco_mask_capabilities(&md, &attr);
+
+    EXPECT_NE(0, attr.cap.flags & UCT_IFACE_FLAG_PUT_BCOPY);
+    EXPECT_NE(0, attr.cap.flags & UCT_IFACE_FLAG_GET_BCOPY);
+    EXPECT_EQ(0, attr.cap.flags & UCT_IFACE_FLAG_ATOMIC_CPU);
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, mr_mkey_non_coco_no_registry)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(0);
+
+    EXPECT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    EXPECT_EQ(NULL, md.coco);
 }

--- a/test/gtest/uct/ib/test_coco_hardening.cc
+++ b/test/gtest/uct/ib/test_coco_hardening.cc
@@ -40,6 +40,9 @@ uct_ib_mlx5_md_t make_mlx5_md(int coco_hardened)
     uct_ib_mlx5_md_t md = {};
 
     md.super.cc_dma_bounce = coco_hardened;
+    if (coco_hardened) {
+        md.super.coco_pd = reinterpret_cast<struct ibv_pd*>(uintptr_t(0x1));
+    }
     return md;
 }
 
@@ -302,7 +305,7 @@ void add_valid_cq_objects(uct_ib_mlx5_md_t *md, uint32_t send_cqn,
 class test_coco_hardening : public ucs::test {
 };
 
-UCS_TEST_F(test_coco_hardening, policy_helper_requires_cc_dma_bounce)
+UCS_TEST_F(test_coco_hardening, policy_helper_requires_coco_pd)
 {
     uct_ib_md_t md = {};
 
@@ -310,26 +313,29 @@ UCS_TEST_F(test_coco_hardening, policy_helper_requires_cc_dma_bounce)
     EXPECT_FALSE(uct_ib_md_is_coco_hardened(&md));
 
     md.cc_dma_bounce = 1;
+    EXPECT_FALSE(uct_ib_md_is_coco_hardened(&md));
+
+    md.coco_pd = reinterpret_cast<struct ibv_pd*>(uintptr_t(0x1));
     EXPECT_TRUE(uct_ib_md_is_coco_hardened(&md));
+
+    md.cc_dma_bounce = 0;
+    EXPECT_FALSE(uct_ib_md_is_coco_hardened(&md));
 }
 
-UCS_TEST_F(test_coco_hardening, policy_transport_rc_mlx5_only)
+UCS_TEST_F(test_coco_hardening, control_pd_uses_coco_pd_when_hardened)
 {
     uct_ib_md_t md = {};
 
-    md.cc_dma_bounce = 0;
-    EXPECT_TRUE(uct_ib_md_coco_transport_allowed(&md, "rc_mlx5"));
-    EXPECT_TRUE(uct_ib_md_coco_transport_allowed(&md, "dc_mlx5"));
-    EXPECT_TRUE(uct_ib_md_coco_transport_allowed(&md, "ud_mlx5"));
-    EXPECT_TRUE(uct_ib_md_coco_transport_allowed(&md, "rc_verbs"));
-    EXPECT_TRUE(uct_ib_md_coco_transport_allowed(&md, "ud_verbs"));
+    md.pd      = reinterpret_cast<struct ibv_pd*>(uintptr_t(0x1));
+    md.coco_pd = reinterpret_cast<struct ibv_pd*>(uintptr_t(0x2));
+
+    EXPECT_EQ(md.pd, uct_ib_md_control_pd(&md));
 
     md.cc_dma_bounce = 1;
-    EXPECT_TRUE(uct_ib_md_coco_transport_allowed(&md, "rc_mlx5"));
-    EXPECT_FALSE(uct_ib_md_coco_transport_allowed(&md, "dc_mlx5"));
-    EXPECT_FALSE(uct_ib_md_coco_transport_allowed(&md, "ud_mlx5"));
-    EXPECT_FALSE(uct_ib_md_coco_transport_allowed(&md, "rc_verbs"));
-    EXPECT_FALSE(uct_ib_md_coco_transport_allowed(&md, "ud_verbs"));
+    EXPECT_EQ(md.coco_pd, uct_ib_md_control_pd(&md));
+
+    md.coco_pd = NULL;
+    EXPECT_EQ(md.pd, uct_ib_md_control_pd(&md));
 }
 
 UCS_TEST_F(test_coco_hardening, config_rejects_tm)

--- a/test/gtest/uct/ib/test_coco_hardening.cc
+++ b/test/gtest/uct/ib/test_coco_hardening.cc
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <stdint.h>
+#include <sys/mman.h>
 #include <vector>
 
 extern "C" {
@@ -147,6 +148,153 @@ public:
 private:
     uct_ib_mlx5_coco_shared_alloc_ops_t ops;
 };
+
+class guarded_output {
+public:
+    explicit guarded_output(size_t readable_size) : m_base(MAP_FAILED),
+                                                    m_ptr(NULL),
+                                                    m_readable_size(readable_size),
+                                                    m_mapping_size(0)
+    {
+        const size_t page_size = ucs_get_page_size();
+
+        m_mapping_size = 2 * page_size;
+        m_base = mmap(NULL, m_mapping_size, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        EXPECT_NE(MAP_FAILED, m_base);
+        if (m_base == MAP_FAILED) {
+            return;
+        }
+
+        EXPECT_EQ(0, mprotect(UCS_PTR_BYTE_OFFSET(m_base, page_size),
+                              page_size, PROT_NONE));
+        m_ptr = UCS_PTR_BYTE_OFFSET(m_base, page_size - readable_size);
+        memset(m_ptr, 0, readable_size);
+    }
+
+    ~guarded_output()
+    {
+        if (m_base != MAP_FAILED) {
+            munmap(m_base, m_mapping_size);
+        }
+    }
+
+    const void *ptr() const
+    {
+        return m_ptr;
+    }
+
+    size_t size() const
+    {
+        return m_readable_size;
+    }
+
+private:
+    void   *m_base;
+    void   *m_ptr;
+    size_t m_readable_size;
+    size_t m_mapping_size;
+};
+
+enum {
+    TEST_COCO_CQ_UMEM_ID  = 0x11,
+    TEST_COCO_DBR_UMEM_ID = 0x12,
+    TEST_COCO_WQ_UMEM_ID  = 0x13
+};
+
+void add_lifecycle_umems(uct_ib_mlx5_md_t *md, void *cq_buf, void *dbr_buf,
+                         void *wq_buf)
+{
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_umem_record_add(
+                          md->coco, TEST_COCO_CQ_UMEM_ID, cq_buf, 128,
+                          ucs_get_page_size(), IBV_ACCESS_LOCAL_WRITE));
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_umem_record_add(
+                          md->coco, TEST_COCO_DBR_UMEM_ID, dbr_buf, 64,
+                          ucs_get_page_size(), 0));
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_umem_record_add(
+                          md->coco, TEST_COCO_WQ_UMEM_ID, wq_buf, 256,
+                          ucs_get_page_size(), 0));
+}
+
+uct_ib_mlx5_coco_cq_req_t make_valid_cq_req()
+{
+    uct_ib_mlx5_coco_cq_req_t req = {};
+
+    req.cq_len         = 16;
+    req.cqe_size       = 64;
+    req.cq_umem_id     = TEST_COCO_CQ_UMEM_ID;
+    req.cq_umem_offset = 0;
+    req.dbr_umem_id    = TEST_COCO_DBR_UMEM_ID;
+    req.dbr_offset     = 0;
+    req.eqn            = 1;
+    req.uar_page       = 2;
+    return req;
+}
+
+uct_ib_mlx5_coco_qp_req_t make_valid_qp_req(uint32_t send_cqn,
+                                            uint32_t recv_cqn)
+{
+    uct_ib_mlx5_coco_qp_req_t req = {};
+
+    req.qp_type       = IBV_QPT_RC;
+    req.send_cqn      = send_cqn;
+    req.recv_cqn      = recv_cqn;
+    req.rmpn          = 0;
+    req.wq_umem_id    = TEST_COCO_WQ_UMEM_ID;
+    req.dbr_umem_id   = TEST_COCO_DBR_UMEM_ID;
+    req.sq_wqe_count  = 64;
+    req.rq_wqe_count  = 0;
+    return req;
+}
+
+uct_ib_mlx5_coco_rmp_req_t make_valid_rmp_req()
+{
+    uct_ib_mlx5_coco_rmp_req_t req = {};
+
+    req.wq_umem_id  = TEST_COCO_WQ_UMEM_ID;
+    req.dbr_umem_id = TEST_COCO_DBR_UMEM_ID;
+    req.wq_size     = 64;
+    req.stride      = 64;
+    req.cyclic      = 1;
+    req.mp_enabled  = 0;
+    return req;
+}
+
+void set_cq_output(void *out, uint32_t cqn)
+{
+    memset(out, 0, UCT_IB_MLX5DV_ST_SZ_BYTES(create_cq_out));
+    UCT_IB_MLX5DV_SET(create_cq_out, static_cast<char*>(out), cqn, cqn);
+}
+
+void set_qp_output(void *out, uint32_t qpn)
+{
+    memset(out, 0, UCT_IB_MLX5DV_ST_SZ_BYTES(create_qp_out));
+    UCT_IB_MLX5DV_SET(create_qp_out, static_cast<char*>(out), qpn, qpn);
+}
+
+void set_rmp_output(void *out, uint32_t rmpn)
+{
+    memset(out, 0, UCT_IB_MLX5DV_ST_SZ_BYTES(create_rmp_out));
+    UCT_IB_MLX5DV_SET(create_rmp_out, static_cast<char*>(out), rmpn, rmpn);
+}
+
+void add_valid_cq_objects(uct_ib_mlx5_md_t *md, uint32_t send_cqn,
+                          uint32_t recv_cqn)
+{
+    char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_cq_out)];
+    uct_ib_mlx5_coco_cq_req_t req = make_valid_cq_req();
+    uint32_t cqn;
+
+    set_cq_output(out, send_cqn);
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_validate_cq_output(
+                          md, &req, out, sizeof(out), &cqn));
+    EXPECT_EQ(send_cqn, cqn);
+
+    set_cq_output(out, recv_cqn);
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_validate_cq_output(
+                          md, &req, out, sizeof(out), &cqn));
+    EXPECT_EQ(recv_cqn, cqn);
+}
 
 }
 
@@ -633,4 +781,143 @@ UCS_TEST_F(test_coco_hardening, mr_mkey_non_coco_no_registry)
 
     EXPECT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
     EXPECT_EQ(NULL, md.coco);
+}
+
+UCS_TEST_F(test_coco_hardening, devx_output_cq_rejects_short_buffer_guarded)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t cq_buf[128], dbr_buf[64], wq_buf[256];
+    guarded_output out(1);
+    uct_ib_mlx5_coco_cq_req_t req = make_valid_cq_req();
+    uint32_t cqn = 0xdeadbeefu;
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    add_lifecycle_umems(&md, cq_buf, dbr_buf, wq_buf);
+    EXPECT_EQ(UCS_ERR_INVALID_PARAM,
+              uct_ib_mlx5_coco_validate_cq_output(&md, &req, out.ptr(),
+                                                  out.size(), &cqn));
+    EXPECT_EQ(0xdeadbeefu, cqn);
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, devx_output_cq_rejects_duplicate_cqn)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t cq_buf[128], dbr_buf[64], wq_buf[256];
+    char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_cq_out)];
+    uct_ib_mlx5_coco_cq_req_t req = make_valid_cq_req();
+    uint32_t cqn;
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    add_lifecycle_umems(&md, cq_buf, dbr_buf, wq_buf);
+    set_cq_output(out, 0x31);
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_validate_cq_output(
+                          &md, &req, out, sizeof(out), &cqn));
+    EXPECT_EQ(0x31u, cqn);
+    EXPECT_EQ(UCS_ERR_ALREADY_EXISTS,
+              uct_ib_mlx5_coco_validate_cq_output(&md, &req, out,
+                                                  sizeof(out), &cqn));
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, devx_output_qp_rejects_duplicate_qpn)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t cq_buf[128], dbr_buf[64], wq_buf[256];
+    char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_qp_out)];
+    uct_ib_mlx5_coco_qp_req_t req = make_valid_qp_req(0x41, 0x42);
+    uint32_t qpn;
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    add_lifecycle_umems(&md, cq_buf, dbr_buf, wq_buf);
+    add_valid_cq_objects(&md, 0x41, 0x42);
+    set_qp_output(out, 0x51);
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_validate_qp_output(
+                          &md, &req, out, sizeof(out), &qpn));
+    EXPECT_EQ(0x51u, qpn);
+    EXPECT_EQ(UCS_ERR_ALREADY_EXISTS,
+              uct_ib_mlx5_coco_validate_qp_output(&md, &req, out,
+                                                  sizeof(out), &qpn));
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, devx_output_rmp_rejects_duplicate_rmpn)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t cq_buf[128], dbr_buf[64], wq_buf[256];
+    char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_rmp_out)];
+    uct_ib_mlx5_coco_rmp_req_t req = make_valid_rmp_req();
+    uint32_t rmpn;
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    add_lifecycle_umems(&md, cq_buf, dbr_buf, wq_buf);
+    set_rmp_output(out, 0x61);
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_validate_rmp_output(
+                          &md, &req, out, sizeof(out), &rmpn));
+    EXPECT_EQ(0x61u, rmpn);
+    EXPECT_EQ(UCS_ERR_ALREADY_EXISTS,
+              uct_ib_mlx5_coco_validate_rmp_output(&md, &req, out,
+                                                   sizeof(out), &rmpn));
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, devx_input_qp_rejects_non_rc)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t cq_buf[128], dbr_buf[64], wq_buf[256];
+    char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_qp_out)];
+    uct_ib_mlx5_coco_qp_req_t req = make_valid_qp_req(0x41, 0x42);
+    uint32_t qpn = 0;
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    add_lifecycle_umems(&md, cq_buf, dbr_buf, wq_buf);
+    add_valid_cq_objects(&md, 0x41, 0x42);
+    set_qp_output(out, 0x51);
+    req.qp_type = UCT_IB_QPT_DCI;
+
+    EXPECT_EQ(UCS_ERR_UNSUPPORTED,
+              uct_ib_mlx5_coco_validate_qp_output(&md, &req, out,
+                                                  sizeof(out), &qpn));
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, devx_input_rmp_rejects_mp)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t cq_buf[128], dbr_buf[64], wq_buf[256];
+    char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_rmp_out)];
+    uct_ib_mlx5_coco_rmp_req_t req = make_valid_rmp_req();
+    uint32_t rmpn = 0;
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    add_lifecycle_umems(&md, cq_buf, dbr_buf, wq_buf);
+    set_rmp_output(out, 0x61);
+    req.mp_enabled = 1;
+
+    EXPECT_EQ(UCS_ERR_UNSUPPORTED,
+              uct_ib_mlx5_coco_validate_rmp_output(&md, &req, out,
+                                                   sizeof(out), &rmpn));
+    uct_ib_mlx5_coco_state_cleanup(&md);
+}
+
+UCS_TEST_F(test_coco_hardening, devx_input_rmp_rejects_non_cyclic)
+{
+    uct_ib_mlx5_md_t md = make_mlx5_md(1);
+    uint8_t cq_buf[128], dbr_buf[64], wq_buf[256];
+    char out[UCT_IB_MLX5DV_ST_SZ_BYTES(create_rmp_out)];
+    uct_ib_mlx5_coco_rmp_req_t req = make_valid_rmp_req();
+    uint32_t rmpn = 0;
+
+    ASSERT_EQ(UCS_OK, uct_ib_mlx5_coco_state_init(&md));
+    add_lifecycle_umems(&md, cq_buf, dbr_buf, wq_buf);
+    set_rmp_output(out, 0x61);
+    req.cyclic = 0;
+
+    EXPECT_EQ(UCS_ERR_UNSUPPORTED,
+              uct_ib_mlx5_coco_validate_rmp_output(&md, &req, out,
+                                                   sizeof(out), &rmpn));
+    uct_ib_mlx5_coco_state_cleanup(&md);
 }

--- a/test/gtest/uct/ib/test_devx.cc
+++ b/test/gtest/uct/ib/test_devx.cc
@@ -41,11 +41,52 @@ public:
 
 UCS_TEST_P(test_devx, dbrec)
 {
-    uct_ib_mlx5_dbrec_t *dbrec;
+    uct_ib_mlx5_dbrec_t *dbrec1;
+    uct_ib_mlx5_dbrec_t *dbrec2;
+    uct_ib_mlx5_dbrec_t *dbrec3;
+    uintptr_t db1;
+    uintptr_t db2;
+    ptrdiff_t db_delta;
+    ptrdiff_t offset_delta;
+    uint32_t mem_id;
+    uint64_t offset;
 
-    dbrec = (uct_ib_mlx5_dbrec_t *)ucs_mpool_get_inline(&md()->dbrec_pool);
-    ASSERT_FALSE(dbrec == NULL);
-    ucs_mpool_put_inline(dbrec);
+    dbrec1 = uct_ib_mlx5_get_dbrec(md());
+    ASSERT_NE(nullptr, dbrec1);
+    dbrec2 = uct_ib_mlx5_get_dbrec(md());
+    ASSERT_NE(nullptr, dbrec2);
+
+    EXPECT_NE(nullptr, dbrec1->db);
+    EXPECT_NE(nullptr, dbrec2->db);
+    EXPECT_EQ(dbrec1->mem_id, dbrec2->mem_id);
+    EXPECT_NE(dbrec1->offset, dbrec2->offset);
+
+    db1          = (uintptr_t)dbrec1->db;
+    db2          = (uintptr_t)dbrec2->db;
+    db_delta     = (db1 > db2) ? (db1 - db2) : (db2 - db1);
+    offset_delta = (dbrec1->offset > dbrec2->offset) ?
+                   (dbrec1->offset - dbrec2->offset) :
+                   (dbrec2->offset - dbrec1->offset);
+    EXPECT_GT(db_delta, 0);
+    EXPECT_EQ(db_delta, offset_delta);
+    EXPECT_EQ(0ul, db_delta % sizeof(*dbrec1->db));
+
+    mem_id = dbrec1->mem_id;
+    offset = dbrec1->offset;
+    dbrec1->db[MLX5_SND_DBR] = 0xdeadbeef;
+    dbrec1->db[MLX5_RCV_DBR] = 0xcafef00d;
+    EXPECT_EQ(mem_id, dbrec1->mem_id);
+    EXPECT_EQ(offset, dbrec1->offset);
+    EXPECT_EQ(md(), dbrec1->md);
+
+    uct_ib_mlx5_put_dbrec(dbrec1);
+    uct_ib_mlx5_put_dbrec(dbrec2);
+
+    dbrec3 = uct_ib_mlx5_get_dbrec(md());
+    ASSERT_NE(nullptr, dbrec3);
+    EXPECT_EQ(0u, dbrec3->db[MLX5_SND_DBR]);
+    EXPECT_EQ(0u, dbrec3->db[MLX5_RCV_DBR]);
+    uct_ib_mlx5_put_dbrec(dbrec3);
 }
 
 UCT_INSTANTIATE_IB_TEST_CASE(test_devx);

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -16,20 +16,6 @@
 #include <common/mem_buffer.h>
 #include <uct/test_md.h>
 
-#include <string>
-#include <type_traits>
-
-#if HAVE_DEVX
-class test_ib_mlx5_dbrec : public ucs::test {
-};
-
-UCS_TEST_F(test_ib_mlx5_dbrec, metadata_uses_external_db_pointer)
-{
-    EXPECT_TRUE(std::is_pointer<
-                decltype(((uct_ib_mlx5_dbrec_t*)nullptr)->db)>::value);
-}
-#endif
-
 class test_ib_md : public test_md
 {
 protected:

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -16,6 +16,8 @@
 #include <common/mem_buffer.h>
 #include <uct/test_md.h>
 
+#include <string>
+
 class test_ib_md : public test_md
 {
 protected:

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -17,6 +17,18 @@
 #include <uct/test_md.h>
 
 #include <string>
+#include <type_traits>
+
+#if HAVE_DEVX
+class test_ib_mlx5_dbrec : public ucs::test {
+};
+
+UCS_TEST_F(test_ib_mlx5_dbrec, metadata_uses_external_db_pointer)
+{
+    EXPECT_TRUE(std::is_pointer<
+                decltype(((uct_ib_mlx5_dbrec_t*)nullptr)->db)>::value);
+}
+#endif
 
 class test_ib_md : public test_md
 {


### PR DESCRIPTION
## What?
Draft PR. This should be merged after PR #11586.

- Harden CoCo RC mlx5 policy gating.
- Harden CoCo DEVX memory key validation.
- Validate DEVX object IDs returned by the untrusted device.

## Why?
After the CoCo control-object path is available, UCX needs to fail closed when DEVX-visible metadata or object identifiers do not match the private UCX state.

## How?
- Restrict the CoCo profile to the audited RC mlx5 path.
- Validate MKey bounds and permissions against private metadata.
- Validate DEVX object outputs before UCX trusts them.