### PR TITLE
CI: Prevent zombie MAD RTE perftest server

### DIFF
--- a/buildlib/tools/test_mad.sh
+++ b/buildlib/tools/test_mad.sh
@@ -36,6 +36,9 @@ docker_run_srv() {
     local test_name="$1"
     HCA=$(detect_active_ib_hca)
     sudo chmod 777 /dev/infiniband/umad*
+    # A zombie server from a canceled or crashed run still holds the MAD
+    # registration on the HCA, which makes this server fail to register
+    docker ps -aq --filter "name=ucx_perftest_" | xargs -r docker rm -f
     docker run \
         --rm \
         --detach \
@@ -53,8 +56,9 @@ docker_run_srv() {
 
 docker_stop_srv() {
     local test_name="$1"
-    cat "${PWD}/ucx_perf_srv_${test_name}_${BUILD_BUILDID}.log"
+    # Stop first so a missing log cannot leave a zombie server container
     docker stop ucx_perftest_"$BUILD_BUILDID" || true
+    cat "${PWD}/ucx_perf_srv_${test_name}_${BUILD_BUILDID}.log" || true
 }
 
 set_vars() {


### PR DESCRIPTION
## What?
Stop the MAD perftest server container reliably, and clear any zombie `ucx_perftest_*` container before starting a new one.

## Why?
On a failed run, `docker_stop_srv` runs `cat` on a missing log, which aborts under `set -e` before `docker stop`. The detached server survives as a zombie and holds the MAD registration on the HCA, so every later build's server dies with `mad_register_server_via ... Invalid argument` and the client hangs until timeout. Broke all PRs until zombies were cleared by hand (e.g. [build 127843](https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=127843&view=logs&j=7b0cc15c-bba0-5ef5-53aa-1923da16b4b2&s=7e07085d-aff3-5ba0-80f9-9d6c1a6bb87a&t=bf4eff78-cb1f-583c-8dfb-a4cb73bc2758&l=35)).

## How?
- `docker_stop_srv`: `docker stop` before `cat`.
- `docker_run_srv`: `docker rm -f` sweep of `ucx_perftest_*` to heal zombies from a canceled or crashed prior run.