### PR TITLE
UCS/TIME: Include ucs/sys/math.h for UCS_INFINITY

### DIFF
--- a/src/ucs/time/time.h
+++ b/src/ucs/time/time.h
@@ -9,6 +9,7 @@
 
 #include <ucs/arch/cpu.h>
 #include <ucs/time/time_def.h>
+#include <ucs/sys/math.h>
 #include <sys/time.h>
 #include <limits.h>
 #include <math.h>


### PR DESCRIPTION
time.h uses UCS_INFINITY (defined in ucs/sys/math.h) but does not include it. When time.h is reached via an include chain that does not pull in math.h indirectly (e.g. from the UCM subsystem), the build fails with 'UCS_INFINITY' undeclared. Detected while compiling OpenHPC on ppc64le. Add the missing include.

Original error:
```
In file included from src/ucm/util/sys.h:13,
                 from src/ucm/mmap/mmap.h:11,
                 from event/event.c:13:
src/ucs/time/time.h: In function 'ucs_time_units_to_sec': src/ucs/time/time.h:166:16: error: 'UCS_INFINITY' undeclared (first use in this function); did you mean 'FP_INFINITE'?
  166 |         return UCS_INFINITY;
      |                ^~~~~~~~~~~~
      |                FP_INFINITE
```