### PR TITLE
Add SGL support for IB rc, cuda copy and cuda IPC (imported)

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -603,6 +603,7 @@ ADD_COMPILER_FLAGS_IF_SUPPORTED([[-Wno-missing-field-initializers],
                                  [-Wno-sign-compare],
                                  [-Wno-multichar],
                                  [-Wno-deprecated-declarations],
+                                 [-Wno-error=unknown-pragmas],
                                  [-Winvalid-pch]],
                                 [AC_LANG_SOURCE([[int main(int argc, char **argv){return 0;}]])])
 

--- a/src/tools/perf/api/libperf.h
+++ b/src/tools/perf/api/libperf.h
@@ -56,6 +56,7 @@ typedef enum {
 typedef enum {
     UCP_PERF_DATATYPE_CONTIG,
     UCP_PERF_DATATYPE_IOV,
+    UCP_PERF_DATATYPE_SGL,
 } ucp_perf_datatype_t;
 
 
@@ -318,6 +319,9 @@ typedef struct ucx_perf_params {
     struct {
         ucp_perf_datatype_t     send_datatype;
         ucp_perf_datatype_t     recv_datatype;
+        size_t                  sgl_cnt;     /* Number of equal-length segments to
+                                                split the message into when the SGL
+                                                datatype is selected */
         size_t                  am_hdr_size; /* UCP Active Message header size
                                                 (not included in message size) */
         int                     is_daemon_mode;  /* Whether DPU offloading daemon

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -17,6 +17,31 @@
 #include <ucs/sys/preprocessor.h>
 #include <ucs/sys/string.h>
 #include <limits>
+#include <stdlib.h>
+
+
+/*
+ * SGL put state. Kept on the heap and referenced by a single pointer from the
+ * runner, so it does not inflate the stack frame of the dispatch functions,
+ * which instantiate many runner objects in one frame. The message is split into
+ * 'count' equal-length segments, all sharing the send buffer's memory handle and
+ * the peer's rkey (the whole buffer is registered as one region). The arrays are
+ * managed with malloc/free rather than STL containers, since the perftest binary
+ * is linked without the C++ runtime.
+ */
+struct ucp_perf_sgl_state {
+    void                **buffers;
+    size_t               *lengths;
+    ucp_mem_h            *memhs;
+    uint64_t             *remote_addrs;
+    ucp_rkey_h           *rkeys;
+    ucp_dt_local_sgl_t    local;
+    ucp_dt_remote_sgl_t   remote;
+    ucp_request_param_t   send_params;
+    ucp_request_param_t   send_get_info_params;
+    size_t                count;
+    size_t                total_length;
+};
 
 
 template <ucx_perf_cmd_t CMD, ucx_perf_test_type_t TYPE, unsigned FLAGS>
@@ -38,7 +63,8 @@ public:
         m_sends_outstanding(0),
         m_max_outstanding(m_perf.params.max_outstanding),
         m_am_rx_buffer(NULL),
-        m_am_rx_length(0ul)
+        m_am_rx_length(0ul),
+        m_sgl(NULL)
     {
         memset(&m_am_rx_params, 0, sizeof(m_am_rx_params));
         memset(&m_send_params, 0, sizeof(m_send_params));
@@ -71,6 +97,15 @@ public:
         set_am_handler(UCP_PERF_DAEMON_AM_ID_RECV_CMPL, NULL, NULL, 0);
         set_am_handler(UCP_PERF_DAEMON_AM_ID_SEND_CMPL, NULL, NULL, 0);
         set_am_handler(AM_ID, NULL, NULL, 0);
+
+        if (m_sgl != NULL) {
+            free(m_sgl->buffers);
+            free(m_sgl->lengths);
+            free(m_sgl->memhs);
+            free(m_sgl->remote_addrs);
+            free(m_sgl->rkeys);
+            free(m_sgl);
+        }
     }
 
     void set_am_handler(unsigned id, ucp_am_recv_callback_t cb, void *arg,
@@ -145,6 +180,108 @@ public:
         }
     }
 
+    inline bool sgl_enabled() const
+    {
+        return (CMD == UCX_PERF_CMD_PUT) &&
+               (m_perf.params.ucp.send_datatype == UCP_PERF_DATATYPE_SGL);
+    }
+
+    /*
+     * Split the message into 'sgl_cnt' equal-length segments (the last segment
+     * absorbs any remainder) and build the local/remote SGL descriptors plus the
+     * request parameters used by the put bandwidth loop. All segments share the
+     * send buffer memory handle and the peer's rkey, since the whole buffer is
+     * registered as a single region.
+     */
+    void init_sgl(size_t total_length)
+    {
+        const size_t count   = m_perf.params.ucp.sgl_cnt;
+        const size_t base    = total_length / count;
+        const size_t rem     = total_length % count;
+        uintptr_t local_base = (uintptr_t)m_perf.send_buffer;
+        uint64_t remote_base = m_perf.ucp.remote_addr;
+        size_t offset        = 0;
+        ucp_perf_sgl_state *sgl;
+        size_t i;
+
+        if (m_sgl == NULL) {
+            m_sgl = (ucp_perf_sgl_state*)calloc(1, sizeof(*m_sgl));
+            ucs_assert_always(m_sgl != NULL);
+        }
+        sgl = m_sgl;
+
+        sgl->count        = count;
+        sgl->total_length = total_length;
+
+        free(sgl->buffers);
+        free(sgl->lengths);
+        free(sgl->memhs);
+        free(sgl->remote_addrs);
+        free(sgl->rkeys);
+        sgl->buffers      = (void**)malloc(count * sizeof(*sgl->buffers));
+        sgl->lengths      = (size_t*)malloc(count * sizeof(*sgl->lengths));
+        sgl->memhs        = (ucp_mem_h*)malloc(count * sizeof(*sgl->memhs));
+        sgl->remote_addrs = (uint64_t*)malloc(count *
+                                              sizeof(*sgl->remote_addrs));
+        sgl->rkeys        = (ucp_rkey_h*)malloc(count * sizeof(*sgl->rkeys));
+        ucs_assert_always((sgl->buffers != NULL) && (sgl->lengths != NULL) &&
+                          (sgl->memhs != NULL) &&
+                          (sgl->remote_addrs != NULL) &&
+                          (sgl->rkeys != NULL));
+
+        for (i = 0; i < count; ++i) {
+            size_t len           = base + ((i < rem) ? 1 : 0);
+            sgl->buffers[i]      = (void*)(local_base + offset);
+            sgl->lengths[i]      = len;
+            sgl->memhs[i]        = m_perf.ucp.send_memh;
+            sgl->remote_addrs[i] = remote_base + offset;
+            sgl->rkeys[i]        = m_perf.ucp.rkey;
+            offset              += len;
+        }
+
+        memset(&sgl->local, 0, sizeof(sgl->local));
+        sgl->local.field_mask = UCP_DT_LOCAL_SGL_FIELD_BUFFERS |
+                                UCP_DT_LOCAL_SGL_FIELD_LENGTHS |
+                                UCP_DT_LOCAL_SGL_FIELD_MEMHS;
+        sgl->local.buffers    = sgl->buffers;
+        sgl->local.lengths    = sgl->lengths;
+        sgl->local.memhs      = sgl->memhs;
+
+        memset(&sgl->remote, 0, sizeof(sgl->remote));
+        sgl->remote.field_mask   = UCP_DT_REMOTE_SGL_FIELD_REMOTE_ADDRS |
+                                   UCP_DT_REMOTE_SGL_FIELD_LENGTHS |
+                                   UCP_DT_REMOTE_SGL_FIELD_RKEYS;
+        sgl->remote.remote_addrs = sgl->remote_addrs;
+        sgl->remote.lengths      = sgl->lengths;
+        sgl->remote.rkeys        = sgl->rkeys;
+
+        fill_sgl_send_params(sgl->send_params, send_cb, 0);
+        /* The get-info variant forces a request handle (NO_IMM_CMPL) and uses a
+         * callback that does not free the request, so send() can safely query it
+         * and release it afterwards - mirroring the contiguous get-info path. */
+        fill_sgl_send_params(sgl->send_get_info_params, send_get_info_cb,
+                             UCP_OP_ATTR_FLAG_NO_IMM_CMPL);
+    }
+
+    void fill_sgl_send_params(ucp_request_param_t &params,
+                             ucp_send_nbx_callback_t cb, uint32_t op_attr_mask)
+    {
+        memset(&params, 0, sizeof(params));
+        params.op_attr_mask    = UCP_OP_ATTR_FIELD_DATATYPE |
+                                 UCP_OP_ATTR_FIELD_REMOTE_DATATYPE |
+                                 UCP_OP_ATTR_FIELD_REMOTE |
+                                 UCP_OP_ATTR_FIELD_REMOTE_COUNT |
+                                 UCP_OP_ATTR_FIELD_CALLBACK |
+                                 UCP_OP_ATTR_FIELD_USER_DATA |
+                                 UCP_OP_ATTR_FLAG_MULTI_SEND | op_attr_mask;
+        params.datatype        = ucp_dt_make_sgl();
+        params.remote_datatype = ucp_dt_make_sgl();
+        params.remote          = &m_sgl->remote;
+        params.remote_count    = m_sgl->count;
+        params.cb.send         = cb;
+        params.user_data       = this;
+    }
+
     void ucp_perf_init_common_params(size_t *total_length, size_t *send_length,
                                      ucp_datatype_t *send_dt,
                                      void **send_buffer, size_t *recv_length,
@@ -158,6 +295,10 @@ public:
         }
 
         ucp_perf_test_prepare_iov_buffers();
+
+        if (sgl_enabled()) {
+            init_sgl(*total_length);
+        }
 
         *send_length = *recv_length = *total_length;
 
@@ -476,7 +617,17 @@ public:
             default:
                 return UCS_ERR_INVALID_PARAM;
             }
-            request = ucp_put_nbx(ep, buffer, length, remote_addr, rkey, param);
+            /* Route the full-size data transfer through the SGL API; the tiny
+             * flow-control ack (length 1) keeps using the contiguous path. */
+            if (sgl_enabled() && (length == m_sgl->total_length)) {
+                request = ucp_put_nbx(ep, &m_sgl->local, m_sgl->count,
+                                      UCP_REMOTE_ADDR_INVALID, UCP_RKEY_INVALID,
+                                      get_info ? &m_sgl->send_get_info_params :
+                                                 &m_sgl->send_params);
+            } else {
+                request = ucp_put_nbx(ep, buffer, length, remote_addr, rkey,
+                                      param);
+            }
             break;
         case UCX_PERF_CMD_GET:
             request = ucp_get_nbx(ep, buffer, length, remote_addr, rkey, param);
@@ -972,6 +1123,10 @@ private:
     ucp_request_param_t m_send_get_info_params;
     ucp_request_param_t m_recv_params;
     ucp_atomic_op_t     m_atomic_op;
+
+    /* Heap-allocated SGL put state (see ucp_perf_sgl_state); NULL unless the SGL
+     * datatype is selected for a put bandwidth test. */
+    ucp_perf_sgl_state      *m_sgl;
 };
 
 #define TEST_CASE(_perf, _cmd, _type, _flags, _mask) \

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -202,6 +202,7 @@ ucs_status_t init_test_params(perftest_params_t *params)
     params->super.iov_stride          = 0;
     params->super.ucp.send_datatype   = UCP_PERF_DATATYPE_CONTIG;
     params->super.ucp.recv_datatype   = UCP_PERF_DATATYPE_CONTIG;
