### PR TITLE
UCT/IB: Skip madvise with DONT_FORK if kernel supports RDMA copy-on-fork - v1.22.x

### DIFF
--- a/contrib/ibmock/verbs.c
+++ b/contrib/ibmock/verbs.c
@@ -20,6 +20,7 @@
 #define DUMMY_PKEY 65535 /* Dummy pkey with full membership for now */
 
 static pthread_mutex_t global_lock = PTHREAD_MUTEX_INITIALIZER;
+static bool fork_initialized       = false;
 
 void lock(void)
 {
@@ -110,7 +111,13 @@ const char *ibv_get_device_name(struct ibv_device *device)
 
 int ibv_fork_init(void)
 {
+    fork_initialized = true;
     return 0;
+}
+
+enum ibv_fork_status ibv_is_fork_initialized(void)
+{
+    return fork_initialized ? IBV_FORK_ENABLED : IBV_FORK_DISABLED;
 }
 
 static int vctx_query_port(struct ibv_context *context, uint8_t port_num,

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -927,6 +927,18 @@ static void uct_ib_fork_warn_enable()
     }
 }
 
+static int uct_ib_is_fork_init_needed()
+{
+#if HAVE_DECL_IBV_IS_FORK_INITIALIZED && HAVE_DECL_IBV_FORK_UNNEEDED
+    if (ibv_is_fork_initialized() == IBV_FORK_UNNEEDED) {
+        ucs_debug("ibv_fork_init() is not needed");
+        return 0;
+    }
+#endif
+
+    return 1;
+}
+
 static void uct_ib_md_release_device_config(uct_ib_md_t *md)
 {
     unsigned i;
@@ -1111,6 +1123,10 @@ uct_ib_fork_init(const uct_ib_md_config_t *md_config, int *fork_init_p)
     int ret;
 
     *fork_init_p = 0;
+
+    if (!uct_ib_is_fork_init_needed()) {
+        return UCS_OK;
+    }
 
     if (md_config->fork_init == UCS_NO) {
         uct_ib_fork_warn_enable();

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -227,6 +227,7 @@ AS_IF([test "x$with_ib" = "xyes"],
                        IBV_LINK_LAYER_ETHERNET,
                        IBV_EVENT_GID_CHANGE,
                        IBV_EVENT_PORT_SPEED_CHANGE,
+                       IBV_FORK_UNNEEDED,
                        IBV_TRANSPORT_USNIC,
                        IBV_TRANSPORT_USNIC_UDP,
                        IBV_TRANSPORT_UNSPECIFIED,
@@ -234,7 +235,8 @@ AS_IF([test "x$with_ib" = "xyes"],
                        ibv_create_cq_ex,
                        ibv_create_srq_ex,
                        ibv_reg_dmabuf_mr,
-                       ibv_query_port_speed],
+                       ibv_query_port_speed,
+                       ibv_is_fork_initialized],
                       [], [], [[#include <infiniband/verbs.h>]])
 
        # Check ECE operation APIs are supported by rdma-core package


### PR DESCRIPTION
Backport #11573.