### PR TITLE
GTEST/UCP/RMA: Skip CUDA SGL put tests due to sporadic failure

### DIFF
--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -970,6 +970,11 @@ public:
     }
 
     virtual void init() override {
+        /* FIXME: sporadic failure on CUDA memory type. re-enable once fixed */
+        if (mem_type() == UCS_MEMORY_TYPE_CUDA) {
+            UCS_TEST_SKIP_R("sporadic failure on CUDA memory type");
+        }
+
         modify_config("MAX_RMA_RAILS", "2");
         test_ucp_rma::init();
     }


### PR DESCRIPTION
## What?
Temporarily skip all `test_ucp_rma_sgl` tests that run with CUDA memory type.

## Why?
`test_ucp_rma_sgl` CUDA variants (`<all/cuda>`) fail sporadically in CI during SGL put on intra-node endpoints. The put request is aborted during protocol reconfiguration because no remote protocol is found:
```
cannot find remote protocol for: ucp_context_* intra-node cfg#2 | put from sgl cuda/GPU1 to cuda/dev[1]
(`proto_reconfig.c:104`)
```
As a result, the put does not complete and the test fails with a data mismatch.
Until protocol selection/reconfiguration for CUDA SGL put is fixed, this avoids intermittent CI failures.

## How?
Add an early skip in `test_ucp_rma_sgl::init()` when `mem_type() == UCS_MEMORY_TYPE_CUDA`. Host-memory variants continue to run unchanged.