+    params->super.ucp.sgl_cnt         = 1;
     params->super.ucp.am_hdr_size     = 0;
     params->super.device_channel_mode = UCX_PERF_CHANNEL_MODE_SINGLE;
     params->super.channel_rand_seed   = ucs_generate_uuid((uintptr_t)params);

--- a/src/tools/perf/perftest_params.c
+++ b/src/tools/perf/perftest_params.c
@@ -159,6 +159,9 @@ static void usage(const struct perftest_context *ctx, const char *program)
     printf("                    data layout for sender and receiver side (contig)\n");
     printf("                        contig - Continuous datatype\n");
     printf("                        iov    - Scatter-gather list\n");
+    printf("                        sgl[/N]- SGL put: split the message into N\n");
+    printf("                                 equal-length segments (only for\n");
+    printf("                                 ucp_put_bw), default N is 1\n");
     printf("     -C             use wild-card tag for tag tests\n");
     printf("     -U             force unexpected flow by using tag probe\n");
     printf("     -r <mode>      receive mode for stream tests (recv)\n");
@@ -476,17 +479,39 @@ static ucs_status_t parse_device_level(const char *opt_arg,
 }
 
 static ucs_status_t parse_ucp_datatype_params(const char *opt_arg,
-                                              ucp_perf_datatype_t *datatype)
+                                              ucp_perf_datatype_t *datatype,
+                                              size_t *sgl_cnt)
 {
     const char  *iov_type         = "iov";
     const size_t iov_type_size    = strlen("iov");
     const char  *contig_type      = "contig";
     const size_t contig_type_size = strlen("contig");
+    const char  *sgl_type         = "sgl";
+    const size_t sgl_type_size    = strlen("sgl");
+    char *endptr;
+    long count;
 
     if (0 == strncmp(opt_arg, iov_type, iov_type_size)) {
         *datatype = UCP_PERF_DATATYPE_IOV;
     } else if (0 == strncmp(opt_arg, contig_type, contig_type_size)) {
         *datatype = UCP_PERF_DATATYPE_CONTIG;
+    } else if (0 == strncmp(opt_arg, sgl_type, sgl_type_size)) {
+        *datatype = UCP_PERF_DATATYPE_SGL;
+        /* Optional "/N" suffix selects the number of equal-length segments */
+        if (opt_arg[sgl_type_size] == '/') {
+            count = strtol(opt_arg + sgl_type_size + 1, &endptr, 10);
+            if ((*endptr != '\0') && (*endptr != ',')) {
+                ucs_error("failed to parse SGL segment count: %s", opt_arg);
+                return UCS_ERR_INVALID_PARAM;
+            }
+            if (count < 1) {
+                ucs_error("SGL segment count must be at least 1: %s", opt_arg);
+                return UCS_ERR_INVALID_PARAM;
+            }
+            *sgl_cnt = (size_t)count;
+        } else {
+            *sgl_cnt = 1;
+        }
     } else {
         return UCS_ERR_INVALID_PARAM;
     }
@@ -633,11 +658,13 @@ ucs_status_t parse_test_params(perftest_params_t *params, char opt,
         } else if (!strcmp(opt_arg, "zcopy")) {
             params->super.uct.data_layout   = UCT_PERF_DATA_LAYOUT_ZCOPY;
         } else if (UCS_OK == parse_ucp_datatype_params(opt_arg,
-                                                       &params->super.ucp.send_datatype)) {
+                                                       &params->super.ucp.send_datatype,
+                                                       &params->super.ucp.sgl_cnt)) {
             optarg2 = strchr(opt_arg, ',');
             if (optarg2) {
                 if (UCS_OK != parse_ucp_datatype_params(optarg2 + 1,
-                                                       &params->super.ucp.recv_datatype)) {
+                                                       &params->super.ucp.recv_datatype,
+                                                       &params->super.ucp.sgl_cnt)) {
                     return UCS_ERR_INVALID_PARAM;
                 }
             }
@@ -819,11 +846,45 @@ ucs_status_t clone_params(perftest_params_t *dest,
     return UCS_OK;
 }
 
