### PR TITLE
UCP/RKEY: Add Null pointer guard to memh pack log print - v1.22.x

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -122,6 +122,7 @@ Tony Curtis <tonycurtis32@gmail.com>
 Tzafrir Cohen <tzafrirc@nvidia.com>
 Valentin Petrov <valentinp@mellanox.com>
 Wenbin Lu <wenbin.lu@stonybrook.edu>
+William Gallagher <wgallagher@nvidia.com>
 Xin Zhao <xinz@mellanox.com>
 Xu Yifeng <yifeng.xyf@alibaba-inc.com>
 Yaser Afshar <yaser.afshar@intel.com>

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -713,8 +713,11 @@ ucp_memh_pack_internal(ucp_mem_h memh, const ucp_memh_pack_params_t *params,
 
     ucs_trace("packing %smemh %p for buffer %p md_map 0x%" PRIx64
               " export_md_map 0x%" PRIx64,
-              (flags & UCP_MEMH_PACK_FLAG_EXPORT) ? "exported " : "", memh,
-              ucp_memh_address(memh), memh->md_map, context->export_md_map);
+              (flags & UCP_MEMH_PACK_FLAG_EXPORT) ? "exported " :
+              ucp_memh_is_zero_length(memh)       ? "zero_length " :
+                                                    "",
+              memh, ucp_memh_address(memh), memh->md_map,
+              (context != NULL) ? context->export_md_map : 0);
 
     if (ucp_memh_is_zero_length(memh)) {
         /* Dummy memh, return dummy key */


### PR DESCRIPTION
## What?
Fixes Null pointer dereference when packing a zero length memory handle when UCX is in log level TRACE. memh->context is not valid when packing a memory handle with zero length.