### PR TITLE
UCP/RNDV: Avoid strict key for fence between PUT and AM

### DIFF
--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -189,7 +189,8 @@ ucp_proto_rndv_put_common_fenced_atp_send(ucp_request_t *req,
 {
     ucs_status_t status;
 
-    status = uct_ep_fence(ucp_ep_get_lane(req->send.ep, lane), 0);
+    status = uct_ep_fence(ucp_ep_get_lane(req->send.ep, lane),
+                          UCT_FENCE_FLAG_AM_ONLY);
     if (ucs_unlikely(status != UCS_OK)) {
         return status;
     }

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -545,6 +545,23 @@ enum uct_flush_flags {
 
 /**
  * @ingroup UCT_RESOURCE
+ * @brief  Fence modifiers.
+ */
+enum uct_fence_flags {
+    UCT_FENCE_FLAG_AM_ONLY = UCS_BIT(0) /**< One-way AM visibility barrier.
+                                             Ensures any operations (RMA, AMO,
+                                             etc.) issued before the fence are
+                                             visible before a subsequent active
+                                             message callback is invoked on the
+                                             remote side. Does not provide any
+                                             other ordering guarantee between
+                                             operations issued before and after
+                                             the fence. */
+};
+
+
+/**
+ * @ingroup UCT_RESOURCE
  * @brief UCT progress types
  */
 enum uct_progress_types {
@@ -2881,11 +2898,12 @@ UCT_INLINE_API ucs_status_t uct_iface_flush(uct_iface_h iface, unsigned flags,
  * @brief Ensures ordering of outstanding communications on the interface.
  * Operations issued on the interface prior to this call are guaranteed to
  * be completed before any subsequent communication operations to the same
- * interface which follow the call to fence.
+ * interface which follow the call to fence, unless otherwise specified by
+ * @a flags.
  *
  * @param [in]    iface  Interface to issue communications from.
- * @param [in]    flags  Flags that control ordering semantic (currently
- *                       unsupported - set to 0).
+ * @param [in]    flags  Flags that control ordering semantic. Supported flags:
+ *                       @ref uct_fence_flags.
  * @return UCS_OK         - Ordering is inserted.
  */
 UCT_INLINE_API ucs_status_t uct_iface_fence(uct_iface_h iface, unsigned flags)
@@ -3304,11 +3322,12 @@ UCT_INLINE_API ucs_status_t uct_ep_flush(uct_ep_h ep, unsigned flags,
  * @brief Ensures ordering of outstanding communications on the endpoint.
  * Operations issued on the endpoint prior to this call are guaranteed to
  * be completed before any subsequent communication operations to the same
- * endpoint which follow the call to fence.
+ * endpoint which follow the call to fence, unless otherwise specified by
+ * @a flags.
  *
  * @param [in]    ep     Endpoint to issue communications from.
- * @param [in]    flags  Flags that control ordering semantic (currently
- *                       unsupported - set to 0).
+ * @param [in]    flags  Flags that control ordering semantic. Supported flags:
+ *                       @ref uct_fence_flags.
  * @return UCS_OK         - Ordering is inserted.
  */
 UCT_INLINE_API ucs_status_t uct_ep_fence(uct_ep_h ep, unsigned flags)

--- a/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
@@ -282,7 +282,7 @@ ucs_status_t uct_dc_mlx5_ep_fence(uct_ep_h tl_ep, unsigned flags)
         dci = uct_dc_mlx5_iface_dci(iface, ep->dci);
         ucs_assertv(uct_dc_mlx5_is_dci_valid(dci), "iface=%p ep=%p dci=%d",
                     iface, ep, ep->dci);
-        return uct_rc_ep_fence(tl_ep, &dci->txwq.fi);
+        return uct_rc_ep_fence(tl_ep, flags, &dci->txwq.fi);
     }
 
     UCT_TL_EP_STAT_FENCE(&ep->super);

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -530,7 +530,7 @@ ucs_status_t uct_rc_mlx5_base_ep_fence(uct_ep_h tl_ep, unsigned flags)
 {
     uct_rc_mlx5_base_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_mlx5_base_ep_t);
 
-    return uct_rc_ep_fence(tl_ep, &ep->tx.wq.fi);
+    return uct_rc_ep_fence(tl_ep, flags, &ep->tx.wq.fi);
 }
 
 ucs_status_t

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -526,13 +526,15 @@ uct_rc_ep_fm(uct_rc_iface_t *iface, uct_ib_fence_info_t* fi, int flag)
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t uct_rc_ep_fence(uct_ep_h tl_ep,
+                                                        unsigned flags,
                                                         uct_ib_fence_info_t *fi)
 {
     uct_rc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_iface_t);
 
     /* in case if fence is requested and enabled by configuration
      * we need to schedule fence for next RDMA operation */
-    if (iface->config.fence_mode != UCT_RC_FENCE_MODE_NONE) {
+    if ((iface->config.fence_mode != UCT_RC_FENCE_MODE_NONE) &&
+        !(flags & UCT_FENCE_FLAG_AM_ONLY)) {
         fi->fence_beat = iface->tx.fi.fence_beat - 1;
     }
 

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -1031,7 +1031,8 @@ ucs_status_t uct_rc_iface_fence(uct_iface_h tl_iface, unsigned flags)
 {
     uct_rc_iface_t *iface = ucs_derived_of(tl_iface, uct_rc_iface_t);
 
-    if (iface->config.fence_mode != UCT_RC_FENCE_MODE_NONE) {
+    if ((iface->config.fence_mode != UCT_RC_FENCE_MODE_NONE) &&
+        !(flags & UCT_FENCE_FLAG_AM_ONLY)) {
         iface->tx.fi.fence_beat++;
     }
 

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -516,7 +516,7 @@ ucs_status_t uct_rc_verbs_ep_fence(uct_ep_h tl_ep, unsigned flags)
 {
     uct_rc_verbs_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
 
-    return uct_rc_ep_fence(tl_ep, &ep->fi);
+    return uct_rc_ep_fence(tl_ep, flags, &ep->fi);
 }
 
 ucs_status_t uct_rc_verbs_ep_post_check(uct_ep_h tl_ep, uct_completion_t *comp)


### PR DESCRIPTION
## What?
Add `UCT_FENCE_FLAG_AM_ONLY` and use it in `rndv/put/mtype` before ATP.

## Why?
RNDV `put/mtype` only needs prior PUT data to be visible before the remote ATP AM callback. It does not need ordering between PUTs before and after the ATP.

Today the fence arms `fence_beat`, but SEND/AM does not consume it, so the next unrelated PUT pays the strict/atomic rkey cost. Impact on setup with PCIe relaxed ordering and two 90GB/s lanes:

- 145727 MB/s, without fix
- 174388 MB/s, with fix, line rate reached with bigger window

`UCX_RNDV_FRAG_SIZE=cuda:16M ucx_perftest -t ucp_put_bw -s $((64*1024*1024)) -O64 -m cuda`

## How?
Pass `UCT_FENCE_FLAG_AM_ONLY` for the fenced ATP path. IB RC/DC keeps the fence call but does not arm `fence_beat`; other transports keep their existing fence behavior.

RDMA may use relaxed ordering and does not consume RX CQEs. The following SEND/AM does consume an RX CQE, whose PCIe write is non-relaxed, so prior relaxed PCIe writes are visible before the AM callback runs.