### PR TITLE
GTEST: Skip slow debug tests under Valgrind

### DIFF
--- a/test/gtest/ucs/test_debug.cc
+++ b/test/gtest/ucs/test_debug.cc
@@ -48,7 +48,8 @@ UCS_TEST_F(test_debug, lookup_invalid) {
     EXPECT_EQ(UCS_ERR_NO_ELEM, status);
 }
 
-UCS_TEST_SKIP_COND_F(test_debug, lookup_address, BULLSEYE_ON) {
+UCS_TEST_SKIP_COND_F(test_debug, lookup_address,
+                     BULLSEYE_ON || RUNNING_ON_VALGRIND) {
     unsigned lineno;
 
     my_cool_function(&lineno);
@@ -73,7 +74,7 @@ UCS_TEST_SKIP_COND_F(test_debug, lookup_address, BULLSEYE_ON) {
 #endif
 }
 
-UCS_TEST_F(test_debug, print_backtrace) {
+UCS_TEST_SKIP_COND_F(test_debug, print_backtrace, RUNNING_ON_VALGRIND) {
     char *data;
     size_t size;
 


### PR DESCRIPTION
## What
Skip `test_debug.lookup_address` and `test_debug.print_backtrace` when running under Valgrind.

## Why
These tests exercise detailed debug symbol/backtrace resolution. When UCX is built with BFD support, this path uses libbfd APIs such as `bfd_map_over_sections()` and `bfd_find_nearest_line()`. Under Valgrind this can make the tests extremely slow and may trip the gtest watchdog.
solve internal issue (https://redmine.mellanox.com/issues/5042805)
