### PR TITLE
UCS/TOPO: Skip sibling match for inactive devices

### DIFF
--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -60,6 +60,7 @@ typedef struct {
     unsigned                name_priority;
     ucs_numa_node_t         numa_node;
     uintptr_t               user_value;
+    int                     active;
 
     /* Secondary device for the current device */
     ucs_sys_device_t        sys_dev_aux;
@@ -378,6 +379,7 @@ ucs_status_t ucs_topo_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
                 UCS_SYS_DEVICE_ID_UNKNOWN;
         ucs_topo_global_ctx.devices[*sys_dev].sys_dev_aux =
                 UCS_SYS_DEVICE_ID_UNKNOWN;
+        ucs_topo_global_ctx.devices[*sys_dev].active = 1;
 
         ucs_debug("added sys_dev %d for bus id %s", *sys_dev, name);
         status = UCS_OK;
@@ -609,10 +611,8 @@ ucs_topo_is_reachable(ucs_sys_device_t sys_dev, ucs_sys_device_t sys_dev_mem)
 
     ucs_spin_lock(&ucs_topo_global_ctx.lock);
     result =
-            /*
-             * Memory device was never matched with a sibling, it does not
-             * mandate and auxiliary path.
-             */
+            /* Memory device was never matched with a sibling, it does not
+             * mandate an auxiliary path. */
             (ucs_topo_global_ctx.devices[sys_dev_mem].sibling_sys_dev ==
              UCS_SYS_DEVICE_ID_UNKNOWN) ||
             /* The device itself never uses auxiliary path */
@@ -631,6 +631,8 @@ int ucs_topo_is_sibling(ucs_sys_device_t sys_dev, ucs_sys_device_t sys_dev_mem)
     int is_sibling;
     ucs_topo_sibling_role_t UCS_V_UNUSED role_dev;
     ucs_topo_sibling_role_t UCS_V_UNUSED role_dev_mem;
+    int UCS_V_UNUSED sys_dev_active;
+    int UCS_V_UNUSED sys_dev_mem_active;
 
     ucs_spin_lock(&ucs_topo_global_ctx.lock);
     is_sibling = (sys_dev < ucs_topo_global_ctx.num_devices) &&
@@ -639,13 +641,19 @@ int ucs_topo_is_sibling(ucs_sys_device_t sys_dev, ucs_sys_device_t sys_dev_mem)
                   sys_dev_mem);
 
     if (is_sibling) {
-        role_dev     = ucs_topo_global_ctx.devices[sys_dev].sibling_role;
-        role_dev_mem = ucs_topo_global_ctx.devices[sys_dev_mem].sibling_role;
+        role_dev       = ucs_topo_global_ctx.devices[sys_dev].sibling_role;
+        role_dev_mem   = ucs_topo_global_ctx.devices[sys_dev_mem].sibling_role;
+        sys_dev_active = ucs_topo_global_ctx.devices[sys_dev].active;
+        sys_dev_mem_active = ucs_topo_global_ctx.devices[sys_dev_mem].active;
         ucs_assertv((role_dev != UCS_TOPO_SIBLING_ROLE_NONE) &&
                     (role_dev_mem != UCS_TOPO_SIBLING_ROLE_NONE) &&
-                    (role_dev != role_dev_mem), "sys_dev=%u sys_dev_mem=%u"
-                    " sys_dev_role=%d sys_dev_mem_role=%d",
-                    sys_dev, sys_dev_mem, role_dev, role_dev_mem);
+                    (role_dev != role_dev_mem) && 
+                    sys_dev_active && sys_dev_mem_active,
+                    "sys_dev=%u sys_dev_mem=%u "
+                    "sys_dev_role=%d sys_dev_mem_role=%d "
+                    "sys_dev_active=%d sys_dev_mem_active=%d",
+                    sys_dev, sys_dev_mem, role_dev, role_dev_mem,
+                    sys_dev_active, sys_dev_mem_active);
     }
     ucs_spin_unlock(&ucs_topo_global_ctx.lock);
 
@@ -968,7 +976,9 @@ static int ucs_topo_sys_device_sibling_match(ucs_sys_device_t sys_dev,
     if ((ucs_topo_global_ctx.devices[sys_dev_mem].sibling_role !=
          UCS_TOPO_SIBLING_ROLE_MEM) ||
         (ucs_topo_global_ctx.devices[sys_dev].sibling_role !=
-         UCS_TOPO_SIBLING_ROLE_DEV)) {
+         UCS_TOPO_SIBLING_ROLE_DEV) ||
+        !ucs_topo_global_ctx.devices[sys_dev].active ||
+        !ucs_topo_global_ctx.devices[sys_dev_mem].active) {
         return 0;
     }
 
