### PR TITLE
UCT/IB: Skip direct-NIC sibling match for HCAs with no active port - v1.22.x

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -539,6 +539,20 @@ uct_ib_device_set_pci_id(uct_ib_device_t *dev, const char *sysfs_path)
               dev->pci_id.vendor, dev->pci_id.device);
 }
 
+int uct_ib_device_has_active_port(uct_ib_device_t *dev)
+{
+    uint8_t port_num;
+
+    for (port_num = dev->first_port;
+         port_num < dev->first_port + dev->num_ports; ++port_num) {
+        if (uct_ib_device_port_attr(dev, port_num)->state == IBV_PORT_ACTIVE) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
 ucs_status_t uct_ib_device_query(uct_ib_device_t *dev,
                                  struct ibv_device *ibv_device)
 {

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -292,6 +292,11 @@ ucs_status_t uct_ib_device_query_ports(uct_ib_device_t *dev, unsigned flags,
 ucs_status_t uct_ib_device_query(uct_ib_device_t *dev,
                                  struct ibv_device *ibv_device);
 
+/**
+ * @return Nonzero if the device has at least one active (IBV_PORT_ACTIVE) port.
+ */
+int uct_ib_device_has_active_port(uct_ib_device_t *dev);
+
 ucs_status_t uct_ib_device_init(uct_ib_device_t *dev,
                                 struct ibv_device *ibv_device, int async_events
                                 UCS_STATS_ARG(ucs_stats_node_t *stats_parent));

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019-2026. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -37,11 +37,12 @@ static uint32_t uct_ib_mlx5_flush_rkey_make()
     return ((getpid() & 0xff) << 8) | UCT_IB_MD_INVALID_FLUSH_RKEY;
 }
 
-ucs_sys_device_t uct_ib_mlx5dv_check_direct_nic(struct ibv_context *ctx,
-                                                ucs_sys_device_t sys_dev_ib,
-                                                int enabled)
+ucs_sys_device_t
+uct_ib_mlx5dv_check_direct_nic(uct_ib_device_t *dev, int enabled)
 {
 #if HAVE_DECL_MLX5DV_GET_DATA_DIRECT_SYSFS_PATH
+    struct ibv_context *ctx     = dev->ibv_context;
+    ucs_sys_device_t sys_dev_ib = dev->sys_dev;
     char sys_path[PATH_MAX];
     char dev_name[64];
     int ret;
@@ -50,19 +51,24 @@ ucs_sys_device_t uct_ib_mlx5dv_check_direct_nic(struct ibv_context *ctx,
 
     if (!enabled) {
         ucs_debug("%s: direct NIC is disabled by configuration",
-                  ibv_get_device_name(ctx->device));
+                  uct_ib_device_name(dev));
+        goto out;
+    }
+
+    if (!uct_ib_device_has_active_port(dev)) {
+        ucs_debug("%s: skipping direct NIC, no active port",
+                  uct_ib_device_name(dev));
         goto out;
     }
 
     ret = mlx5dv_get_data_direct_sysfs_path(ctx, sys_path, sizeof(sys_path));
     if (ret != 0) {
         ucs_debug("%s: mlx5dv_get_data_direct_sysfs_path() failed: ret=%d",
-                  ibv_get_device_name(ctx->device), ret);
+                  uct_ib_device_name(dev), ret);
         goto out_not_supported;
     }
 
-    snprintf(dev_name, sizeof(dev_name), "%s_direct",
-             ibv_get_device_name(ctx->device));
+    snprintf(dev_name, sizeof(dev_name), "%s_direct", uct_ib_device_name(dev));
     sys_dev_dnic = ucs_topo_get_sysfs_dev(dev_name, sys_path, 0);
     status = ucs_topo_sys_device_set_sys_dev_aux(sys_dev_ib, sys_dev_dnic);
     if (status != UCS_OK) {
@@ -71,19 +77,18 @@ ucs_sys_device_t uct_ib_mlx5dv_check_direct_nic(struct ibv_context *ctx,
 
     ucs_debug("%s: Direct NIC is supported sys_path='%s%s' "
               "sys_dev=%u sys_dev_aux=%u",
-              ibv_get_device_name(ctx->device),
-              (sys_path[0] != 0) ? "/sys" : "", sys_path, sys_dev_ib,
-              sys_dev_dnic);
+              uct_ib_device_name(dev), (sys_path[0] != 0) ? "/sys" : "",
+              sys_path, sys_dev_ib, sys_dev_dnic);
 
     return sys_dev_dnic;
 out_not_supported:
     ucs_debug("%s: direct NIC is requested but not supported",
-              ibv_get_device_name(ctx->device));
+              uct_ib_device_name(dev));
 out:
 #else
     ucs_debug("%s: direct NIC is disabled because declaration of "
               "mlx5dv_get_data_direct_sysfs_path was not found",
-              ibv_get_device_name(ctx->device));
+              uct_ib_device_name(dev));
 #endif
     return UCS_SYS_DEVICE_ID_UNKNOWN;
 }
@@ -2503,8 +2508,8 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
 
     odp_version = uct_ib_mlx5_devx_check_odp(md, md_config, cap);
 
-    md->direct_nic_sys_dev = uct_ib_mlx5dv_check_direct_nic(
-            ctx, dev->sys_dev, md_config->ext.direct_nic);
+    md->direct_nic_sys_dev =
+            uct_ib_mlx5dv_check_direct_nic(dev, md_config->ext.direct_nic);
 
     if (UCT_IB_MLX5DV_GET(cmd_hca_cap, cap, atomic)) {
         int ops = UCT_IB_MLX5_ATOMIC_OPS_CMP_SWAP |
@@ -3391,8 +3396,8 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
     uct_ib_md_parse_relaxed_order(&md->super, md_config, 0);
     uct_ib_md_ece_check(&md->super);
     uct_ib_md_check_odp(&md->super, md_config);
-    md->direct_nic_sys_dev = uct_ib_mlx5dv_check_direct_nic(
-            ctx, dev->sys_dev, md_config->ext.direct_nic);
+    md->direct_nic_sys_dev =
+            uct_ib_mlx5dv_check_direct_nic(dev, md_config->ext.direct_nic);
 
     md->super.flush_rkey = uct_ib_mlx5_flush_rkey_make();
 

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -1364,22 +1364,13 @@ uct_gdaki_dev_matrix_init(const uct_ib_md_t *ib_md, size_t *dmat_length_p)
     struct ibv_device **device_list;
     struct ibv_device *ibdev;
     uct_gdaki_dev_score_t *scores;
-    char *path_buffer;
-    const char *sysfs_path;
     uct_gdaki_dev_matrix_elem_t *ibdesc;
     struct ibv_context *context;
-    ucs_sys_device_t sys_dev_ib;
-
-    status = ucs_string_alloc_path_buffer(&path_buffer, "path_buffer");
-    if (status != UCS_OK) {
-        return NULL;
-    }
 
     /* Obtain the list of IB devices */
     device_list = ibv_get_device_list(&ibdev_count);
     if (device_list == NULL) {
-        status = UCS_ERR_IO_ERROR;
-        goto out_buff;
+        return NULL;
     }
 
     ucs_assert(ibdev_count > 0);
@@ -1397,15 +1388,13 @@ uct_gdaki_dev_matrix_init(const uct_ib_md_t *ib_md, size_t *dmat_length_p)
         goto out_dmat;
     }
 
-    /* Initialize each IB device, retrieve its system device representation */
+    /* Query each IB device so its sys_dev is resolved and its port state is
+     * known before direct-NIC sibling matching can be triggered. */
     for (ibdev_index = 0; ibdev_index < ibdev_count; ibdev_index++) {
-        ibdesc          = &dmat[ibdev_index];
-        ibdev           = device_list[ibdev_index];
-        sysfs_path      = ucs_topo_resolve_sysfs_path(ibdev->ibdev_path,
-                                                      path_buffer);
+        uct_ib_device_t tmp_dev = {0};
 
-        sys_dev_ib = ucs_topo_get_sysfs_dev(ibv_get_device_name(ibdev),
-                                            sysfs_path, 0);
+        ibdesc  = &dmat[ibdev_index];
+        ibdev   = device_list[ibdev_index];
         context = ibv_open_device(ibdev);
         if (context == NULL) {
             ucs_error("ibv_open_device(%s) failed: %m",
@@ -1414,11 +1403,16 @@ uct_gdaki_dev_matrix_init(const uct_ib_md_t *ib_md, size_t *dmat_length_p)
             goto out;
         }
 
-        ibdesc->direct_nic = uct_ib_mlx5dv_check_direct_nic(context, sys_dev_ib,
-                                                            1) !=
+        tmp_dev.ibv_context = context;
+        status              = uct_ib_device_query(&tmp_dev, ibdev);
+        if (status != UCS_OK) {
+            ibv_close_device(context);
+            goto out;
+        }
+
+        ibdesc->sys_dev    = tmp_dev.sys_dev;
+        ibdesc->direct_nic = uct_ib_mlx5dv_check_direct_nic(&tmp_dev, 1) !=
                              UCS_SYS_DEVICE_ID_UNKNOWN;
-        ibdesc->sys_dev = ucs_topo_get_sysfs_dev(ibv_get_device_name(ibdev),
-                                                 sysfs_path, 0);
         scores[ibdev_index].index = ibdev_index;
         ibv_close_device(context);
     }
@@ -1483,8 +1477,6 @@ out_dmat:
     }
 out_dev:
     ibv_free_device_list(device_list);
-out_buff:
-    ucs_free(path_buffer);
     return dmat;
 }
 

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -1322,8 +1322,7 @@ static inline const char *uct_ib_mlx5_dev_name(uct_ib_mlx5_md_t *md)
     return uct_ib_device_name(&md->super.dev);
 }
 
-ucs_sys_device_t uct_ib_mlx5dv_check_direct_nic(struct ibv_context *ctx,
-                                                ucs_sys_device_t sys_dev_ib,
-                                                int direct_nic);
+ucs_sys_device_t
+uct_ib_mlx5dv_check_direct_nic(uct_ib_device_t *dev, int enabled);
 
 #endif


### PR DESCRIPTION
Backport #11611