### PR TITLE
PERFTEST/FT: Adds validation mode to pingpong perftests

### DIFF
--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -16,7 +16,7 @@
 
 #include <ucs/sys/preprocessor.h>
 #include <ucs/sys/string.h>
-#include "ucs/type/status.h"
+#include <ucs/type/status.h>
 #include <limits>
 
 
@@ -815,7 +815,12 @@ public:
                 wait_recv_window(m_max_outstanding);
 
                 if (validate) {
-                    memcpy(send_buffer, recv_buffer, send_length);
+                    memset(send_buffer, sn, send_length);
+                    status = validate_buffers(send_buffer, recv_buffer,
+                                              send_length);
+                    if (status != UCS_OK) {
+                        return status;
+                    }
                 }
 
                 send(ep, send_buffer, send_length, send_datatype, sn,

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -16,6 +16,7 @@
 
 #include <ucs/sys/preprocessor.h>
 #include <ucs/sys/string.h>
+#include "ucs/type/status.h"
 #include <limits>
 
 
@@ -733,6 +734,21 @@ public:
                  m_perf.ucp.self_recv_rkey);
     }
 
+    ucs_status_t validate_buffers(void *send_buffer, void *recv_buffer,
+                                  size_t length)
+    {
+        if (CMD == UCX_PERF_CMD_PUT) {
+            fence();
+        }
+
+        if (memcmp(send_buffer, recv_buffer, length)) {
+            ucs_error("data mismatch between send and receive buffers");
+            return UCS_ERR_IO_ERROR;
+        }
+
+        return UCS_OK;
+    }
+
     ucs_status_t run_pingpong()
     {
         unsigned my_index;
@@ -744,6 +760,8 @@ public:
         ucp_rkey_h rkey;
         size_t length, send_length, recv_length;
         psn_t sn;
+        bool validate;
+        ucs_status_t status;
 
         send_buffer = m_perf.send_buffer;
         recv_buffer = m_perf.recv_buffer;
@@ -751,13 +769,15 @@ public:
         ep          = m_perf.ucp.ep;
         remote_addr = m_perf.ucp.remote_addr;
         rkey        = m_perf.ucp.rkey;
-        sn          = 0;
+        sn          = 1;
 
         ucp_perf_init_common_params(&length, &send_length, &send_datatype,
                                     &send_buffer, &recv_length, &recv_datatype,
                                     &recv_buffer);
 
         reset_buffers(length, UNKNOWN_SN);
+
+        validate = m_perf.params.flags & UCX_PERF_TEST_FLAG_VALIDATE;
 
         ucp_perf_barrier(&m_perf);
 
@@ -769,9 +789,23 @@ public:
 
         if (my_index == 0) {
             UCX_PERF_TEST_FOREACH(&m_perf) {
+
+                if (validate) {
+                    memset(send_buffer, sn, send_length);
+                }
+
                 send(ep, send_buffer, send_length, send_datatype, sn, remote_addr, rkey);
                 recv(worker, ep, recv_buffer, recv_length, recv_datatype, sn);
                 wait_recv_window(m_max_outstanding);
+
+                if (validate) {
+                    status = validate_buffers(send_buffer, recv_buffer,
+                                              send_length);
+                    if (status != UCS_OK) {
+                        return status;
+                    }
+                }
+
                 ucx_perf_update(&m_perf, 1, 1, length);
                 ++sn;
             }
@@ -779,6 +813,11 @@ public:
             UCX_PERF_TEST_FOREACH(&m_perf) {
                 recv(worker, ep, recv_buffer, recv_length, recv_datatype, sn);
                 wait_recv_window(m_max_outstanding);
+
+                if (validate) {
+                    memcpy(send_buffer, recv_buffer, send_length);
+                }
+
                 send(ep, send_buffer, send_length, send_datatype, sn,
                      remote_addr, rkey, m_perf.current.iters == 0);
                 ucx_perf_update(&m_perf, 1, 1, length);
@@ -834,7 +873,7 @@ public:
         if (m_perf.params.flags & UCX_PERF_TEST_FLAG_LOOPBACK) {
             UCX_PERF_TEST_FOREACH(&m_perf) {
                 send(ep, send_buffer, send_length, send_datatype,
-                     sn, remote_addr, rkey);
+                    sn, remote_addr, rkey);
                 recv(worker, ep, recv_buffer, recv_length, recv_datatype, sn);
                 ucx_perf_update(&m_perf, 1, 1, length);
                 ++sn;

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -769,7 +769,7 @@ public:
         ep          = m_perf.ucp.ep;
         remote_addr = m_perf.ucp.remote_addr;
         rkey        = m_perf.ucp.rkey;
-        sn          = 1;
+        sn          = 0;
 
         ucp_perf_init_common_params(&length, &send_length, &send_datatype,
                                     &send_buffer, &recv_length, &recv_datatype,

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -746,7 +746,7 @@ public:
         size_t length, send_length, recv_length;
         psn_t sn;
         bool validate;
-        void *validate_buffer;
+        void *validate_buffer = NULL;
         ucs_status_t status;
 
         send_buffer = m_perf.send_buffer;
@@ -1017,7 +1017,6 @@ private:
                             m_perf.params.recv_mem_type, m_perf.recv_allocator,
                             length, sn, host_buffer);
     }
-
 
     void *alloc_validate_common(size_t buffer_length)
     {

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -734,45 +734,6 @@ public:
                  m_perf.ucp.self_recv_rkey);
     }
 
-    ucs_status_t validate_recv_buffer(void *recv_buffer, size_t length,
-                                      psn_t sn, void *host_buffer)
-    {
-        if (CMD == UCX_PERF_CMD_PUT) {
-            fence();
-        }
-
-        return validate_sn(recv_buffer, m_perf.params.ucp.recv_datatype,
-                            m_perf.params.recv_mem_type, m_perf.recv_allocator,
-                            length, sn, host_buffer);
-    }
-
-    /* Allocate a host staging buffer for validation. For IOV datatypes the
-     * buffer is sized to the longest element; otherwise to recv_length. */
-    void *alloc_validate_buffer(void *recv_buffer, size_t recv_length)
-    {
-        size_t buflen;
-
-        if (m_perf.params.ucp.recv_datatype == UCP_PERF_DATATYPE_IOV) {
-            const ucp_dt_iov_t *iov =
-                    reinterpret_cast<const ucp_dt_iov_t*>(recv_buffer);
-
-            buflen = 0;
-            for (size_t i = 0; i < recv_length; ++i) {
-                buflen = ucs_max(buflen, iov[i].length);
-            }
-        } else {
-            buflen = recv_length;
-        }
-
-        void *buffer = malloc(buflen);
-        if (buffer == NULL) {
-            ucs_error("failed to allocate validation buffer of %zu bytes",
-                      buflen);
-        }
-
-        return buffer;
-    }
-
     ucs_status_t run_pingpong()
     {
         unsigned my_index;
@@ -785,7 +746,7 @@ public:
         size_t length, send_length, recv_length;
         psn_t sn;
         bool validate;
-        void *validate_buffer = NULL;
+        void *validate_buffer;
         ucs_status_t status;
 
         send_buffer = m_perf.send_buffer;
@@ -806,10 +767,14 @@ public:
         status   = UCS_OK;
 
         if (validate) {
-            validate_buffer = alloc_validate_buffer(recv_buffer, recv_length);
+            if (m_perf.params.ucp.recv_datatype == UCP_PERF_DATATYPE_IOV) {
+                validate_buffer = alloc_validate_buffer(
+                    reinterpret_cast<ucp_dt_iov_t*>(recv_buffer), recv_length);
+            } else {
+                validate_buffer = alloc_validate_buffer(recv_length);
+            }
             if (validate_buffer == NULL) {
-                status = UCS_ERR_NO_MEMORY;
-                goto out;
+                return UCS_ERR_NO_MEMORY;
             }
         }
 
@@ -1039,6 +1004,48 @@ private:
                               "<failed to query: %s>",
                               ucs_status_string(status));
         }
+    }
+
+    ucs_status_t validate_recv_buffer(void *recv_buffer, size_t length,
+                                      psn_t sn, void *host_buffer)
+    {
+        if (CMD == UCX_PERF_CMD_PUT) {
+            fence();
+        }
+
+        return validate_sn(recv_buffer, m_perf.params.ucp.recv_datatype,
+                            m_perf.params.recv_mem_type, m_perf.recv_allocator,
+                            length, sn, host_buffer);
+    }
+
+
+    void *alloc_validate_common(size_t buffer_length)
+    {
+        void *buffer = NULL;
+
+        buffer = malloc(buffer_length);
+        if (buffer == NULL) {
+            ucs_error("failed to allocate validation buffer of %zu bytes",
+                      buffer_length);
+        }
+
+        return buffer;
+    }
+
+    void *alloc_validate_buffer(size_t recv_length)
+    {
+        return alloc_validate_common(recv_length);
+    }
+
+    void *alloc_validate_buffer(ucp_dt_iov_t *iov, size_t iov_cnt)
+    {
+        size_t buffer_length = 0;
+
+        for (size_t i = 0; i < iov_cnt; ++i) {
+            buffer_length = ucs_max(buffer_length, iov[i].length);
+        }
+
+        return alloc_validate_common(buffer_length);
     }
 
     int                m_recvs_outstanding;

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -734,19 +734,43 @@ public:
                  m_perf.ucp.self_recv_rkey);
     }
 
