### PR TITLE
UCP/EP/FT: Add async block/unblock on proto reconfig

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2037,8 +2037,6 @@ void ucp_ep_set_lanes_failed_schedule(ucp_ep_h ucp_ep, ucp_lane_map_t lanes,
     ucp_worker_h worker = ucp_ep->worker;
     ucp_ep_set_lanes_failed_arg_t *set_ep_failed_arg;
 
-    UCP_WORKER_THREAD_CS_CHECK_IS_BLOCKED(worker);
-
     set_ep_failed_arg = ucs_malloc(sizeof(*set_ep_failed_arg),
                                    "set_ep_failed_arg");
     if (set_ep_failed_arg == NULL) {
@@ -2050,8 +2048,10 @@ void ucp_ep_set_lanes_failed_schedule(ucp_ep_h ucp_ep, ucp_lane_map_t lanes,
     set_ep_failed_arg->lanes  = lanes;
     set_ep_failed_arg->status = status;
 
+    UCS_ASYNC_BLOCK(&worker->async);
     ucs_callbackq_add_oneshot(&worker->uct->progress_q, ucp_ep,
                               ucp_ep_set_lanes_failed_progress, set_ep_failed_arg);
+    UCS_ASYNC_UNBLOCK(&worker->async);
 
     /* If the worker supports the UCP_FEATURE_WAKEUP feature, signal the user so
      * that he can wake-up on this event */

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -108,9 +108,7 @@ static ucs_status_t ucp_proto_reconfig_progress(uct_pending_req_t *self)
          * the EP so the user error callback fires. */
         if (!ucp_ep_err_mode_eq(ep, UCP_ERR_HANDLING_MODE_NONE) &&
             !(ep->flags & UCP_EP_FLAG_FAILED)) {
-            UCS_ASYNC_BLOCK(&ep->worker->async);
             ucp_ep_set_lanes_failed_schedule(ep, 0, UCS_ERR_ENDPOINT_TIMEOUT);
-            UCS_ASYNC_UNBLOCK(&ep->worker->async);
         }
 
         ucp_proto_request_abort(req, UCS_ERR_CANCELED);

--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -108,7 +108,9 @@ static ucs_status_t ucp_proto_reconfig_progress(uct_pending_req_t *self)
          * the EP so the user error callback fires. */
         if (!ucp_ep_err_mode_eq(ep, UCP_ERR_HANDLING_MODE_NONE) &&
             !(ep->flags & UCP_EP_FLAG_FAILED)) {
+            UCS_ASYNC_BLOCK(&ep->worker->async);
             ucp_ep_set_lanes_failed_schedule(ep, 0, UCS_ERR_ENDPOINT_TIMEOUT);
+            UCS_ASYNC_UNBLOCK(&ep->worker->async);
         }
 
         ucp_proto_request_abort(req, UCS_ERR_CANCELED);


### PR DESCRIPTION
## What?
Adds UCS_ASYNC_BLOCK/UNBLOCK around call to ucp_ep_set_lanes_failed_schedule().

## Why?
Required in function ucp_ep_set_lanes_failed_schedule(). Otherwise UCX terminates execution in this function. Other paths into this function have UCS_ASYNC_BLOCK set before calling.