+static ucs_status_t check_sgl_params(const ucx_perf_params_t *params)
+{
+    if (params->ucp.send_datatype != UCP_PERF_DATATYPE_SGL) {
+        return UCS_OK;
+    }
+
+    /* SGL put is currently wired only into the UCP put bandwidth path */
+    if ((params->api != UCX_PERF_API_UCP) ||
+        (params->command != UCX_PERF_CMD_PUT) ||
+        (params->test_type != UCX_PERF_TEST_TYPE_STREAM_UNI)) {
+        ucs_error("the sgl datatype is only supported by the ucp_put_bw test");
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    if (params->ucp.sgl_cnt < 1) {
+        ucs_error("sgl segment count must be at least 1");
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    if (ucx_perf_get_message_size(params) < params->ucp.sgl_cnt) {
+        ucs_error("message size (%zu) must be at least the number of sgl "
+                  "segments (%zu)",
+                  ucx_perf_get_message_size(params), params->ucp.sgl_cnt);
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    return UCS_OK;
+}
+
 ucs_status_t check_params(const perftest_params_t *params)
 {
     ucs_status_t status;
 
     status = check_daemon_params(&params->super);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    status = check_sgl_params(&params->super);
     if (status != UCS_OK) {
         return status;
     }

--- a/src/uct/cuda/cuda_copy/cuda_copy_ep.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_ep.c
@@ -21,6 +21,9 @@
 #include <ucs/type/class.h>
 #include <ucs/memory/memtype_cache.h>
 
+#include <cuda.h>
+#include <string.h>
+
 typedef struct {
     ucs_memory_type_t       src_type;
     ucs_memory_type_t       dst_type;
@@ -403,6 +406,185 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_ep_put_zcopy,
     uct_cuda_copy_trace_data("PUT_ZCOPY", remote_addr, iov, iovcnt);
     return status;
 }
+
+#if CUDA_VERSION >= 13000
+static ucs_status_t
+uct_cuda_copy_ep_put_sgl_check_homogeneous(
+        uct_cuda_copy_iface_t *iface, void * const *buffers,
+        const uint64_t *remote_addrs, const size_t *lengths, size_t count)
+{
+    ucs_memory_type_t src0, dst0, src_i, dst_i;
+    ucs_sys_device_t UCS_V_UNUSED sys0;
+    ucs_sys_device_t UCS_V_UNUSED sys_i;
+    CUdeviceptr cuda_deviceptr;
+    size_t i;
+
+    ucs_assert(count > 0u);
+
+    uct_cuda_copy_get_mem_types(iface->super.super.md, buffers[0],
+                                (void *)(uintptr_t)remote_addrs[0], lengths[0],
+                                &src0, &dst0, &sys0, &cuda_deviceptr);
+
+    for (i = 1; i < count; i++) {
+        uct_cuda_copy_get_mem_types(iface->super.super.md, buffers[i],
+                                    (void *)(uintptr_t)remote_addrs[i],
+                                    lengths[i], &src_i, &dst_i, &sys_i,
+                                    &cuda_deviceptr);
+        if ((src_i != src0) || (dst_i != dst0)) {
+            ucs_error("cuda_copy put_sgl_zcopy requires homogeneous segments "
+                      "(segment %zu is %s->%s, expected %s->%s)",
+                      i, ucs_memory_type_names[src_i],
+                      ucs_memory_type_names[dst_i],
+                      ucs_memory_type_names[src0],
+                      ucs_memory_type_names[dst0]);
+            return UCS_ERR_INVALID_PARAM;
+        }
+    }
+
+    return UCS_OK;
+}
+
+UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_copy_ep_put_sgl_zcopy,
+                 (tl_ep, buffers, lengths, memhs, remote_addrs, rkeys, counts,
+                  strides, count, comp),
+                 uct_ep_h tl_ep, void * const *buffers, const size_t *lengths,
+                 uct_mem_h const *memhs UCS_V_UNUSED,
+                 const uint64_t *remote_addrs, uct_rkey_t const *rkeys UCS_V_UNUSED,
+                 const size_t *counts, const size_t *strides,
+                 size_t count, uct_completion_t *comp)
+{
+    uct_cuda_copy_iface_t *iface = ucs_derived_of(tl_ep->iface,
+                                                  uct_cuda_copy_iface_t);
+    uct_cuda_copy_ep_ctx_t ctx;
+    ucs_status_t status;
+    uct_cuda_queue_desc_t *q_desc;
+    ucs_queue_head_t *event_q;
+    CUstream *stream;
+    uct_cuda_event_desc_t *cuda_event;
+    CUdeviceptr *cuda_dsts;
+    CUdeviceptr *cuda_srcs;
+    CUmemcpyAttributes attr;
+    size_t attrs_idxs[1];
+    CUresult cu_err;
+    size_t i;
+    size_t total_length;
+
+    if (count == 0) {
+        return UCS_OK;
+    }
+
+    if ((buffers == NULL) || (lengths == NULL) || (remote_addrs == NULL)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    /* Strided repetition (counts/strides) is not implemented by this transport */
+    if ((counts != NULL) || (strides != NULL)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    status = uct_cuda_copy_ep_put_sgl_check_homogeneous(iface, buffers,
+                                                        remote_addrs, lengths,
+                                                        count);
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
+    }
+
+    status = uct_cuda_copy_ep_get_ctx(iface, buffers[0],
+                                      (void *)(uintptr_t)remote_addrs[0],
+                                      lengths[0], &ctx);
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
+    }
+
+    q_desc  = &ctx.ctx_rsc->queue_desc[ctx.src_type][ctx.dst_type];
+    event_q = &q_desc->event_queue;
+    stream  = uct_cuda_copy_get_stream(ctx.ctx_rsc, ctx.src_type, ctx.dst_type);
+    if (ucs_unlikely(stream == NULL)) {
+        ucs_error("stream for src %s dst %s not available",
+                  ucs_memory_type_names[ctx.src_type],
+                  ucs_memory_type_names[ctx.dst_type]);
+        status = UCS_ERR_IO_ERROR;
+        goto out_pop_and_release;
+    }
+
+    cuda_event = ucs_mpool_get(&ctx.ctx_rsc->super.event_mp);
+    if (ucs_unlikely(cuda_event == NULL)) {
+        ucs_error("failed to allocate cuda event object");
+        status = UCS_ERR_NO_MEMORY;
+        goto out_pop_and_release;
+    }
+
+    cuda_dsts = ucs_malloc(count * sizeof(*cuda_dsts), "cuda_copy_sgl_dsts");
+    if (cuda_dsts == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err_mpool_put;
+    }
+
+    cuda_srcs = ucs_malloc(count * sizeof(*cuda_srcs), "cuda_copy_sgl_srcs");
+    if (cuda_srcs == NULL) {
+        ucs_free(cuda_dsts);
+        status = UCS_ERR_NO_MEMORY;
+        goto err_mpool_put;
+    }
+
+    total_length = 0;
+    for (i = 0; i < count; i++) {
+        cuda_dsts[i] = (CUdeviceptr)(uintptr_t)remote_addrs[i];
+        cuda_srcs[i] = (CUdeviceptr)(uintptr_t)buffers[i];
+        total_length += lengths[i];
+    }
+
+    memset(&attr, 0, sizeof(attr));
+    attr.srcAccessOrder                = CU_MEMCPY_SRC_ACCESS_ORDER_STREAM;
+    attrs_idxs[0]                      = 0;
+
+    cu_err = cuMemcpyBatchAsync(cuda_dsts, cuda_srcs, (size_t *)lengths, count,
+                                &attr, attrs_idxs, 1, *stream);
+    if (ucs_unlikely(cu_err != CUDA_SUCCESS)) {
+        UCT_CUDADRV_LOG(cuMemcpyBatchAsync, UCS_LOG_LEVEL_ERROR, cu_err);
+        ucs_free(cuda_srcs);
+        ucs_free(cuda_dsts);
+        status = UCS_ERR_IO_ERROR;
+        goto err_mpool_put;
+    }
+
+    ucs_free(cuda_srcs);
+    ucs_free(cuda_dsts);
+
+    status = UCT_CUDADRV_FUNC_LOG_ERR(
+            cuEventRecord(cuda_event->event, *stream));
+    if (ucs_unlikely(status != UCS_OK)) {
+        goto err_mpool_put;
+    }
+
+    if (ucs_queue_is_empty(event_q)) {
+        ucs_queue_push(&iface->super.active_queue, &q_desc->queue);
+    }
+
+    ucs_queue_push(event_q, &cuda_event->queue);
+    cuda_event->comp = comp;
+
+    UCS_STATIC_BITMAP_SET(&iface->streams_to_sync,
+                          uct_cuda_copy_flush_bitmap_idx(ctx.src_type,
+                                                         ctx.dst_type));
+
+    ucs_trace("cuda_copy put_sgl_zcopy: count=%zu total_length=%zu", count,
+              total_length);
+
+    UCT_TL_EP_STAT_OP(ucs_derived_of(tl_ep, uct_base_ep_t), PUT, ZCOPY,
+                      total_length);
+
+    status = UCS_INPROGRESS;
+
+out_pop_and_release:
+    uct_cuda_ctx_pop_and_release(ctx.cuda_device, ctx.cuda_context);
+    return status;
+
+err_mpool_put:
+    ucs_mpool_put(cuda_event);
+    goto out_pop_and_release;
+}
+#endif /* CUDA_VERSION >= 13000 */
 
 static UCS_F_ALWAYS_INLINE ucs_status_t uct_cuda_copy_ep_rma_short(
         uct_ep_h tl_ep, CUdeviceptr dst, CUdeviceptr src, unsigned length)

--- a/src/uct/cuda/cuda_copy/cuda_copy_ep.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_ep.h
@@ -33,6 +33,17 @@ ucs_status_t uct_cuda_copy_ep_put_zcopy(uct_ep_h tl_ep,
                                         uint64_t remote_addr, uct_rkey_t rkey,
                                         uct_completion_t *comp);
 
+ucs_status_t uct_cuda_copy_ep_put_sgl_zcopy(uct_ep_h tl_ep,
+                                            void * const *buffers,
+                                            const size_t *lengths,
+                                            uct_mem_h const *memhs,
+                                            const uint64_t *remote_addrs,
+                                            uct_rkey_t const *rkeys,
+                                            const size_t *counts,
+                                            const size_t *strides,
+                                            size_t count,
+                                            uct_completion_t *comp);
+
 ucs_status_t uct_cuda_copy_ep_put_short(uct_ep_h tl_ep, const void *buffer,
                                         unsigned length, uint64_t remote_addr,
                                         uct_rkey_t rkey);

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -13,10 +13,15 @@
 
 #include <uct/cuda/base/cuda_iface.h>
 #include <uct/cuda/base/cuda_md.h>
+#include <uct/api/v2/uct_v2.h>
 #include <ucs/type/class.h>
+#include <ucs/type/init_once.h>
 #include <ucs/sys/string.h>
+#include <ucs/sys/sys.h>
 #include <ucs/async/eventfd.h>
 #include <ucs/arch/cpu.h>
+#include <cuda.h>
+#include <unistd.h>
 
 
 #define UCT_CUDA_COPY_IFACE_OVERHEAD 0
@@ -263,8 +268,35 @@ uct_cuda_copy_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
     return UCS_OK;
 }
 
+#if CUDA_VERSION >= 13000
+static ucs_status_t
+uct_cuda_copy_iface_query_v2(uct_iface_h iface, uct_iface_attr_v2_t *iface_attr)
+{
+    ucs_status_t status;
+
+    status = uct_iface_base_query_v2(iface, iface_attr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_CAP_FLAGS) {
+        iface_attr->cap.flags |= UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY;
+    }
+
+    if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT) {
+        iface_attr->max_put_sgl_zcopy_count = SIZE_MAX;
+    }
+
+    return UCS_OK;
+}
+#endif
+
 static uct_iface_internal_ops_t uct_cuda_copy_iface_internal_ops = {
+#if CUDA_VERSION >= 13000
+    .iface_query_v2        = uct_cuda_copy_iface_query_v2,
+#else
     .iface_query_v2        = uct_iface_base_query_v2,
+#endif
     .iface_estimate_perf   = uct_cuda_copy_estimate_perf,
     .iface_vfs_refresh     = (uct_iface_vfs_refresh_func_t)ucs_empty_function,
     .ep_query              = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
@@ -272,7 +304,13 @@ static uct_iface_internal_ops_t uct_cuda_copy_iface_internal_ops = {
     .ep_connect_to_ep_v2   = (uct_ep_connect_to_ep_v2_func_t)ucs_empty_function_return_unsupported,
     .iface_is_reachable_v2 = uct_cuda_copy_iface_is_reachable_v2,
     .ep_is_connected       = uct_base_ep_is_connected,
-    .ep_get_device_ep      = (uct_ep_get_device_ep_func_t)ucs_empty_function_return_unsupported
+    .ep_get_device_ep      = (uct_ep_get_device_ep_func_t)ucs_empty_function_return_unsupported,
+#if CUDA_VERSION >= 13000
+    .ep_put_sgl_zcopy      = uct_cuda_copy_ep_put_sgl_zcopy
+#else
+    .ep_put_sgl_zcopy      =
+            (uct_ep_put_sgl_zcopy_func_t)ucs_empty_function_return_unsupported
+#endif
 };
 
 static uct_cuda_ctx_rsc_t * uct_cuda_copy_ctx_rsc_create(uct_iface_h tl_iface)
@@ -320,6 +358,26 @@ static uct_cuda_iface_ops_t uct_cuda_iface_ops = {
     .complete_event = (uct_cuda_complete_event_fn_t)ucs_empty_function
 };
 
+/*
+ * cuda_copy performs transfers directly on process virtual addresses, so an
+ * endpoint is only usable when the peer lives in the same address space. All
+ * cuda_copy ifaces in a process therefore share a single id, making ifaces of
+ * different workers within the same process mutually reachable. Different
+ * processes obtain different ids and stay unreachable (cuda_ipc handles the
+ * inter-process case).
+ */
+static uct_cuda_copy_iface_addr_t uct_cuda_copy_iface_get_process_id(void)
+{
+    static ucs_init_once_t init_once = UCS_INIT_ONCE_INITIALIZER;
+    static uct_cuda_copy_iface_addr_t process_id;
+
+    UCS_INIT_ONCE(&init_once) {
+        process_id = ucs_generate_uuid((uintptr_t)getpid());
+    }
+
+    return process_id;
+}
+
 static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h worker,
                            const uct_iface_params_t *params,
                            const uct_iface_config_t *tl_config)
@@ -337,7 +395,7 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h work
         return status;
     }
 