-    ucs_status_t validate_buffers(void *send_buffer, void *recv_buffer,
-                                  size_t length)
+    ucs_status_t validate_recv_buffer(void *recv_buffer, size_t length,
+                                      psn_t sn, void *host_buffer)
     {
         if (CMD == UCX_PERF_CMD_PUT) {
             fence();
         }
 
-        if (memcmp(send_buffer, recv_buffer, length)) {
-            ucs_error("data mismatch between send and receive buffers");
-            return UCS_ERR_IO_ERROR;
+        return validate_sn(recv_buffer, m_perf.params.ucp.recv_datatype,
+                            m_perf.params.recv_mem_type, m_perf.recv_allocator,
+                            length, sn, host_buffer);
+    }
+
+    /* Allocate a host staging buffer for validation. For IOV datatypes the
+     * buffer is sized to the longest element; otherwise to recv_length. */
+    void *alloc_validate_buffer(void *recv_buffer, size_t recv_length)
+    {
+        size_t buflen;
+
+        if (m_perf.params.ucp.recv_datatype == UCP_PERF_DATATYPE_IOV) {
+            const ucp_dt_iov_t *iov =
+                    reinterpret_cast<const ucp_dt_iov_t*>(recv_buffer);
+
+            buflen = 0;
+            for (size_t i = 0; i < recv_length; ++i) {
+                buflen = ucs_max(buflen, iov[i].length);
+            }
+        } else {
+            buflen = recv_length;
         }
 
-        return UCS_OK;
+        void *buffer = malloc(buflen);
+        if (buffer == NULL) {
+            ucs_error("failed to allocate validation buffer of %zu bytes",
+                      buflen);
+        }
+
+        return buffer;
     }
 
     ucs_status_t run_pingpong()
@@ -761,6 +785,7 @@ public:
         size_t length, send_length, recv_length;
         psn_t sn;
         bool validate;
+        void *validate_buffer = NULL;
         ucs_status_t status;
 
         send_buffer = m_perf.send_buffer;
@@ -778,6 +803,15 @@ public:
         reset_buffers(length, UNKNOWN_SN);
 
         validate = m_perf.params.flags & UCX_PERF_TEST_FLAG_VALIDATE;
+        status   = UCS_OK;
+
+        if (validate) {
+            validate_buffer = alloc_validate_buffer(recv_buffer, recv_length);
+            if (validate_buffer == NULL) {
+                status = UCS_ERR_NO_MEMORY;
+                goto out;
+            }
+        }
 
         ucp_perf_barrier(&m_perf);
 
@@ -791,7 +825,8 @@ public:
             UCX_PERF_TEST_FOREACH(&m_perf) {
 
                 if (validate) {
-                    memset(send_buffer, sn, send_length);
+                    fill_sn(send_buffer, m_perf.params.ucp.send_datatype,
+                            m_perf.send_allocator, send_length, sn);
                 }
 
                 send(ep, send_buffer, send_length, send_datatype, sn, remote_addr, rkey);
@@ -799,10 +834,10 @@ public:
                 wait_recv_window(m_max_outstanding);
 
                 if (validate) {
-                    status = validate_buffers(send_buffer, recv_buffer,
-                                              send_length);
+                    status = validate_recv_buffer(recv_buffer, recv_length, sn,
+                                                  validate_buffer);
                     if (status != UCS_OK) {
-                        return status;
+                        goto out;
                     }
                 }
 
@@ -815,12 +850,13 @@ public:
                 wait_recv_window(m_max_outstanding);
 
                 if (validate) {
-                    memset(send_buffer, sn, send_length);
-                    status = validate_buffers(send_buffer, recv_buffer,
-                                              send_length);
+                    status = validate_recv_buffer(recv_buffer, recv_length, sn,
+                                                  validate_buffer);
                     if (status != UCS_OK) {
-                        return status;
+                        goto out;
                     }
+                    fill_sn(send_buffer, m_perf.params.ucp.send_datatype,
+                            m_perf.send_allocator, send_length, sn);
                 }
 
                 send(ep, send_buffer, send_length, send_datatype, sn,
@@ -838,7 +874,10 @@ public:
 
         ucx_perf_get_time(&m_perf);
         ucp_perf_barrier(&m_perf);
-        return UCS_OK;
+
+out:
+        free(validate_buffer);
+        return status;
     }
 
     ucs_status_t run_stream_uni()

--- a/src/tools/perf/lib/ucp_tests.h
+++ b/src/tools/perf/lib/ucp_tests.h
@@ -99,8 +99,79 @@ public:
         }
     }
 