@@ -1054,6 +1064,47 @@ int ucs_topo_device_has_sibling(ucs_sys_device_t sys_dev)
     result = (sys_dev < ucs_topo_global_ctx.num_devices) &&
              (ucs_topo_global_ctx.devices[sys_dev].sibling_sys_dev !=
               UCS_SYS_DEVICE_ID_UNKNOWN);
+    ucs_spin_unlock(&ucs_topo_global_ctx.lock);
+
+    return result;
+}
+
+ucs_status_t ucs_topo_sys_device_set_inactive(ucs_sys_device_t sys_dev)
+{
+    ucs_status_t status = UCS_OK;
+
+    ucs_spin_lock(&ucs_topo_global_ctx.lock);
+    if (sys_dev >= ucs_topo_global_ctx.num_devices) {
+        ucs_error("system device %d is invalid (max: %d)", sys_dev,
+                  ucs_topo_global_ctx.num_devices);
+        status = UCS_ERR_INVALID_PARAM;
+        goto out;
+    }
+
+    if (ucs_topo_global_ctx.devices[sys_dev].sibling_sys_dev !=
+        UCS_SYS_DEVICE_ID_UNKNOWN) {
+        ucs_error("cannot set device %d inactive: sibling %d already matched",
+                  sys_dev,
+                  ucs_topo_global_ctx.devices[sys_dev].sibling_sys_dev);
+        status = UCS_ERR_INVALID_PARAM;
+        goto out;
+    }
+
+    ucs_topo_global_ctx.devices[sys_dev].active = 0;
+
+out:
+    ucs_spin_unlock(&ucs_topo_global_ctx.lock);
+    return status;
+}
+
+int ucs_topo_device_is_active(ucs_sys_device_t sys_dev)
+{
+    int result;
+
+    ucs_spin_lock(&ucs_topo_global_ctx.lock);
+    result = (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) ||
+             ((sys_dev < ucs_topo_global_ctx.num_devices) &&
+              ucs_topo_global_ctx.devices[sys_dev].active);
     ucs_spin_unlock(&ucs_topo_global_ctx.lock);
 
     return result;

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -434,6 +434,27 @@ int ucs_topo_device_has_sibling(ucs_sys_device_t sys_dev);
 
 
 /**
+ * Mark a system device as inactive.
+ *
+ * @param [in] sys_dev System device index.
+ *
+ * @return UCS_OK on success, error otherwise.
+ */
+ucs_status_t ucs_topo_sys_device_set_inactive(ucs_sys_device_t sys_dev);
+
+
+/**
+ * Check whether a system device is active.
+ *
+ * @param [in] sys_dev System device index.
+ *
+ * @return Nonzero if the device is active. UNKNOWN is treated as active;
+ *         an out-of-range device is treated as inactive.
+ */
+int ucs_topo_device_is_active(ucs_sys_device_t sys_dev);
+
+
+/**
  * Get the number of registered system devices.
  *
  * @return Number of system devices.

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -23,6 +23,7 @@
 #include <ucs/type/class.h>
 #include <ucs/sys/module.h>
 #include <ucs/sys/string.h>
+#include <ucs/sys/topo/base/topo.h>
 #include <ucs/time/time.h>
 #include <ucs/arch/cpu.h>
 #include <ucs/vfs/base/vfs_obj.h>
@@ -115,6 +116,10 @@ ucs_status_t uct_md_query_tl_resources(uct_md_h md,
 
         /* add tl devices to overall list of resources */
         for (i = 0; i < num_tl_devices; ++i) {
+            ucs_assertv(ucs_topo_device_is_active(tl_devices[i].sys_device),
+                        "%s device %s sys_dev %d is inactive", tl->name,
+                        tl_devices[i].name, tl_devices[i].sys_device);
+
             ucs_strncpy_zero(tmp[num_resources + i].tl_name, tl->name,
                              sizeof(tmp[num_resources + i].tl_name));
             ucs_strncpy_zero(tmp[num_resources + i].dev_name, tl_devices[i].name,

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -597,6 +597,15 @@ ucs_status_t uct_ib_device_query(uct_ib_device_t *dev,
     uct_ib_device_set_pci_id(dev, sysfs_path);
     dev->pci_bw = ucs_topo_get_pci_bw(dev_name, sysfs_path);
 
+    if ((dev->sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) &&
+        !uct_ib_device_has_active_port(dev)) {
+        ucs_debug("%s: setting sys_dev %d inactive because it has no active ports",
+                  dev_name, dev->sys_dev);
+        status = ucs_topo_sys_device_set_inactive(dev->sys_dev);
+        goto out_free_path_buffer;
+    }
+
+out_free_path_buffer:
     ucs_free(path_buffer);
 out:
     return status;
@@ -764,6 +773,20 @@ static unsigned long uct_ib_device_get_ib_gid_index(uct_ib_md_t *md)
     } else {
         return md->config.gid_index;
     }
+}
+
+int uct_ib_device_has_active_port(uct_ib_device_t *dev)
+{
+    uint8_t port_num;
+
+    for (port_num = dev->first_port;
+         port_num < dev->first_port + dev->num_ports; ++port_num) {
+        if (uct_ib_device_port_attr(dev, port_num)->state == IBV_PORT_ACTIVE) {
+            return 1;
+        }
+    }
+
+    return 0;
 }
 
 static ucs_status_t
@@ -1330,6 +1353,11 @@ ucs_status_t uct_ib_device_query_ports(uct_ib_device_t *dev, unsigned flags,
         status = UCS_ERR_NO_DEVICE;
         goto err_free;
     }
+
+    ucs_assertv(ucs_topo_device_is_active(dev->sys_dev),
+                "ib device with num_tl_devices > 0 is expected to be active; "
+                "sys_dev=%u",
+                dev->sys_dev);
 
     *num_tl_devices_p = num_tl_devices;
     *tl_devices_p     = tl_devices;

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -292,6 +292,11 @@ ucs_status_t uct_ib_device_query_ports(uct_ib_device_t *dev, unsigned flags,
 ucs_status_t uct_ib_device_query(uct_ib_device_t *dev,
                                  struct ibv_device *ibv_device);
 
+/**
+ * @return Nonzero if the device has at least one active (IBV_PORT_ACTIVE) port.
+ */
+int uct_ib_device_has_active_port(uct_ib_device_t *dev);
+
 ucs_status_t uct_ib_device_init(uct_ib_device_t *dev,
                                 struct ibv_device *ibv_device, int async_events
                                 UCS_STATS_ARG(ucs_stats_node_t *stats_parent));

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -1512,6 +1512,13 @@ uct_gdaki_query_tl_devices(uct_md_h tl_md,
         goto out;
     }
 
+    if (!ucs_topo_device_is_active(ib_md->dev.sys_dev)) {
+        ucs_debug("%s: sys_dev %d is inactive", uct_ib_device_name(&ib_md->dev),
+                  ib_md->dev.sys_dev);
+        status = UCS_ERR_NO_DEVICE;
+        goto out;
+    }
+
     UCS_INIT_ONCE(&dmat_once) {
         dmat = uct_gdaki_dev_matrix_init(ib_md, &dmat_length);
     }

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -365,6 +365,41 @@ void test_topo::read_pcie_devices()
     closedir(dir);
 }
 
+UCS_TEST_F(test_topo, device_active) {
+    ucs_sys_bus_id_t bus_id;
+    ucs_sys_device_t dev;
+
+    bus_id.domain   = 0xffff;
+    bus_id.bus      = 0xfe;
+    bus_id.slot     = 0xfe;
+    bus_id.function = 3;
+
+    ASSERT_UCS_OK(ucs_topo_find_device_by_bus_id(&bus_id, &dev));
+    ASSERT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, dev);
+
+    /* Devices default to active */
+    EXPECT_TRUE(ucs_topo_device_is_active(dev));
+
+    /* UNKNOWN is treated as active*/
+    EXPECT_TRUE(ucs_topo_device_is_active(UCS_SYS_DEVICE_ID_UNKNOWN));
+
+    /* An out-of-range device id is treated as inactive */
+    EXPECT_FALSE(ucs_topo_device_is_active(ucs_topo_num_devices()));
+
+    /* set_inactive is a one-way latch */
+    ASSERT_UCS_OK(ucs_topo_sys_device_set_inactive(dev));
+    EXPECT_FALSE(ucs_topo_device_is_active(dev));
+
+    /* An UNKNOWN or out-of-range device id is rejected */
+    {
+        const scoped_log_handler slh(hide_errors_logger);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM,
+                  ucs_topo_sys_device_set_inactive(ucs_topo_num_devices()));
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM,
+                  ucs_topo_sys_device_set_inactive(UCS_SYS_DEVICE_ID_UNKNOWN));
+    }
+}
+
 UCS_TEST_F(test_topo, sibling_error) {
     scoped_log_handler slh(hide_errors_logger);
     ASSERT_EQ(UCS_ERR_INVALID_PARAM, ucs_topo_sys_device_set_sys_dev_aux(1, 0));
@@ -430,4 +465,74 @@ UCS_TEST_F(test_topo, sibling) {
         ASSERT_FALSE(ucs_topo_is_sibling(hca_devs[0], gpu_dev));
         ASSERT_FALSE(ucs_topo_is_sibling(gpu_dev, hca_devs[0]));
     }
+}
+
+UCS_TEST_F(test_topo, sibling_inactive) {
+    read_pcie_devices();
+    if ((m_hcas.size() == 0) || (m_gpus.size() == 0) || (m_dmas.size() == 0)) {
+        UCS_TEST_SKIP_R("Not enough HCA, GPU and DMA PCIe device");
+    }
+
+    std::string sibling_gpu, sibling_dma;
+    get_siblings(m_hcas[0], sibling_gpu, sibling_dma);
+    if (sibling_dma.empty()) {
+        UCS_TEST_SKIP_R("No GPU/HCA sibling pair found");
+    }
+
+    auto hca_dev = register_device("hca0", m_hcas[0]);
+    ASSERT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, hca_dev);
+    auto dma_dev = register_device("dma", sibling_dma);
+    ASSERT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, dma_dev);
+    auto gpu_dev = register_device("gpu0", sibling_gpu);
+    ASSERT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, gpu_dev);
+
+    /* Mark the NIC inactive (e.g. its port is down) before matching */
+    ASSERT_UCS_OK(ucs_topo_sys_device_set_inactive(hca_dev));
+
+    ASSERT_UCS_OK(ucs_topo_sys_device_set_sys_dev_aux(hca_dev, dma_dev));
+    ASSERT_UCS_OK(ucs_topo_sys_device_enable_aux_path(gpu_dev));
+
+    /* An inactive NIC must not be matched as a sibling */
+    EXPECT_FALSE(ucs_topo_is_sibling(hca_dev, gpu_dev));
+    EXPECT_FALSE(ucs_topo_device_has_sibling(gpu_dev));
+}
+
+UCS_TEST_F(test_topo, set_inactive_with_sibling) {
+    read_pcie_devices();
+    if ((m_hcas.size() == 0) || (m_gpus.size() == 0) || (m_dmas.size() == 0)) {
+        UCS_TEST_SKIP_R("Not enough HCA, GPU and DMA PCIe device");
+    }
+
+    std::string sibling_gpu, sibling_dma;
+    get_siblings(m_hcas[0], sibling_gpu, sibling_dma);
+    if (sibling_dma.empty()) {
+        UCS_TEST_SKIP_R("No GPU/HCA sibling pair found");
+    }
+
+    auto hca_dev = register_device("hca0", m_hcas[0]);
+    ASSERT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, hca_dev);
+    auto dma_dev = register_device("dma", sibling_dma);
+    ASSERT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, dma_dev);
+    auto gpu_dev = register_device("gpu0", sibling_gpu);
+    ASSERT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, gpu_dev);
+
+    /* Establish the GPU/NIC sibling match first */
+    ASSERT_UCS_OK(ucs_topo_sys_device_set_sys_dev_aux(hca_dev, dma_dev));
+    ASSERT_UCS_OK(ucs_topo_sys_device_enable_aux_path(gpu_dev));
+    ASSERT_TRUE(ucs_topo_is_sibling(hca_dev, gpu_dev));
+
+    /* Deactivating a device that already has a sibling must fail and leave
+     * both the active state and the sibling link untouched */
+    {
+        const scoped_log_handler slh(hide_errors_logger);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM,
+                  ucs_topo_sys_device_set_inactive(hca_dev));
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM,
+                  ucs_topo_sys_device_set_inactive(gpu_dev));
+    }
+
+    /* Nothing changes after the failure */
+    EXPECT_TRUE(ucs_topo_device_is_active(hca_dev));
+    EXPECT_TRUE(ucs_topo_device_is_active(gpu_dev));
+    EXPECT_TRUE(ucs_topo_is_sibling(hca_dev, gpu_dev));
 }


### PR DESCRIPTION
## What?
Prevent GPU/NIC sibling matching in topo if the port(s) of the IB NIC is down.
Added `active` flag to topo devices that is default `1` and can be set to `0` (one-way) to indicate that the device should not be used.

## Why?
Previously a GPU and an IB NIC under a shared PCIe switch are matched as siblings, without checking the port state. 
As a result `ucs_topo_device_has_sibling(gpu)` returned true even when the sibling NIC's port is down, causing `cuda_copy` to select the data-direct PCIe dmabuf mapping (`CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE`) for a NIC that cannot serve it (IB NICs with port down are filtered out in `uct_ib_device_query_ports` and does not appear as usable resources)