-    self->id                           = ucs_generate_uuid((uintptr_t)self);
+    self->id                           = uct_cuda_copy_iface_get_process_id();
     self->config.bw                    = config->bw;
     self->super.ops                    = &uct_cuda_iface_ops;
     self->super.config.max_events      = config->max_cuda_events;

--- a/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
@@ -105,7 +105,8 @@ uct_dc_mlx5_iface_zcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
                                    tag, app_ctx, ib_imm_be, NULL, av_size,
                                    MLX5_WQE_CTRL_CQ_UPDATE | send_flags,
                                    ep->dci_channel_index,
-                                   UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super.super));
+                                   UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super.super),
+                                   0);
 
     uct_rc_txqp_add_send_comp(&iface->super.super, txqp, handler, comp, sn,
                               op_flags | UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY, iov,

--- a/src/uct/ib/mlx5/rc/rc_mlx5.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.h
@@ -124,6 +124,14 @@ ucs_status_t uct_rc_mlx5_base_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
                                            uct_completion_t *comp);
 
 ucs_status_t
+uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
+                                  const size_t *lengths, uct_mem_h const *memhs,
+                                  const uint64_t *remote_addrs,
+                                  uct_rkey_t const *rkeys, const size_t *counts,
+                                  const size_t *strides, size_t count,
+                                  uct_completion_t *comp);
+
+ucs_status_t
 uct_rc_mlx5_base_ep_get_bcopy(uct_ep_h tl_ep, uct_unpack_callback_t unpack_cb,
                               void *arg, size_t length, uint64_t remote_addr,
                               uct_rkey_t rkey, uct_completion_t *comp);

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -804,7 +804,8 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
                          /* TAG  */ uct_tag_t tag, uint32_t app_ctx, uint32_t ib_imm_be,
                          /* MMO  */ const uct_ib_mlx5_dma_opaque_mr_t *opaque_mr,
                                     size_t av_size, uint8_t fm_ce_se,
-                                    uint16_t dci_channel, int max_log_sge)
+                                    uint16_t dci_channel, int max_log_sge,
+                                    unsigned iov_post_flags)
 {
     struct mlx5_wqe_ctrl_seg     *ctrl;
     struct mlx5_wqe_raddr_seg    *raddr;
@@ -820,8 +821,11 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
     uint32_t                     dma_src_key, dma_dst_key;
 #endif
 
-    if (!(fm_ce_se & MLX5_WQE_CTRL_CQ_UPDATE)) {
-        fm_ce_se |= uct_rc_iface_tx_moderation(&iface->super, txqp, MLX5_WQE_CTRL_CQ_UPDATE);
+    if (!(iov_post_flags & UCT_RC_MLX5_IOV_POST_FLAG_SKIP_TX_MODERATION)) {
+        if (!(fm_ce_se & MLX5_WQE_CTRL_CQ_UPDATE)) {
+            fm_ce_se |= uct_rc_iface_tx_moderation(&iface->super, txqp,
+                                                   MLX5_WQE_CTRL_CQ_UPDATE);
+        }
     }
 
     ctrl         = txwq->curr;
@@ -1949,7 +1953,8 @@ static UCS_F_ALWAYS_INLINE ucs_status_t uct_rc_mlx5_base_ep_zcopy_post(
                                    tag, app_ctx, ib_imm_be,
                                    opaque_mr,
                                    0, fm_ce_se, 0,
-                                   UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super));
+                                   UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super),
+                                   0);
 
     uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, handler, comp, sn,
                               op_flags | UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -46,6 +46,12 @@
 #define UCT_RC_MLX5_SINGLE_FRAG_MSG(_flags) \
     (((_flags) & UCT_CB_PARAM_FLAG_FIRST) && !((_flags) & UCT_CB_PARAM_FLAG_MORE))
 
+/** Flags for @ref uct_rc_mlx5_txqp_dptr_post_iov */
+enum {
+    /** Do not force CQ update via TX moderation for inner batched WRs */
+    UCT_RC_MLX5_IOV_POST_FLAG_SKIP_TX_MODERATION = UCS_BIT(0)
+};
+
 #define UCT_RC_MLX5_CHECK_AM_ZCOPY(_id, _header_length, _length, _seg_size, _av_size) \
     UCT_CHECK_AM_ID(_id); \
     UCT_RC_CHECK_ZCOPY_DATA(_header_length, _length, _seg_size) \

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -176,6 +176,95 @@ ucs_status_t uct_rc_mlx5_base_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
 }
 
 ucs_status_t
+uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
+                                  const size_t *lengths, uct_mem_h const *memhs,
+                                  const uint64_t *remote_addrs,
+                                  uct_rkey_t const *rkeys, const size_t *counts,
+                                  const size_t *strides, size_t count,
+                                  uct_completion_t *comp)
+{
+    UCT_RC_MLX5_BASE_EP_DECL(tl_ep, iface, ep);
+    uct_iov_t iov;
+    size_t iov_it;
+    size_t total_length = 0;
+    uint16_t sn;
+    unsigned skip_flag;
+    uint8_t fm_ce_se;
+
+    if (count == 0) {
+        return UCS_OK;
+    }
+
+    if (count > iface->super.config.max_put_sgl_zcopy) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    ucs_assert(count <= UCT_IB_RC_PUT_SGL_ZCOPY_MAX);
+
+    if (iface->super.config.tx_moderation > 0) {
+        if (ep->super.txqp.unsignaled + count - 1 >= iface->super.config.tx_moderation) {
+            return UCS_ERR_NO_RESOURCE;
+        }
+    }
+
+    /* Each segment posts one single-SGE RDMA_WRITE WQE, which always occupies
+     * exactly one WQE building block (BB), so the chain consumes 'count' BBs
+     * (and, since only the last WQE is signaled, one CQE whose completion
+     * releases all of them). Reserving UCT_IB_MLX5_MAX_BB per segment would
+     * over-reserve 4x and, for large counts, exceed the QP/CQ credit pools,
+     * making the check impossible to satisfy (permanent NO_RESOURCE). */
+    UCT_RC_CHECK_MULTI_TX_CREDITS(&iface->super, &ep->super, count, count);
+
+    sn = ep->tx.wq.sw_pi;
+
+    for (iov_it = 0; iov_it < count; ++iov_it) {
+        uct_rkey_t rkey      = rkeys[iov_it];
+        uint64_t remote_addr = remote_addrs[iov_it];
+
+        UCT_CHECK_LENGTH(lengths[iov_it], 1, UCT_IB_MAX_MESSAGE_SIZE,
+                         "put_sgl_zcopy");
+
+        uct_rc_mlx5_ep_fence_put(iface, &ep->tx.wq, &rkey, &remote_addr,
+                                 ep->super.atomic_mr_offset, &fm_ce_se);
+
+        iov.buffer = buffers[iov_it];
+        iov.length = lengths[iov_it];
+        iov.memh   = memhs ? memhs[iov_it] : UCT_MEM_HANDLE_NULL;
+        iov.stride = (strides != NULL) ? strides[iov_it] : 0;
+        iov.count  = (counts != NULL) ? counts[iov_it] : 1;
+
+        /* Signal completion only on the last segment of the chain */
+        if (iov_it == count - 1) {
+            fm_ce_se |= MLX5_WQE_CTRL_CQ_UPDATE;
+        }
+        skip_flag = (iov_it + 1 < count) ?
+                    UCT_RC_MLX5_IOV_POST_FLAG_SKIP_TX_MODERATION : 0;
+
+        uct_rc_mlx5_txqp_dptr_post_iov(iface, IBV_QPT_RC,
+                                       &ep->super.txqp, &ep->tx.wq,
+                                       MLX5_OPCODE_RDMA_WRITE,
+                                       &iov, 1,
+                                       0, NULL, 0,
+                                       remote_addr, rkey,
+                                       0ul, 0, 0, NULL,
+                                       0, fm_ce_se, 0,
+                                       UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super),
+                                       skip_flag);
+        total_length += lengths[iov_it];
+    }
+
+    uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp,
+                              uct_rc_ep_send_op_completion_handler, comp, sn,
+                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY, NULL, 0,
+                              total_length);
+
+    UCT_TL_EP_STAT_OP(&ep->super.super, PUT, ZCOPY, total_length);
+    uct_rc_ep_enable_flush_remote(&ep->super);
+
+    return UCS_INPROGRESS;
+}
+
+ucs_status_t
 uct_rc_mlx5_base_ep_get_bcopy(uct_ep_h tl_ep, uct_unpack_callback_t unpack_cb,
                               void *arg, size_t length, uint64_t remote_addr,
                               uct_rkey_t rkey, uct_completion_t *comp)

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -14,6 +14,7 @@
 #include <uct/ib/mlx5/ib_mlx5_ext.h>
 #include <uct/ib/mlx5/dv/ib_mlx5_dv.h>
 #include <uct/ib/base/ib_device.h>
+#include <uct/base/uct_iface.h>
 #include <uct/base/uct_md.h>
 #include <ucs/arch/cpu.h>
 #include <ucs/debug/log.h>
@@ -1011,19 +1012,17 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_rc_mlx5_iface_t, uct_iface_t, uct_md_h,
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rc_mlx5_iface_t, uct_iface_t);
 
 static ucs_status_t
-uct_rc_mlx5_iface_query_v2(uct_iface_h UCS_V_UNUSED iface,
-                           uct_iface_attr_v2_t *iface_attr)
+uct_rc_mlx5_iface_query_v2(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
 {
-    size_t max_sgl = uct_ib_mlx5_ext_max_put_sgl_zcopy_count();
+    ucs_status_t status;
 
-    if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_CAP_FLAGS) {
-        iface_attr->cap.flags = (max_sgl > 0) ? UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY : 0;
+    status = uct_iface_base_query_v2(tl_iface, iface_attr);
+    if (status != UCS_OK) {
+        return status;
     }
 
-    if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT) {
-        iface_attr->max_put_sgl_zcopy_count = max_sgl;
-    }
-
+    uct_rc_iface_query_put_sgl_cap_v2(ucs_derived_of(tl_iface, uct_rc_iface_t),
+                                      iface_attr);
     return UCS_OK;
 }
 
@@ -1039,7 +1038,7 @@ static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops = {
             .iface_is_reachable_v2  = uct_rc_mlx5_iface_is_reachable_v2,
             .ep_is_connected        = uct_rc_mlx5_base_ep_is_connected,
             .ep_get_device_ep       = (uct_ep_get_device_ep_func_t)ucs_empty_function_return_unsupported,
-            .ep_put_sgl_zcopy       = uct_ib_mlx5_ext_ep_put_sgl_zcopy
+            .ep_put_sgl_zcopy       = uct_rc_mlx5_base_ep_put_sgl_zcopy
         },
         .create_cq      = uct_rc_mlx5_iface_common_create_cq,
         .destroy_cq     = uct_rc_mlx5_iface_common_destroy_cq,

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -145,6 +145,26 @@ enum {
     UCT_RC_CHECK_TX_CQ_RES(_iface, _ep) \
     UCT_RC_CHECK_NUM_RDMA_READ_RET(_iface, UCS_ERR_NO_RESOURCE)
 
+#define UCT_RC_CHECK_MULTI_TX_CREDITS(_iface, _ep, _tx_slots, _cq_slots) \
+    ucs_assert((_ep)->flags & UCT_RC_EP_FLAG_CONNECTED); \
+    UCT_RC_CHECK_NUM_RDMA_READ_RET(_iface, UCS_ERR_NO_RESOURCE) \
+    UCT_RC_CHECK_CQE_RET(_iface, _ep, UCS_ERR_NO_RESOURCE) \
+    if (ucs_unlikely(uct_rc_txqp_available(&(_ep)->txqp) < (int16_t)(_tx_slots))) { \
+        /* Record how many TX slots this batch needs so that a subsequent \
+         * uct_ep_pending_add() queues the request instead of returning BUSY. \
+         * Without this, uct_rc_ep_has_tx_resources() only checks for >0 credits \
+         * and the caller busy-spins retrying an op that needs '_tx_slots' \
+         * credits, never yielding to poll the CQ that would free them. */ \
+        (_ep)->txqp_reserve = ucs_max((_ep)->txqp_reserve, (uint16_t)(_tx_slots)); \
+        UCS_STATS_UPDATE_COUNTER((_ep)->super.stats, UCT_EP_STAT_NO_RES, 1); \
+        return UCS_ERR_NO_RESOURCE; \
+    } \
+    if (ucs_unlikely((_iface)->tx.cq_available < (ssize_t)(_cq_slots))) { \
+        UCS_STATS_UPDATE_COUNTER((_iface)->stats, UCT_RC_IFACE_STAT_NO_CQE, 1); \
+        UCS_STATS_UPDATE_COUNTER((_ep)->super.stats, UCT_EP_STAT_NO_RES, 1); \
+        return UCS_ERR_NO_RESOURCE; \
+    }
+
 /*
  * check for FC credits and add FC protocol bits (if any)
  */

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -580,6 +580,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_iface_ops_t *tl_ops,
     ucs_status_t status;
     unsigned tx_cq_size;
     ucs_mpool_params_t mp_params;
+    size_t max_put_sgl_zcopy;
 
     UCS_CLASS_CALL_SUPER_INIT(uct_ib_iface_t, tl_ops, &ops->super, tl_md,
                               worker, params, &config->super, init_attr);
@@ -594,6 +595,20 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_iface_ops_t *tl_ops,
     self->config.tx_min_sge     = config->super.tx.min_sge;
     self->config.tx_min_inline  = config->super.tx.min_inline;
     self->config.tx_moderation  = init_attr->tx_moderation;
+    /* A put_sgl_zcopy call posts the whole SGL as one atomic batch of WQEs and
+     * must reserve TX credits for all of them up front. The batch therefore
+     * cannot exceed what the QP can ever hold at once: mlx5's usable depth is
+     * bb_max = qp_len - 2*MAX_BB (one WQE/BB per segment), and verbs is bounded
+     * by qp_len send WRs. Bound the advertised count by half the QP depth so a
+     * full batch is always postable (with headroom for other traffic); large
+     * QPs keep the previous min(tx_moderation, MAX) behavior. */
+    max_put_sgl_zcopy              = ucs_min((size_t)self->config.tx_qp_len / 2,
+                                             (size_t)UCT_IB_RC_PUT_SGL_ZCOPY_MAX);
+    self->config.max_put_sgl_zcopy =
+            (self->config.tx_moderation == 0) ?
+                    1 :
+                    ucs_min((size_t)self->config.tx_moderation,
+                            max_put_sgl_zcopy);
     self->config.tx_poll_always = config->tx.poll_always;
     self->config.tx_cq_len      = tx_cq_size;
     self->config.min_rnr_timer  = uct_ib_to_rnr_fabric_time(config->tx.rnr_timeout);
@@ -1088,6 +1103,22 @@ void uct_rc_iface_vfs_refresh(uct_iface_h iface)
     /* Add objects for EPs */
     ucs_list_for_each(ep, &rc_iface->ep_list, list) {
         rc_iface_ops->ep_vfs_populate(ep);
+    }
+}
+
+void uct_rc_iface_query_put_sgl_cap_v2(uct_rc_iface_t *iface,
+                                       uct_iface_attr_v2_t *iface_attr)
+{
+    if (iface->config.max_put_sgl_zcopy == 0) {
+        return;
+    }
+
+    if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_CAP_FLAGS) {
+        iface_attr->cap.flags |= UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY;
+    }
+
+    if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT) {
+        iface_attr->max_put_sgl_zcopy_count = iface->config.max_put_sgl_zcopy;
     }
 }
 

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -10,6 +10,7 @@
 #include "rc_def.h"
 
 #include <uct/base/uct_iface.h>