+    void fill_sn(void *buffer, ucp_perf_datatype_t datatype,
+                 const ucx_perf_allocator_t *allocator, size_t length, PSN sn)
+    {
+        if (datatype == UCP_PERF_DATATYPE_IOV) {
+            const ucp_dt_iov_t *iov = reinterpret_cast<const ucp_dt_iov_t*>(buffer);
+            for (size_t i = 0; i < length; ++i) {
+                fill_sn_region(iov[i].buffer, iov[i].length, allocator, sn);
+            }
+        } else {
+            fill_sn_region(buffer, length, allocator, sn);
+        }
+    }
+
+    ucs_status_t validate_sn(const void *buffer, ucp_perf_datatype_t datatype,
+                             ucs_memory_type_t mem_type,
+                             const ucx_perf_allocator_t *allocator,
+                             size_t length, PSN sn, void *host_buffer)
+    {
+        if (datatype == UCP_PERF_DATATYPE_IOV) {
+            const ucp_dt_iov_t *iov = reinterpret_cast<const ucp_dt_iov_t*>(buffer);
+            for (size_t i = 0; i < length; ++i) {
+                ucs_status_t status = validate_sn_region(iov[i].buffer,
+                                                         mem_type, allocator,
+                                                         iov[i].length, sn,
+                                                         host_buffer);
+                if (status != UCS_OK) {
+                    ucs_error("data validation failed in iov element %zu", i);
+                    return status;
+                }
+            }
+            return UCS_OK;
+        }
+
+        return validate_sn_region(buffer, mem_type, allocator, length, sn,
+                                  host_buffer);
+    }
+
 protected:
     ucx_perf_context_t &m_perf;
+
+private:
+    void fill_sn_region(void *buffer, size_t length, const ucx_perf_allocator_t *allocator,
+                        PSN sn)
+    {
+        allocator->memset(buffer, sn, length);
+    }
+
+    ucs_status_t validate_sn_region(const void *buffer,
+                                    ucs_memory_type_t mem_type,
+                                    const ucx_perf_allocator_t *allocator,
+                                    size_t length, PSN sn, void *host_buffer)
+    {
+        const uint8_t *data;
+
+        if (mem_type == UCS_MEMORY_TYPE_HOST) {
+            data = reinterpret_cast<const uint8_t*>(buffer);
+        } else {
+            allocator->memcpy(host_buffer, UCS_MEMORY_TYPE_HOST, buffer,
+                              mem_type, length);
+            data = reinterpret_cast<const uint8_t*>(host_buffer);
+        }
+
+        for (size_t i = 0; i < length; ++i) {
+            if (data[i] != static_cast<uint8_t>(sn)) {
+                ucs_error("data validation failed at offset %zu: "
+                          "got 0x%x expected 0x%x",
+                          i, data[i], static_cast<uint8_t>(sn));
+                return UCS_ERR_IO_ERROR;
+            }
+        }
+
+        return UCS_OK;
+    }
 };
 
 #endif /* UCP_TESTS_H */