+#include <uct/api/v2/uct_v2.h>
 #include <uct/ib/base/ib_log.h>
 #include <uct/ib/base/ib_iface.h>
 #include <ucs/datastruct/arbiter.h>
@@ -22,6 +23,9 @@
 #define UCT_RC_QP_TABLE_SIZE        UCS_BIT(UCT_RC_QP_TABLE_ORDER)
 #define UCT_RC_QP_TABLE_MEMB_ORDER  (UCT_IB_QPN_ORDER - UCT_RC_QP_TABLE_ORDER)
 #define UCT_RC_QP_MAX_RETRY_COUNT   7
+
+/** Upper bound on segments per @ref uct_ep_put_sgl_zcopy on RC IB transports. */
+#define UCT_IB_RC_PUT_SGL_ZCOPY_MAX   64
 
 #define UCT_RC_CHECK_AM_SHORT(_am_id, _length, _header_t, _max_inline) \
      UCT_CHECK_AM_ID(_am_id); \
@@ -308,6 +312,7 @@ struct uct_rc_iface {
         unsigned             exp_backoff;
         unsigned long        ece;
         size_t               max_get_zcopy;
+        size_t               max_put_sgl_zcopy;
 
         /* Atomic callbacks */
         uct_rc_send_handler_t  atomic64_handler;      /* 64bit ib-spec */
@@ -385,6 +390,9 @@ ucs_status_t uct_rc_iface_query(uct_rc_iface_t *iface,
                                 size_t put_max_short, size_t max_inline,
                                 size_t am_max_hdr, size_t am_max_iov,
                                 size_t am_min_hdr, size_t rma_max_iov);
+
+void uct_rc_iface_query_put_sgl_cap_v2(uct_rc_iface_t *iface,
+                                       uct_iface_attr_v2_t *iface_attr);
 
 ucs_status_t
 uct_rc_iface_add_qp(uct_rc_iface_t *iface, uct_rc_ep_t *ep, unsigned qp_num);

--- a/src/uct/ib/rc/verbs/rc_verbs.h
+++ b/src/uct/ib/rc/verbs/rc_verbs.h
@@ -123,6 +123,17 @@ ucs_status_t uct_rc_verbs_ep_put_zcopy(uct_ep_h tl_ep,
                                        uint64_t remote_addr, uct_rkey_t rkey,
                                        uct_completion_t *comp);
 
+ucs_status_t uct_rc_verbs_ep_put_sgl_zcopy(uct_ep_h tl_ep,
+                                           void * const *buffers,
+                                           const size_t *lengths,
+                                           uct_mem_h const *memhs,
+                                           const uint64_t *remote_addrs,
+                                           uct_rkey_t const *rkeys,
+                                           const size_t *counts,
+                                           const size_t *strides,
+                                           size_t count,
+                                           uct_completion_t *comp);
+
 ucs_status_t uct_rc_verbs_ep_get_bcopy(uct_ep_h tl_ep,
                                        uct_unpack_callback_t unpack_cb,
                                        void *arg, size_t length,

--- a/src/uct/ib/rc/verbs/rc_verbs_ep.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_ep.c
@@ -16,6 +16,7 @@
 #include <ucs/vfs/base/vfs_obj.h>
 #include <ucs/arch/bitops.h>
 #include <uct/ib/base/ib_log.h>
+#include <string.h>
 
 void uct_rc_verbs_txcnt_init(uct_rc_verbs_txcnt_t *txcnt)
 {
@@ -211,6 +212,117 @@ ucs_status_t uct_rc_verbs_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, siz
                                  uct_iov_total_length(iov, iovcnt));
     uct_rc_ep_enable_flush_remote(&ep->super);
     return status;
+}
+
+ucs_status_t uct_rc_verbs_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
+                                           const size_t *lengths,
+                                           uct_mem_h const *memhs,
+                                           const uint64_t *remote_addrs,
+                                           uct_rkey_t const *rkeys,
+                                           const size_t *counts,
+                                           const size_t *strides,
+                                           size_t count,
+                                           uct_completion_t *comp)
+{
+    uct_rc_verbs_iface_t *iface = ucs_derived_of(tl_ep->iface,
+                                                 uct_rc_verbs_iface_t);
+    uct_rc_verbs_ep_t *ep       = ucs_derived_of(tl_ep, uct_rc_verbs_ep_t);
+    struct ibv_send_wr *bad_wr;
+    uct_iov_t iov;
+    size_t iov_it;
+    size_t total_length = 0;
+    uint16_t base_pi;
+    int ret;
+
+    if (count == 0) {
+        return UCS_OK;
+    }
+
+    if (count > iface->super.config.max_put_sgl_zcopy) {
+        return UCS_ERR_INVALID_PARAM;
+    }
+
+    ucs_assert(count <= UCT_IB_RC_PUT_SGL_ZCOPY_MAX);
+
+    if (iface->super.config.tx_moderation > 0) {
+        if (ep->super.txqp.unsignaled + count - 1 >= iface->super.config.tx_moderation) {
+            return UCS_ERR_NO_RESOURCE;
+        }
+    }
+
+    UCT_RC_CHECK_MULTI_TX_CREDITS(&iface->super, &ep->super, count, count);
+
+    /* 'count' is validated above (0 < count <= max_put_sgl_zcopy), so the
+     * work-request/SGE arrays are bounded and sized to the actual segment
+     * count. Post the whole chain with a single doorbell ring. */
+    {
+        struct ibv_send_wr wrs[count];
+        struct ibv_sge sges[count];
+
+        memset(wrs, 0, sizeof(wrs[0]) * count);
+        base_pi = ep->txcnt.pi;
+
+        for (iov_it = 0; iov_it < count; ++iov_it) {
+            uct_rkey_t rkey      = rkeys[iov_it];
+            uint64_t remote_addr = remote_addrs[iov_it];
+
+            UCT_CHECK_LENGTH(lengths[iov_it], 1, UCT_IB_MAX_MESSAGE_SIZE,
+                             "put_sgl_zcopy");
+
+            uct_rc_verbs_ep_fence_put(iface, ep, &rkey, &remote_addr);
+
+            iov.buffer = buffers[iov_it];
+            iov.length = lengths[iov_it];
+            iov.memh   = memhs ? memhs[iov_it] : UCT_MEM_HANDLE_NULL;
+            iov.stride = (strides != NULL) ? strides[iov_it] : 0;
+            iov.count  = (counts != NULL) ? counts[iov_it] : 1;
+
+            if (uct_ib_verbs_sge_fill_iov(&sges[iov_it], &iov, 1) != 1) {
+                return UCS_ERR_INVALID_PARAM;
+            }
+
+            UCT_RC_VERBS_FILL_RDMA_WR(wrs[iov_it], wrs[iov_it].opcode,
+                                      IBV_WR_RDMA_WRITE, sges[iov_it],
+                                      uct_iov_get_length(&iov), remote_addr,
+                                      uct_ib_md_direct_rkey(rkey));
+            wrs[iov_it].next       = (iov_it + 1 < count) ? &wrs[iov_it + 1] :
+                                                            NULL;
+            wrs[iov_it].wr_id      = base_pi + iov_it + 1;
+            wrs[iov_it].send_flags = (iov_it == count - 1) ? IBV_SEND_SIGNALED :
+                                                             0;
+
+            uct_ib_log_post_send(&iface->super.super, ep->qp, &wrs[iov_it],
+                                 INT_MAX, NULL);
+            total_length += lengths[iov_it];
+        }
+
+        ucs_assertv(ep->qp->state == IBV_QPS_RTS, "QP 0x%x state is %d",
+                    ep->qp->qp_num, ep->qp->state);
+
+        ret = ibv_post_send(ep->qp, &wrs[0], &bad_wr);
+        if (ret != 0) {
+            ucs_fatal("ibv_post_send() returned %d (%m)", ret);
+        }
+    }
+
+    ep->txcnt.pi = base_pi + count;
+
+    for (iov_it = 0; iov_it + 1 < count; ++iov_it) {
+        uct_rc_txqp_posted(&ep->super.txqp, &iface->super, 1, 0);
+    }
+
+    uct_rc_txqp_posted(&ep->super.txqp, &iface->super, 1, 1);
+
+    uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp,
+                              uct_rc_ep_send_op_completion_handler, comp,
+                              ep->txcnt.pi,
+                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY, NULL, 0,
+                              total_length);
+
+    UCT_TL_EP_STAT_OP(&ep->super.super, PUT, ZCOPY, total_length);
+    uct_rc_ep_enable_flush_remote(&ep->super);
+
+    return UCS_INPROGRESS;
 }
 
 ucs_status_t uct_rc_verbs_ep_get_bcopy(uct_ep_h tl_ep,

--- a/src/uct/ib/rc/verbs/rc_verbs_iface.c
+++ b/src/uct/ib/rc/verbs/rc_verbs_iface.c
@@ -226,6 +226,21 @@ uct_rc_verbs_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
 }
 
 static ucs_status_t