--- a/src/tools/perf/perftest.h
+++ b/src/tools/perf/perftest.h
@@ -19,7 +19,7 @@
 #endif
 
 #define TL_RESOURCE_NAME_NONE   "<none>"
-#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:a:R:lyzL:F:Y:"
+#define TEST_PARAMS_ARGS        "t:n:s:W:O:w:D:i:H:oSCIqM:r:E:T:d:x:A:BUem:a:R:lyzL:F:Y:V"
 #define TEST_ID_UNDEFINED       -1
 
 #define DEFAULT_DAEMON_PORT     1338
@@ -41,7 +41,7 @@ extern test_type_t tests[];
 ucs_status_t run_test(struct perftest_context *ctx);
 ucs_status_t clone_params(perftest_params_t *dest,
                           const perftest_params_t *src);
-ucs_status_t check_params(const perftest_params_t *params);
+ucs_status_t check_params(perftest_params_t *params);
 ucs_status_t parse_opts(struct perftest_context *ctx, int mpi_initialized,
                         int argc, char **argv);
 ucs_status_t init_test_params(perftest_params_t *params);

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -11,7 +11,7 @@
 #include "api/libperf.h"
 #include "perftest.h"
 
-#include "ucs/memory/memory_type.h"
+#include <ucs/memory/memory_type.h>
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/sock.h>

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -8,8 +8,10 @@
 #  include "config.h"
 #endif
 
+#include "api/libperf.h"
 #include "perftest.h"
 
+#include "ucs/memory/memory_type.h"
 #include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/sock.h>
@@ -173,6 +175,7 @@ static void usage(const struct perftest_context *ctx, const char *program)
                                 ctx->params.super.ucp.am_hdr_size);
     printf("     -y             do additional memcopy to the user memory in active message receive handler\n");
     printf("     -z             pass pre-registered memory handle\n");