+uct_rc_verbs_iface_query_v2(uct_iface_h tl_iface, uct_iface_attr_v2_t *iface_attr)
+{
+    ucs_status_t status;
+
+    status = uct_iface_base_query_v2(tl_iface, iface_attr);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    uct_rc_iface_query_put_sgl_cap_v2(ucs_derived_of(tl_iface, uct_rc_iface_t),
+                                      iface_attr);
+    return UCS_OK;
+}
+
+static ucs_status_t
 uct_rc_iface_verbs_init_rx(uct_rc_iface_t *rc_iface,
                            const uct_rc_iface_common_config_t *config)
 {
@@ -495,7 +510,7 @@ static uct_iface_ops_t uct_rc_verbs_iface_tl_ops = {
 static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
     .super = {
         .super = {
-            .iface_query_v2         = uct_iface_base_query_v2,
+            .iface_query_v2         = uct_rc_verbs_iface_query_v2,
             .iface_estimate_perf    = uct_rc_iface_estimate_perf,
             .iface_vfs_refresh      = uct_rc_iface_vfs_refresh,
             .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
@@ -503,7 +518,8 @@ static uct_rc_iface_ops_t uct_rc_verbs_iface_ops = {
             .ep_connect_to_ep_v2    = uct_rc_verbs_ep_connect_to_ep_v2,
             .iface_is_reachable_v2  = uct_ib_iface_is_reachable_v2,
             .ep_is_connected        = uct_rc_verbs_ep_is_connected,
-            .ep_get_device_ep       = (uct_ep_get_device_ep_func_t)ucs_empty_function_return_unsupported
+            .ep_get_device_ep       = (uct_ep_get_device_ep_func_t)ucs_empty_function_return_unsupported,
+            .ep_put_sgl_zcopy       = uct_rc_verbs_ep_put_sgl_zcopy
         },
         .create_cq      = uct_ib_verbs_create_cq,
         .destroy_cq     = uct_ib_verbs_destroy_cq,

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -970,11 +970,6 @@ public:
     }
 
     virtual void init() override {
-        /* FIXME: sporadic failure on CUDA memory type. re-enable once fixed */
-        if (mem_type() == UCS_MEMORY_TYPE_CUDA) {
-            UCS_TEST_SKIP_R("sporadic failure on CUDA memory type");
-        }
-
         modify_config("MAX_RMA_RAILS", "2");
         test_ucp_rma::init();
     }
@@ -1066,6 +1061,46 @@ protected:
         }
 
         ctx.remote_lengths = ctx.lengths;
+    }
+
+    /*
+     * Whether the sender context can *detect* that a buffer is of the given
+     * memory type. UCP only builds a mem-type detection MD list from memory
+     * domains that survived transport selection: ucp_fill_tl_md() closes any MD
+     * with no selected transport resources *before* adding it to
+     * context->mem_type_detect_mds. So an allow-list like UCX_TLS=rc drops the
+     * cuda_copy MD and, with it, CUDA detection - even though an IB MD can still
+     * *register* CUDA memory via GPUDirect. Registration therefore does not
+     * imply detection, and only detection is checked here.
+     */
+    static bool check_detect_mem_type(const entity &e,
+                                      ucs_memory_type_t mem_type) {
+        ucp_context_h context = e.ucph();
+        for (ucp_md_index_t i = 0; i < context->num_mem_type_detect_mds; ++i) {
+            ucp_md_index_t md_index = context->mem_type_detect_mds[i];
+            if (context->tl_mds[md_index].attr.detect_mem_types &
+                UCS_BIT(mem_type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /*
+     * The mixed/inconsistent mem-type negative tests expect UCP to reject an SGL
+     * whose segments span different memory types. That rejection is best-effort:
+     * ucp_dt_sgl_check_same_mem_info() compares the per-segment memory type
+     * returned by ucp_memory_detect(), so it can only fire when CUDA is
+     * detectable. When it is not (e.g. UCX_TLS=rc dropped the cuda_copy detect
+     * MD), a real CUDA buffer is reported as HOST, the SGL looks homogeneous,
+     * and the put is (correctly, given the available information) accepted.
+     * Skip the negative test in that configuration since its premise cannot
+     * hold. Note: registrability of CUDA is not sufficient - detection is.
+     */
+    void skip_if_cuda_detect_unsupported() {
+        if (!check_detect_mem_type(sender(), UCS_MEMORY_TYPE_CUDA)) {
+            UCS_TEST_SKIP_R("selected transports cannot detect CUDA memory");
+        }
     }
 
     static ucp_dt_local_sgl_t
@@ -1211,6 +1246,11 @@ protected:
             UCP_DT_REMOTE_SGL_FIELD_LENGTHS |
             UCP_DT_REMOTE_SGL_FIELD_RKEYS;
 
+    /* Element size used by the negative/param-check cases. gdrcopy rounds
+     * registrations up to a GPU page, so use a full 64K page to test whether
+     * tiny buffers are behind the sporadic gdr_copy pin failures. */
+    static constexpr size_t SGL_SMALL_ELEM_SIZE = 64 * UCS_KBYTE;
+
     void expect_sgl_put_status_ctx(
             sgl_ctx &ctx, uint64_t local_mask, uint64_t remote_mask,
             size_t count, ucs_status_t expected_status,
@@ -1260,7 +1300,7 @@ protected:
                                       size_t remote_count = 0)
     {
         sgl_ctx ctx;
-        init_sgl_ctx(ctx, count, 64);
+        init_sgl_ctx(ctx, count, SGL_SMALL_ELEM_SIZE);
         expect_sgl_put_invalid_param_ctx(ctx, local_mask, remote_mask, count,
                                          remote_addr, rkey, clear_param_mask,
                                          null_remote, remote_count);
@@ -1344,7 +1384,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_invalid_remote_addr,
 UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_invalid_rkey,
                      !ENABLE_PARAMS_CHECK) {
     sgl_ctx ctx;
-    init_sgl_ctx(ctx, 2, 64);
+    init_sgl_ctx(ctx, 2, SGL_SMALL_ELEM_SIZE);
     expect_sgl_put_invalid_param_ctx(ctx, LOCAL_MASK_DEFAULT,
                                      REMOTE_MASK_DEFAULT, 2,
                                      UCP_REMOTE_ADDR_INVALID, ctx.rkeys[0]);
@@ -1408,6 +1448,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_mixed_mem_types,
                      !ENABLE_PARAMS_CHECK ||
                              !mem_buffer::is_mem_type_supported(
                                      UCS_MEMORY_TYPE_CUDA)) {
+    skip_if_cuda_detect_unsupported();
     sgl_ctx ctx;
     init_sgl_ctx_mixed_mem_types(ctx);
     expect_sgl_put_invalid_param_ctx(ctx, LOCAL_MASK_DEFAULT,
@@ -1417,7 +1458,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_mixed_mem_types,
 UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_memhs_null_memh,
                      !ENABLE_PARAMS_CHECK) {
     sgl_ctx ctx;
-    init_sgl_ctx(ctx, 2, 64);
+    init_sgl_ctx(ctx, 2, SGL_SMALL_ELEM_SIZE);
     ctx.memhs[1] = NULL;
     expect_sgl_put_invalid_param_ctx(
             ctx, LOCAL_MASK_DEFAULT | UCP_DT_LOCAL_SGL_FIELD_MEMHS,
@@ -1427,7 +1468,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_memhs_null_memh,
 UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_memhs_buffer_out_of_range,
                      !ENABLE_PARAMS_CHECK) {
     sgl_ctx ctx;
-    init_sgl_ctx(ctx, 2, 64);
+    init_sgl_ctx(ctx, 2, SGL_SMALL_ELEM_SIZE);
     ctx.buffers[1] = reinterpret_cast<void*>(0xdeadbeefUL);
     expect_sgl_put_invalid_param_ctx(
             ctx, LOCAL_MASK_DEFAULT | UCP_DT_LOCAL_SGL_FIELD_MEMHS,
@@ -1438,6 +1479,14 @@ UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_memhs_inconsistent_mem_info,
                      !ENABLE_PARAMS_CHECK ||
                              !mem_buffer::is_mem_type_supported(
                                      UCS_MEMORY_TYPE_CUDA)) {
+    /*
+     * User memhs carry the memory type recorded at ucp_mem_map() time, and the
+     * consistency check runs via ucp_datatype_iter_is_user_memh_valid(). But
+     * that recorded type is itself the result of ucp_memory_detect(): without
+     * CUDA detection the CUDA buffer is registered as HOST, so memhs[1] matches
+     * memhs[0] and the mismatch cannot be observed. Gate on detection too.
+     */
+    skip_if_cuda_detect_unsupported();
     sgl_ctx ctx;
     init_sgl_ctx_mixed_mem_types(ctx);
     expect_sgl_put_invalid_param_ctx(
@@ -1448,7 +1497,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_memhs_inconsistent_mem_info,
 UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_rkeys_null,
                      !ENABLE_PARAMS_CHECK) {
     sgl_ctx ctx;
-    init_sgl_ctx(ctx, 2, 64);
+    init_sgl_ctx(ctx, 2, SGL_SMALL_ELEM_SIZE);
     ctx.rkeys[1] = NULL;
     expect_sgl_put_invalid_param_ctx(ctx, LOCAL_MASK_DEFAULT,
                                      REMOTE_MASK_DEFAULT, 2);
@@ -1457,7 +1506,7 @@ UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_rkeys_null,
 UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_rkeys_mismatched_cfg,
                      !ENABLE_PARAMS_CHECK) {
     sgl_ctx ctx;
-    init_sgl_ctx(ctx, 2, 64);
+    init_sgl_ctx(ctx, 2, SGL_SMALL_ELEM_SIZE);
 
     ucp_worker_cfg_index_t saved_cfg_index = ctx.rkeys[1]->cfg_index;
     ctx.rkeys[1]->cfg_index = saved_cfg_index + 1;
@@ -1474,10 +1523,11 @@ UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_without_proto,
                      !ENABLE_PARAMS_CHECK, "PROTO_ENABLE=n")
 {
     sgl_ctx ctx;
-    init_sgl_ctx(ctx, 2, 64);
+    init_sgl_ctx(ctx, 2, SGL_SMALL_ELEM_SIZE);
     expect_sgl_put_status_ctx(
             ctx, LOCAL_MASK_DEFAULT | UCP_DT_LOCAL_SGL_FIELD_MEMHS,
             REMOTE_MASK_DEFAULT, 2, UCS_ERR_UNSUPPORTED);
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_rma_sgl, all, "all")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_rma_sgl, rc, "rc")


### PR DESCRIPTION
Adds native UCT transport support for the scatter-gather list (SGL) zero-copy put operation (uct_ep_put_sgl_zcopy), which previously only had the UCP software-emulation path. This lets a multi-segment ucp_put_nbx SGL operation be offloaded directly to the transport as a single batched submission instead of being decomposed into individual puts.

Implemented for:

 - IB RC — rc_verbs (chained ibv_send_wr batch, single doorbell) and rc_mlx5 (one WQE per segment, batched).
 - CUDA — cuda_copy (intra-process device↔device) and cuda_ipc (inter-process device memory).
Also adds gtest coverage and a ucx_perftest bandwidth mode for benchmarking.

### Details / commits
 - BUILD: stop treating -Wunknown-pragmas as an error so compilers without OpenMP #pragma omp support can build.
UCT/IB/RC (base): advertise the max SGL segment count (bounded by QP depth), add a v2 capability-query helper, and reserve the full TX credit count for a multi-WQE SGL op so it is queued as pending instead of busy-spinning when credits are momentarily short.
 - UCT/IB/RC/VERBS: implement uct_rc_verbs_ep_put_sgl_zcopy, posting the whole segment list as a chained RDMA_WRITE batch with one doorbell ring.
 - UCT/IB/MLX5: implement uct_rc_mlx5_base_ep_put_sgl_zcopy; add an iov_post_flags argument to uct_rc_mlx5_txqp_dptr_post_iov to skip forced TX moderation on inner batched WQEs (DC caller updated for the new signature).
 - UCT/CUDA/COPY: implement uct_cuda_copy_ep_put_sgl_zcopy and use a process-wide interface id so cuda_copy interfaces in the same process are mutually reachable and can serve as the SGL RMA lane.
 - UCT/CUDA/IPC: implement uct_cuda_ipc_ep_put_sgl_zcopy (originates from michal-shalev's uct-cuda-ipc-sgl branch).
 - TEST/GTEST: enable the UCP SGL put tests and adapt the CUDA IPC device SGL test to the new API.
 - TOOLS/PERF: add -D sgl[/N] to ucx_perftest (ucp_put_bw), splitting the message into N equal segments and driving it through the SGL put API.

### Notes
 - The counts/strides (strided/repeated) SGL fields are handled where the transport supports them; the basic N→N mapping is the primary path.
 - '-D' sgl is restricted to the UCP put bandwidth test.

### Tests
- [x] gtest: test_ucp_rma_sgl.* (host and CUDA) and uct/cuda/test_cuda_ipc_device SGL cases pass.
- [x]  ucx_perftest -t ucp_put_bw -D sgl/4 ... runs over rc_verbs, rc_mlx5, and intra-node cuda_copy/cuda_ipc.
- [x]  Size sweep vs -D contig shows expected bandwidth.
- [x]  Build passes on a compiler without OpenMP pragmas.

### Follow-up
- while verifying the rkey handling I noticed two now-redundant `uct_ib_md_direct_rkey()` calls in the RC put paths. Both the mlx5 and verbs put flows already resolve the remote key in place via their fence_put helpers — `uct_rc_mlx5_ep_fence_put()` and `uct_rc_ep_fence_put()` set `*rkey = uct_ib_md_direct_rkey(*rkey)` (or the atomic-resolve variant) before the key is ever posted. As a result, (1) the `uct_ib_md_direct_rkey(rdma_rkey)` inside `uct_rc_mlx5_base_ep_zcopy_post()` (rc_mlx5.inl) and (2) the `uct_ib_md_direct_rkey(rkey)` in the verbs SGL fill (UCT_RC_VERBS_FILL_RDMA_WR in `uct_rc_verbs_ep_put_sgl_zcopy`) both re-apply the conversion to an already-resolved key. Since `uct_ib_md_direct_rkey()` is just a low-32-bit mask ((uint32_t)uct_rkey), re-applying it to a value whose high bits are already cleared is idempotent — a no-op — so these calls are harmless but redundant. (On mlx5 it's doubly redundant, because `uct_ib_mlx5_ep_set_rdma_seg()` only writes the low 32 bits of the key into the WQE regardless.) They can be dropped for clarity, or kept for visual symmetry; either way there is no behavioral difference.