+    printf("     -V             validate data correctness for pingpong tests\n");
     printf("     -g <IP>[:<port>], --daemon-local <IP>[:<port>]\n");
     printf("                    IP address and port of the local daemon to offload UCP operations to\n");
     printf("                    Port is optional, by default daemon port is (%d)\n",
@@ -771,6 +774,9 @@ ucs_status_t parse_test_params(perftest_params_t *params, char opt,
     case 'z':
         params->super.flags |= UCX_PERF_TEST_FLAG_PREREG;
         return UCS_OK;
+    case 'V':
+        params->super.flags |= UCX_PERF_TEST_FLAG_VALIDATE;
+        return UCS_OK;
     default:
        return UCS_ERR_INVALID_PARAM;
     }
@@ -819,11 +825,41 @@ ucs_status_t clone_params(perftest_params_t *dest,
     return UCS_OK;
 }
 
+ucs_status_t check_validation_params(const ucx_perf_params_t *params)
+{
+    if (!(params->flags & UCX_PERF_TEST_FLAG_VALIDATE)) {
+        return UCS_OK;
+    }
+
+    if (params->api == UCX_PERF_API_UCT) {
+        ucs_error("validation mode is not compatible with UCT tests");
+        return UCS_ERR_INVALID_PARAM;
+    }
+   
+    if (params->test_type != UCX_PERF_TEST_TYPE_PINGPONG) {
+        ucs_error("validation mode requires using a PingPong test");
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    if ((params->send_mem_type != UCS_MEMORY_TYPE_HOST) || 
+        (params->recv_mem_type != UCS_MEMORY_TYPE_HOST)) {
+        ucs_error("validation mode requires send and recv buffers to use host memory");
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return UCS_OK;
+}
+
 ucs_status_t check_params(const perftest_params_t *params)
 {
     ucs_status_t status;
 
     status = check_daemon_params(&params->super);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = check_validation_params(&params->super);
     if (status != UCS_OK) {
         return status;
     }
@@ -916,7 +952,7 @@ ucs_status_t parse_opts(struct perftest_context *ctx, int mpi_initialized,
 
     optind = 1;
     while ((c = getopt_long(argc, argv,
-                            "p:b:6NfvXc:P:hK:g:G:k" TEST_PARAMS_ARGS,
+                            "p:b:6NfvXc:P:hK:g:G:kV" TEST_PARAMS_ARGS,
                             TEST_PARAMS_ARGS_LONG, NULL)) != -1) {
         switch (c) {
         case 'p':

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -825,7 +825,7 @@ ucs_status_t clone_params(perftest_params_t *dest,
     return UCS_OK;
 }
 
-ucs_status_t check_validation_params(const ucx_perf_params_t *params)
+ucs_status_t check_validation_params(ucx_perf_params_t *params)
 {
     if (!(params->flags & UCX_PERF_TEST_FLAG_VALIDATE)) {
         return UCS_OK;
@@ -841,16 +841,14 @@ ucs_status_t check_validation_params(const ucx_perf_params_t *params)
         return UCS_ERR_INVALID_PARAM;
     }
 
-    if ((params->send_mem_type != UCS_MEMORY_TYPE_HOST) || 
-        (params->recv_mem_type != UCS_MEMORY_TYPE_HOST)) {
-        ucs_error("validation mode requires send and recv buffers to use host memory");
-        return UCS_ERR_INVALID_PARAM;
+    if (params->command == UCX_PERF_CMD_AM) {
+        params->flags |= UCX_PERF_TEST_FLAG_AM_RECV_COPY;
     }
 
     return UCS_OK;
 }
 
-ucs_status_t check_params(const perftest_params_t *params)
+ucs_status_t check_params(perftest_params_t *params)
 {
     ucs_status_t status;
 
@@ -952,7 +950,7 @@ ucs_status_t parse_opts(struct perftest_context *ctx, int mpi_initialized,
 
     optind = 1;
     while ((c = getopt_long(argc, argv,
-                            "p:b:6NfvXc:P:hK:g:G:kV" TEST_PARAMS_ARGS,
+                            "p:b:6NfvXc:P:hK:g:G:k" TEST_PARAMS_ARGS,
                             TEST_PARAMS_ARGS_LONG, NULL)) != -1) {
         switch (c) {
         case 'p':

--- a/src/tools/perf/perftest_run.c
+++ b/src/tools/perf/perftest_run.c
@@ -278,7 +278,7 @@ static ucs_status_t read_batch_file(FILE *batch_file, const char *file_name,
 }
 
 static ucs_status_t run_test_recurs(struct perftest_context *ctx,
-                                    const perftest_params_t *parent_params,
+                                    perftest_params_t *parent_params,
                                     unsigned depth)
 {
     perftest_params_t params;


### PR DESCRIPTION
## What?
Adds a new mode to UCX perftest to validate that buffers are transferred completely.

## Why?
Allows for validation of data transfers during fault tolerance testing when end point lanes fail and are restored.

## How?
UCP Pingpong perftests set send buffers to a known value on the sender side. The buffer contents are received and echoed back by the receiving side. The contents of the buffer are validated back on the sender side.