### PR TITLE
UCT/IB: Support relaxed-only memory keys

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,8 @@
 
 ## Current
 ### Features:
+#### RDMA CORE (IB, ROCE, etc.)
+ * UCX_IB_PCI_RELAXED_ORDERING=yes now requires all memory keys to use relaxed ordering and omits strict-order companion keys; the former "only" value is removed
 ### Bugfixes:
 
 ## 1.21.0 (June 24, 2026)

--- a/src/uct/ib/AGENTS.md
+++ b/src/uct/ib/AGENTS.md
@@ -50,6 +50,10 @@ at runtime.
   (`uct_ib_reg_mr` / `uct_ib_dereg_mr` in `ib_md.c`) — they handle ODP,
   multi-MR, and DMABUF correctly. Recent fixes around DMABUF offsets live
   in `ib_md.c`.
+- When building `access_flags` for a direct `ibv_reg_mr` call (bypassing
+  `uct_ib_reg_mr`), wrap the flags with `uct_ib_md_access_flags()` so that
+  `IBV_ACCESS_RELAXED_ORDERING` is automatically set on relaxed-only devices
+  (`relaxed_order_required`).
 - DMABUF FD ownership: when `mem_reg`/`mem_advise` accepts a DMABUF FD, the
   caller retains ownership. Register paths must compute the offset from
   the original mapping base, not the registration base.

--- a/src/uct/ib/AGENTS.md
+++ b/src/uct/ib/AGENTS.md
@@ -52,7 +52,7 @@ at runtime.
   in `ib_md.c`.
 - When building `access_flags` for a direct `ibv_reg_mr` call (bypassing
   `uct_ib_reg_mr`), wrap the flags with `uct_ib_md_access_flags()` so that
-  `IBV_ACCESS_RELAXED_ORDERING` is automatically set on relaxed-only devices
+  `IBV_ACCESS_RELAXED_ORDERING` is automatically set in relaxed-only mode
   (`relaxed_order_required`).
 - DMABUF FD ownership: when `mem_reg`/`mem_advise` accepts a DMABUF FD, the
   caller retains ownership. Register paths must compute the offset from

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1296,7 +1296,7 @@ ucs_status_t uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
                           "IBV_ACCESS_RELAXED_ORDERING is not supported",
                           uct_ib_device_name(&md->dev));
             }
-            return UCS_ERR_UNSUPPORTED;
+            return is_required ? UCS_ERR_IO_ERROR : UCS_ERR_UNSUPPORTED;
         }
 
         if (md_config->mr_relaxed_order == UCT_IB_RELAXED_ORDERING_NO) {

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -50,35 +50,6 @@ static const char *uct_ib_devx_objs[] = {
     NULL
 };
 
-static int uct_ib_md_config_sscanf_relaxed_order(const char *buf, void *dest,
-                                                  const void *arg)
-{
-    if (!strcasecmp(buf, "only")) {
-        *(uct_ib_relaxed_ordering_t*)dest = UCT_IB_RELAXED_ORDERING_ONLY;
-        return 1;
-    }
-
-    return ucs_config_sscanf_ternary_auto(buf, dest, arg);
-}
-
-static int uct_ib_md_config_sprintf_relaxed_order(char *buf, size_t max,
-                                                   const void *src,
-                                                   const void *arg)
-{
-    if (*(const uct_ib_relaxed_ordering_t*)src ==
-        UCT_IB_RELAXED_ORDERING_ONLY) {
-        return snprintf(buf, max, "only");
-    }
-
-    return ucs_config_sprintf_ternary_auto(buf, max, src, arg);
-}
-
-#define UCT_IB_CONFIG_TYPE_RELAXED_ORDER \
-    {uct_ib_md_config_sscanf_relaxed_order, \
-     uct_ib_md_config_sprintf_relaxed_order, ucs_config_clone_int, \
-     ucs_config_release_nop, ucs_config_help_generic, ucs_config_doc_nop, \
-     "<yes|no|try|auto|only>"}
-
 ucs_config_field_t uct_ib_md_config_table[] = {
     {"", "", NULL,
      ucs_offsetof(uct_ib_md_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
@@ -200,16 +171,14 @@ ucs_config_field_t uct_ib_md_config_table[] = {
     {"PCI_RELAXED_ORDERING", "auto",
      "Control relaxed ordering for PCIe transactions:\n"
      "  no    - disable relaxed ordering\n"
-     "  yes   - enable relaxed ordering, retain strict-order companion keys "
-     "when available, and warn if relaxed ordering is unsupported\n"
+     "  yes   - require all memory keys to use relaxed ordering, fail if "
+     "unsupported, and do not create strict-order companion keys\n"
      "  try   - enable relaxed ordering when supported, retain strict-order "
      "companion keys when available, and silently continue if unsupported\n"
      "  auto  - honor a firmware relaxed-only requirement, otherwise use "
-     "the CPU preference\n"
-     "  only  - require all memory keys to use relaxed ordering and do not "
-     "create strict-order companion keys\n",
+     "the CPU preference\n",
      ucs_offsetof(uct_ib_md_config_t, mr_relaxed_order),
-     UCT_IB_CONFIG_TYPE_RELAXED_ORDER},
+     UCS_CONFIG_TYPE_TERNARY_AUTO},
 
     {"MAX_IDLE_RKEY_COUNT", "16",
      "Maximal number of invalidated memory keys that are kept idle before reuse.",
@@ -1293,29 +1262,20 @@ ucs_status_t uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
                       "IBV_ACCESS_RELAXED_ORDERING is unavailable",
                       uct_ib_device_name(&md->dev),
                       is_required ? "firmware" :
-                                    "IB_PCI_RELAXED_ORDERING=only");
+                                    "IB_PCI_RELAXED_ORDERING=yes");
             return is_required ? UCS_ERR_IO_ERROR : UCS_ERR_UNSUPPORTED;
         }
 
-        if (md_config->mr_relaxed_order == UCT_IB_RELAXED_ORDERING_NO) {
+        if (md_config->mr_relaxed_order == UCS_NO) {
             ucs_error("%s: strong-order memory keys are not supported; "
                       "IB_PCI_RELAXED_ORDERING=n is invalid",
                       uct_ib_device_name(&md->dev));
             return UCS_ERR_INVALID_PARAM;
         }
 
-    } else if (md_config->mr_relaxed_order == UCT_IB_RELAXED_ORDERING_YES) {
-        if (have_relaxed_order) {
-            mem_types = all_mem_types;
-        } else {
-            ucs_warn("%s: relaxed order memory access requested, but "
-                     "unsupported",
-                     uct_ib_device_name(&md->dev));
-            return UCS_OK;
-        }
-    } else if (md_config->mr_relaxed_order == UCT_IB_RELAXED_ORDERING_TRY) {
+    } else if (md_config->mr_relaxed_order == UCS_TRY) {
         mem_types = have_relaxed_order ? all_mem_types : 0;
-    } else if (md_config->mr_relaxed_order == UCT_IB_RELAXED_ORDERING_AUTO) {
+    } else if (md_config->mr_relaxed_order == UCS_AUTO) {
         mem_types = have_relaxed_order ?
                     uct_ib_md_relaxed_order_auto_mem_types(
                             ucs_arch_get_cpu_vendor(), ucs_arch_get_cpu_model()) :

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -30,6 +30,7 @@
 #include <pthread_np.h>
 #endif
 #include <sys/resource.h>
+#include <strings.h>
 
 
 #define UCT_IB_MD_RCACHE_DEFAULT_ALIGN 16
@@ -48,6 +49,35 @@ static const char *uct_ib_devx_objs[] = {
     [UCT_IB_DEVX_OBJ_AUTO]  = "auto",
     NULL
 };
+
+static int uct_ib_md_config_sscanf_relaxed_order(const char *buf, void *dest,
+                                                  const void *arg)
+{
+    if (!strcasecmp(buf, "only")) {
+        *(uct_ib_relaxed_ordering_t*)dest = UCT_IB_RELAXED_ORDERING_ONLY;
+        return 1;
+    }
+
+    return ucs_config_sscanf_ternary_auto(buf, dest, arg);
+}
+
+static int uct_ib_md_config_sprintf_relaxed_order(char *buf, size_t max,
+                                                   const void *src,
+                                                   const void *arg)
+{
+    if (*(const uct_ib_relaxed_ordering_t*)src ==
+        UCT_IB_RELAXED_ORDERING_ONLY) {
+        return snprintf(buf, max, "only");
+    }
+
+    return ucs_config_sprintf_ternary_auto(buf, max, src, arg);
+}
+
+#define UCT_IB_CONFIG_TYPE_RELAXED_ORDER \
+    {uct_ib_md_config_sscanf_relaxed_order, \
+     uct_ib_md_config_sprintf_relaxed_order, ucs_config_clone_int, \
+     ucs_config_release_nop, ucs_config_help_generic, ucs_config_doc_nop, \
+     "<yes|no|try|auto|only>"}
 
 ucs_config_field_t uct_ib_md_config_table[] = {
     {"", "", NULL,
@@ -168,8 +198,16 @@ ucs_config_field_t uct_ib_md_config_table[] = {
      ucs_offsetof(uct_ib_md_config_t, ext.mt_reg_bind), UCS_CONFIG_TYPE_BOOL},
 
     {"PCI_RELAXED_ORDERING", "auto",
-     "Enable relaxed ordering for PCIe transactions to improve performance on some systems.",
-     ucs_offsetof(uct_ib_md_config_t, mr_relaxed_order), UCS_CONFIG_TYPE_TERNARY_AUTO},
+     "Control relaxed ordering for PCIe transactions:\n"
+     "  no    - disable relaxed ordering\n"
+     "  yes   - request relaxed ordering and warn if it is unsupported\n"
+     "  try   - enable relaxed ordering when supported\n"
+     "  auto  - honor a firmware relaxed-only requirement, otherwise use "
+     "the CPU preference\n"
+     "  only  - force relaxed-only memory keys regardless of the firmware "
+     "capability\n",
+     ucs_offsetof(uct_ib_md_config_t, mr_relaxed_order),
+     UCT_IB_CONFIG_TYPE_RELAXED_ORDER},
 
     {"MAX_IDLE_RKEY_COUNT", "16",
      "Maximal number of invalidated memory keys that are kept idle before reuse.",
@@ -496,6 +534,7 @@ ucs_status_t uct_ib_reg_mr(const uct_ib_md_t *md, void *address, size_t length,
                                     DMABUF_FD, UCT_DMABUF_FD_INVALID);
     dmabuf_offset = UCS_PARAM_VALUE(UCT_MD_MEM_REG_FIELD, params, dmabuf_offset,
                                     DMABUF_OFFSET, 0);
+    access_flags  = uct_ib_md_access_flags(md, access_flags);
 
     if (dm != NULL) {
 #if HAVE_IBV_DM
@@ -1221,37 +1260,58 @@ static void uct_ib_md_log_relaxed_order(uct_ib_md_t *md)
     UCS_STRING_BUFFER_ONSTACK(strb, 128);
 
     if (!uct_ib_md_is_relaxed_order(md)) {
-        ucs_debug("%s: relaxed order memory access is disabled",
-                  uct_ib_device_name(&md->dev));
+        ucs_debug("%s: relaxed order memory access is disabled%s",
+                  uct_ib_device_name(&md->dev),
+                  md->relaxed_order_required ? " (required)" : "");
         return;
     }
 
     ucs_string_buffer_append_flags(&strb, md->relaxed_order_mem_types,
                                    ucs_memory_type_names);
-    ucs_debug("%s: relaxed order memory access is enabled for %s",
-              uct_ib_device_name(&md->dev), ucs_string_buffer_cstr(&strb));
+    ucs_debug("%s: relaxed order memory access is enabled for %s%s",
+              uct_ib_device_name(&md->dev), ucs_string_buffer_cstr(&strb),
+              md->relaxed_order_required ? " (required)" : "");
 }
 
-void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
-                                   const uct_ib_md_config_t *md_config,
-                                   int is_supported)
+ucs_status_t uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
+                                           const uct_ib_md_config_t *md_config,
+                                           int is_supported, int is_required)
 {
-    int have_relaxed_order = (IBV_ACCESS_RELAXED_ORDERING != 0) && is_supported;
+    int relaxed_order_required =
+            uct_ib_md_is_relaxed_order_required(md_config, is_required);
+    int have_relaxed_order = (IBV_ACCESS_RELAXED_ORDERING != 0) &&
+                             (is_supported || relaxed_order_required);
     uint64_t all_mem_types = UCS_MASK(UCS_MEMORY_TYPE_LAST);
     uint64_t mem_types     = 0;
 
-    if (md_config->mr_relaxed_order == UCS_YES) {
+    md->relaxed_order_required = relaxed_order_required;
+    if (relaxed_order_required) {
+        if (!have_relaxed_order) {
+            ucs_error("%s: strong-order memory keys are not supported, but "
+                      "relaxed-order memory access is unavailable",
+                      uct_ib_device_name(&md->dev));
+            return UCS_ERR_UNSUPPORTED;
+        }
+
+        if (md_config->mr_relaxed_order == UCT_IB_RELAXED_ORDERING_NO) {
+            ucs_error("%s: strong-order memory keys are not supported; "
+                      "IB_PCI_RELAXED_ORDERING=n is invalid",
+                      uct_ib_device_name(&md->dev));
+            return UCS_ERR_INVALID_PARAM;
+        }
+
+    } else if (md_config->mr_relaxed_order == UCT_IB_RELAXED_ORDERING_YES) {
         if (have_relaxed_order) {
             mem_types = all_mem_types;
         } else {
             ucs_warn("%s: relaxed order memory access requested, but "
                      "unsupported",
                      uct_ib_device_name(&md->dev));
-            return;
+            return UCS_OK;
         }
-    } else if (md_config->mr_relaxed_order == UCS_TRY) {
+    } else if (md_config->mr_relaxed_order == UCT_IB_RELAXED_ORDERING_TRY) {
         mem_types = have_relaxed_order ? all_mem_types : 0;
-    } else if (md_config->mr_relaxed_order == UCS_AUTO) {
+    } else if (md_config->mr_relaxed_order == UCT_IB_RELAXED_ORDERING_AUTO) {
         mem_types = have_relaxed_order ?
                     uct_ib_md_relaxed_order_auto_mem_types(
                             ucs_arch_get_cpu_vendor(), ucs_arch_get_cpu_model()) :
@@ -1260,6 +1320,7 @@ void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
 
     md->relaxed_order_mem_types = mem_types;
     uct_ib_md_log_relaxed_order(md);
+    return UCS_OK;
 }
 
 void uct_ib_check_gpudirect_driver(uct_ib_md_t *md, const char *file,
@@ -1348,6 +1409,7 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
                           UCT_MD_FLAG_ADVISE;
     md->reg_cost                = md_config->reg_cost;
     md->relaxed_order_mem_types = 0;
+    md->relaxed_order_required  = 0;
 
     /* Create statistics */
     status = UCS_STATS_NODE_ALLOC(&md->stats, &uct_ib_md_stats_class,
@@ -1606,7 +1668,10 @@ static ucs_status_t uct_ib_verbs_md_open(struct ibv_device *ibv_device,
     md->flush_rkey = UCT_IB_MD_INVALID_FLUSH_RKEY;
 
     uct_ib_md_ece_check(md);
-    uct_ib_md_parse_relaxed_order(md, md_config, 0);
+    status = uct_ib_md_parse_relaxed_order(md, md_config, 0, 0);
+    if (status != UCS_OK) {
+        goto err_device_config_release;
+    }
     uct_ib_md_check_odp(md, md_config);
 
     *p_md = md;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1287,9 +1287,15 @@ ucs_status_t uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
     md->relaxed_order_required = relaxed_order_required;
     if (relaxed_order_required) {
         if (!have_relaxed_order) {
-            ucs_error("%s: strong-order memory keys are not supported, but "
-                      "relaxed-order memory access is unavailable",
-                      uct_ib_device_name(&md->dev));
+            if (is_required) {
+                ucs_error("%s: strong-order memory keys are not supported, but "
+                          "relaxed-order memory access is unavailable",
+                          uct_ib_device_name(&md->dev));
+            } else {
+                ucs_error("%s: IB_PCI_RELAXED_ORDERING=only requested, but "
+                          "IBV_ACCESS_RELAXED_ORDERING is not supported",
+                          uct_ib_device_name(&md->dev));
+            }
             return UCS_ERR_UNSUPPORTED;
         }
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -611,11 +611,11 @@ ucs_status_t uct_ib_mem_advise(uct_md_h uct_md, uct_mem_h memh, void *addr,
 }
 
 ucs_status_t uct_ib_memh_alloc(uct_ib_md_t *md, size_t length,
-                               unsigned mem_flags, int relaxed_order,
+                               unsigned mem_flags, int strict_order_mr,
                                size_t memh_base_size, size_t mr_size,
                                uct_ib_mem_t **memh_p)
 {
-    int num_mrs = relaxed_order ?
+    int num_mrs = strict_order_mr ?
                           2 /* UCT_IB_MR_DEFAULT and UCT_IB_MR_STRICT_ORDER */ :
                           1 /* UCT_IB_MR_DEFAULT */;
     uct_ib_mem_t *memh;
@@ -649,8 +649,8 @@ ucs_status_t uct_ib_memh_alloc(uct_ib_md_t *md, size_t length,
         memh->flags |= UCT_IB_MEM_FLAG_GVA;
     }
 
-    if (relaxed_order) {
-        memh->flags |= UCT_IB_MEM_RELAXED_ORDER;
+    if (strict_order_mr) {
+        memh->flags |= UCT_IB_MEM_STRICT_ORDER_MR;
     }
 
     *memh_p = memh;
@@ -675,8 +675,8 @@ ucs_status_t uct_ib_verbs_mem_reg(uct_md_h uct_md, void *address, size_t length,
                                   const uct_md_mem_reg_params_t *params,
                                   uct_mem_h *memh_p)
 {
-    uct_ib_md_t *md   = ucs_derived_of(uct_md, uct_ib_md_t);
-    int relaxed_order = uct_ib_memh_is_relaxed_order(md, params);
+    uct_ib_md_t *md     = ucs_derived_of(uct_md, uct_ib_md_t);
+    int strict_order_mr = uct_ib_md_needs_strict_order_mr(md, params);
     struct ibv_mr *mr_default;
     uct_ib_verbs_mem_t *memh;
     uct_ib_mem_t *ib_memh;
@@ -686,14 +686,14 @@ ucs_status_t uct_ib_verbs_mem_reg(uct_md_h uct_md, void *address, size_t length,
     status = uct_ib_memh_alloc(md, length,
                                UCT_MD_MEM_REG_FIELD_VALUE(params, flags,
                                                           FIELD_FLAGS, 0),
-                               relaxed_order, sizeof(*memh),
+                               strict_order_mr, sizeof(*memh),
                                sizeof(memh->mrs[0]), &ib_memh);
     if (status != UCS_OK) {
         goto err;
     }
 
     memh         = ucs_derived_of(ib_memh, uct_ib_verbs_mem_t);
-    access_flags = uct_ib_memh_access_flags(&memh->super, relaxed_order,
+    access_flags = uct_ib_memh_access_flags(&memh->super, strict_order_mr,
                                             md->dev.mr_access_flags);
 
     status = uct_ib_reg_mr(md, address, length, params, access_flags, NULL,
@@ -706,7 +706,7 @@ ucs_status_t uct_ib_verbs_mem_reg(uct_md_h uct_md, void *address, size_t length,
     memh->super.rkey                = mr_default->rkey;
     memh->mrs[UCT_IB_MR_DEFAULT].ib = mr_default;
 
-    if (relaxed_order) {
+    if (strict_order_mr) {
         status = uct_ib_reg_mr(md, address, length, params,
                                access_flags & ~IBV_ACCESS_RELAXED_ORDERING,
                                NULL, &memh->mrs[UCT_IB_MR_STRICT_ORDER].ib);
@@ -740,7 +740,7 @@ uct_ib_verbs_mem_dereg(uct_md_h uct_md, const uct_md_mem_dereg_params_t *params)
 
     memh = params->memh;
 
-    if (memh->super.flags & UCT_IB_MEM_RELAXED_ORDER) {
+    if (uct_ib_memh_uses_strict_order_mr(&memh->super)) {
         status = uct_ib_dereg_mr(memh->mrs[UCT_IB_MR_STRICT_ORDER].ib);
         if (status != UCS_OK) {
             return status;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -676,7 +676,8 @@ ucs_status_t uct_ib_verbs_mem_reg(uct_md_h uct_md, void *address, size_t length,
                                   uct_mem_h *memh_p)
 {
     uct_ib_md_t *md     = ucs_derived_of(uct_md, uct_ib_md_t);
-    int strict_order_mr = uct_ib_md_needs_strict_order_mr(md, params);
+    int strict_order_mr =
+            uct_ib_md_is_strict_order_mr_required(md, params);
     struct ibv_mr *mr_default;
     uct_ib_verbs_mem_t *memh;
     uct_ib_mem_t *ib_memh;

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1287,15 +1287,11 @@ ucs_status_t uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
     md->relaxed_order_required = relaxed_order_required;
     if (relaxed_order_required) {
         if (!have_relaxed_order) {
-            if (is_required) {
-                ucs_error("%s: strong-order memory keys are not supported, but "
-                          "relaxed-order memory access is unavailable",
-                          uct_ib_device_name(&md->dev));
-            } else {
-                ucs_error("%s: IB_PCI_RELAXED_ORDERING=only requested, but "
-                          "IBV_ACCESS_RELAXED_ORDERING is not supported",
-                          uct_ib_device_name(&md->dev));
-            }
+            ucs_error("%s: relaxed-only memory keys required by %s, but "
+                      "IBV_ACCESS_RELAXED_ORDERING is unavailable",
+                      uct_ib_device_name(&md->dev),
+                      is_required ? "firmware" :
+                                    "IB_PCI_RELAXED_ORDERING=only");
             return is_required ? UCS_ERR_IO_ERROR : UCS_ERR_UNSUPPORTED;
         }
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -200,12 +200,14 @@ ucs_config_field_t uct_ib_md_config_table[] = {
     {"PCI_RELAXED_ORDERING", "auto",
      "Control relaxed ordering for PCIe transactions:\n"
      "  no    - disable relaxed ordering\n"
-     "  yes   - request relaxed ordering and warn if it is unsupported\n"
-     "  try   - enable relaxed ordering when supported\n"
+     "  yes   - enable relaxed ordering, retain strict-order companion keys "
+     "when available, and warn if relaxed ordering is unsupported\n"
+     "  try   - enable relaxed ordering when supported, retain strict-order "
+     "companion keys when available, and silently continue if unsupported\n"
      "  auto  - honor a firmware relaxed-only requirement, otherwise use "
      "the CPU preference\n"
-     "  only  - force relaxed-only memory keys regardless of the firmware "
-     "capability\n",
+     "  only  - require all memory keys to use relaxed ordering and do not "
+     "create strict-order companion keys\n",
      ucs_offsetof(uct_ib_md_config_t, mr_relaxed_order),
      UCT_IB_CONFIG_TYPE_RELAXED_ORDER},
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -30,7 +30,6 @@
 #include <pthread_np.h>
 #endif
 #include <sys/resource.h>
-#include <strings.h>
 
 
 #define UCT_IB_MD_RCACHE_DEFAULT_ALIGN 16
@@ -1230,18 +1229,22 @@ static void uct_ib_md_log_relaxed_order(uct_ib_md_t *md)
 {
     UCS_STRING_BUFFER_ONSTACK(strb, 128);
 
+    if (md->relaxed_order_required) {
+        ucs_debug("%s: relaxed order memory access is required for all MRs",
+                  uct_ib_device_name(&md->dev));
+        return;
+    }
+
     if (!uct_ib_md_is_relaxed_order(md)) {
-        ucs_debug("%s: relaxed order memory access is disabled%s",
-                  uct_ib_device_name(&md->dev),
-                  md->relaxed_order_required ? " (required)" : "");
+        ucs_debug("%s: relaxed order memory access is disabled",
+                  uct_ib_device_name(&md->dev));
         return;
     }
 
     ucs_string_buffer_append_flags(&strb, md->relaxed_order_mem_types,
                                    ucs_memory_type_names);
-    ucs_debug("%s: relaxed order memory access is enabled for %s%s",
-              uct_ib_device_name(&md->dev), ucs_string_buffer_cstr(&strb),
-              md->relaxed_order_required ? " (required)" : "");
+    ucs_debug("%s: relaxed order memory access is enabled for %s",
+              uct_ib_device_name(&md->dev), ucs_string_buffer_cstr(&strb));
 }
 
 ucs_status_t uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1262,12 +1262,18 @@ ucs_status_t uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
     md->relaxed_order_required = relaxed_order_required;
     if (relaxed_order_required) {
         if (!have_relaxed_order) {
-            ucs_error("%s: relaxed-only memory keys required by %s, but "
-                      "IBV_ACCESS_RELAXED_ORDERING is unavailable",
-                      uct_ib_device_name(&md->dev),
-                      is_required ? "firmware" :
-                                    "IB_PCI_RELAXED_ORDERING=yes");
-            return is_required ? UCS_ERR_IO_ERROR : UCS_ERR_UNSUPPORTED;
+            if (is_required) {
+                ucs_error("%s: firmware requires relaxed-only memory keys, "
+                          "but IBV_ACCESS_RELAXED_ORDERING is unavailable",
+                          uct_ib_device_name(&md->dev));
+                return UCS_ERR_IO_ERROR;
+            }
+
+            ucs_error("%s: IB_PCI_RELAXED_ORDERING=yes requires relaxed-only "
+                      "memory keys, but IBV_ACCESS_RELAXED_ORDERING is "
+                      "unavailable",
+                      uct_ib_device_name(&md->dev));
+            return UCS_ERR_UNSUPPORTED;
         }
 
         if (md_config->mr_relaxed_order == UCS_NO) {

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1644,13 +1644,15 @@ static ucs_status_t uct_ib_verbs_md_open(struct ibv_device *ibv_device,
     uct_ib_md_ece_check(md);
     status = uct_ib_md_parse_relaxed_order(md, md_config, 0, 0);
     if (status != UCS_OK) {
-        goto err_device_config_release;
+        goto err_md_close;
     }
     uct_ib_md_check_odp(md, md_config);
 
     *p_md = md;
     return UCS_OK;
 
+err_md_close:
+    uct_ib_md_close_common(md);
 err_device_config_release:
     uct_ib_md_release_device_config(md);
 err_md_free:

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -138,7 +138,9 @@ typedef enum {
     UCT_IB_RELAXED_ORDERING_NO   = UCS_NO,   /**< Disable relaxed ordering */
     UCT_IB_RELAXED_ORDERING_YES  = UCS_YES,  /**< Enable; warn if unsupported */
     UCT_IB_RELAXED_ORDERING_TRY  = UCS_TRY,  /**< Enable when supported */
-    UCT_IB_RELAXED_ORDERING_AUTO = UCS_AUTO, /**< Honor firmware requirement */
+    UCT_IB_RELAXED_ORDERING_AUTO = UCS_AUTO, /**< Honor firmware relaxed-only
+                                               *   requirement; otherwise derive
+                                               *   from CPU preference */
     UCT_IB_RELAXED_ORDERING_ONLY            /**< Force relaxed-only keys */
 } uct_ib_relaxed_ordering_t;
 
@@ -178,7 +180,7 @@ typedef struct uct_ib_md {
     uint64_t                 subnet_filter;
     double                   pci_bw;
     uint64_t                 relaxed_order_mem_types;
-    int                      relaxed_order_required; /**< Relaxed-only required */
+    int                      relaxed_order_required; /**< Relaxed-only mode */
     int                      fork_init;
     uint64_t                 reg_mem_types;
     uint64_t                 gva_mem_types;
@@ -343,6 +345,15 @@ static inline uint16_t uct_ib_md_atomic_offset(uint8_t atomic_mr_id)
 }
 
 
+/**
+ * Return the MR type to use for atomic operations on @a md.
+ *
+ * When relaxed ordering is enabled but NOT required (i.e. the device provides
+ * both a relaxed-order default MR and a companion strict-order MR), atomics
+ * must use the strict-order MR (@c UCT_IB_MR_STRICT_ORDER). In all other
+ * cases, relaxed ordering is either disabled or required, and the default MR
+ * is used.
+ */
 static UCS_F_ALWAYS_INLINE uct_ib_mr_type_t
 uct_ib_memh_get_atomic_mr_type(const uct_ib_mem_t *memh)
 {

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -138,8 +138,8 @@ typedef enum {
     UCT_IB_RELAXED_ORDERING_NO   = UCS_NO,   /**< Disable relaxed ordering */
     UCT_IB_RELAXED_ORDERING_YES  = UCS_YES,  /**< Enable; warn if unsupported */
     UCT_IB_RELAXED_ORDERING_TRY  = UCS_TRY,  /**< Enable when supported */
-    UCT_IB_RELAXED_ORDERING_AUTO = UCS_AUTO, /**< Honor firmware requirement; fall back to CPU preference */
-    UCT_IB_RELAXED_ORDERING_ONLY            /**< Force relaxed-only keys (no strict-order MR created) */
+    UCT_IB_RELAXED_ORDERING_AUTO = UCS_AUTO, /**< Honor firmware requirement */
+    UCT_IB_RELAXED_ORDERING_ONLY            /**< Force relaxed-only keys */
 } uct_ib_relaxed_ordering_t;
 
 
@@ -178,7 +178,7 @@ typedef struct uct_ib_md {
     uint64_t                 subnet_filter;
     double                   pci_bw;
     uint64_t                 relaxed_order_mem_types;
-    int                      relaxed_order_required; /**< Non-zero when firmware mandates relaxed-only keys */
+    int                      relaxed_order_required; /**< Firmware required */
     int                      fork_init;
     uint64_t                 reg_mem_types;
     uint64_t                 gva_mem_types;
@@ -228,7 +228,7 @@ typedef struct uct_ib_md_config {
     int                      mlx5dv; /**< mlx5 support */
     int                      devx; /**< DEVX support */
     uint64_t                 devx_objs;    /**< Objects to be created by DevX */
-    uct_ib_relaxed_ordering_t mr_relaxed_order; /**< Relaxed-ordering mode (no/yes/try/auto/only) */
+    uct_ib_relaxed_ordering_t mr_relaxed_order; /**< Relaxed-ordering mode */
     int                      enable_gpudirect_rdma; /**< Enable GPUDirect RDMA */
     int                      xgvmi_umr_enable; /**< Enable UMR workflow for XGVMI */
 } uct_ib_md_config_t;

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -178,7 +178,7 @@ typedef struct uct_ib_md {
     uint64_t                 subnet_filter;
     double                   pci_bw;
     uint64_t                 relaxed_order_mem_types;
-    int                      relaxed_order_required; /**< Firmware required */
+    int                      relaxed_order_required; /**< Relaxed-only required */
     int                      fork_init;
     uint64_t                 reg_mem_types;
     uint64_t                 gva_mem_types;

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -130,12 +130,16 @@ typedef struct {
 } uct_ib_mem_t;
 
 
+/**
+ * PCIe relaxed-ordering mode for IB memory registrations.
+ * Mirrors UCT_IB_PCI_RELAXED_ORDERING configuration values.
+ */
 typedef enum {
-    UCT_IB_RELAXED_ORDERING_NO   = UCS_NO,
-    UCT_IB_RELAXED_ORDERING_YES  = UCS_YES,
-    UCT_IB_RELAXED_ORDERING_TRY  = UCS_TRY,
-    UCT_IB_RELAXED_ORDERING_AUTO = UCS_AUTO,
-    UCT_IB_RELAXED_ORDERING_ONLY
+    UCT_IB_RELAXED_ORDERING_NO   = UCS_NO,   /**< Disable relaxed ordering */
+    UCT_IB_RELAXED_ORDERING_YES  = UCS_YES,  /**< Enable; warn if unsupported */
+    UCT_IB_RELAXED_ORDERING_TRY  = UCS_TRY,  /**< Enable when supported */
+    UCT_IB_RELAXED_ORDERING_AUTO = UCS_AUTO, /**< Honor firmware requirement; fall back to CPU preference */
+    UCT_IB_RELAXED_ORDERING_ONLY            /**< Force relaxed-only keys (no strict-order MR created) */
 } uct_ib_relaxed_ordering_t;
 
 
@@ -147,8 +151,9 @@ typedef struct {
 typedef enum {
     /* Default memory region with either strict or relaxed order */
     UCT_IB_MR_DEFAULT,
-    /* Additional memory region with strict order,
-     * if the default region is relaxed order */
+    /* Additional strict-order memory region allocated alongside the default
+     * relaxed-order MR, only when relaxed_order is set and
+     * relaxed_order_required is not (i.e. the device supports both modes) */
     UCT_IB_MR_STRICT_ORDER,
     UCT_IB_MR_LAST
 } uct_ib_mr_type_t;
@@ -173,7 +178,7 @@ typedef struct uct_ib_md {
     uint64_t                 subnet_filter;
     double                   pci_bw;
     uint64_t                 relaxed_order_mem_types;
-    int                      relaxed_order_required;
+    int                      relaxed_order_required; /**< Non-zero when firmware mandates relaxed-only keys */
     int                      fork_init;
     uint64_t                 reg_mem_types;
     uint64_t                 gva_mem_types;
@@ -223,7 +228,7 @@ typedef struct uct_ib_md_config {
     int                      mlx5dv; /**< mlx5 support */
     int                      devx; /**< DEVX support */
     uint64_t                 devx_objs;    /**< Objects to be created by DevX */
-    uct_ib_relaxed_ordering_t mr_relaxed_order; /**< Allow reorder memory accesses */
+    uct_ib_relaxed_ordering_t mr_relaxed_order; /**< Relaxed-ordering mode (no/yes/try/auto/only) */
     int                      enable_gpudirect_rdma; /**< Enable GPUDirect RDMA */
     int                      xgvmi_umr_enable; /**< Enable UMR workflow for XGVMI */
 } uct_ib_md_config_t;
@@ -387,6 +392,10 @@ uct_ib_memh_is_relaxed_order(uct_ib_md_t *md,
     return !!(md->relaxed_order_mem_types & UCS_BIT(mem_type));
 }
 
+/**
+ * Augment @a access_flags with IBV_ACCESS_RELAXED_ORDERING when the memory
+ * domain requires relaxed-only memory keys (relaxed_order_required is set).
+ */
 static UCS_F_ALWAYS_INLINE uint64_t
 uct_ib_md_access_flags(const uct_ib_md_t *md, uint64_t access_flags)
 {
@@ -418,6 +427,11 @@ static UCS_F_ALWAYS_INLINE uint8_t uct_ib_md_get_atomic_mr_id(uct_ib_md_t *md)
     return md->flush_rkey >> 8;
 }
 
+/**
+ * Return non-zero when relaxed-only memory keys are required, either because
+ * the firmware capability @a fw_required is set or the user selected
+ * UCT_IB_RELAXED_ORDERING_ONLY via configuration.
+ */
 static UCS_F_ALWAYS_INLINE int uct_ib_md_is_relaxed_order_required(
         const uct_ib_md_config_t *md_config, int fw_required)
 {
@@ -425,6 +439,19 @@ static UCS_F_ALWAYS_INLINE int uct_ib_md_is_relaxed_order_required(
            (md_config->mr_relaxed_order == UCT_IB_RELAXED_ORDERING_ONLY);
 }
 
+/**
+ * Apply the relaxed-ordering configuration to @a md.
+ *
+ * @param md           IB memory domain being initialised.
+ * @param md_config    User configuration for the MD.
+ * @param is_supported Non-zero when the hardware/driver supports relaxed
+ *                     ordering (e.g. KSM indirect key can be created).
+ * @param is_required  Non-zero when the firmware requires relaxed-only keys
+ *                     (mkc_order_write_after_write_ro_only capability).
+ *
+ * @return UCS_OK on success, or an error if the requested mode is incompatible
+ *         with hardware capabilities.
+ */
 ucs_status_t uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
                                            const uct_ib_md_config_t *md_config,
                                            int is_supported, int is_required);

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -77,8 +77,9 @@ enum {
                                                         GVA region */
     UCT_IB_MEM_DIRECT_NIC            = UCS_BIT(6), /**< The memory handle was
                                                         registered using Direct NIC */
-    UCT_IB_MEM_RELAXED_ORDER         = UCS_BIT(7), /**< Relaxed ordering is enabled
-                                                        for this memory handle */
+    UCT_IB_MEM_STRICT_ORDER_MR       = UCS_BIT(7), /**< A strict-order MR is
+                                                        allocated alongside the
+                                                        relaxed-order default MR */
 };
 
 enum {
@@ -329,9 +330,15 @@ static inline uint16_t uct_ib_md_atomic_offset(uint8_t atomic_mr_id)
     return 8 * atomic_mr_id;
 }
 
+static UCS_F_ALWAYS_INLINE int
+uct_ib_memh_uses_strict_order_mr(const uct_ib_mem_t *memh)
+{
+    return !!(memh->flags & UCT_IB_MEM_STRICT_ORDER_MR);
+}
+
 
 /**
- * Return the MR type to use for atomic operations on @a md.
+ * Return the MR type to use for atomic operations on @a memh.
  *
  * When relaxed ordering is enabled but NOT required, the memory domain has a
  * relaxed-order default MR and a companion strict-order MR. Atomics must use
@@ -341,7 +348,7 @@ static inline uint16_t uct_ib_md_atomic_offset(uint8_t atomic_mr_id)
 static UCS_F_ALWAYS_INLINE uct_ib_mr_type_t
 uct_ib_memh_get_atomic_mr_type(const uct_ib_mem_t *memh)
 {
-    return (memh->flags & UCT_IB_MEM_RELAXED_ORDER) ?
+    return uct_ib_memh_uses_strict_order_mr(memh) ?
            UCT_IB_MR_STRICT_ORDER : UCT_IB_MR_DEFAULT;
 }
 
@@ -369,8 +376,8 @@ uct_ib_md_is_relaxed_order(const uct_ib_md_t *md)
 }
 
 static UCS_F_ALWAYS_INLINE int
-uct_ib_memh_is_relaxed_order(uct_ib_md_t *md,
-                             const uct_md_mem_reg_params_t *params)
+uct_ib_md_needs_strict_order_mr(
+        const uct_ib_md_t *md, const uct_md_mem_reg_params_t *params)
 {
     ucs_memory_type_t mem_type;
 
@@ -532,7 +539,7 @@ ucs_status_t uct_ib_fork_init(const uct_ib_md_config_t *md_config,
                               int *fork_init_p);
 
 ucs_status_t uct_ib_memh_alloc(uct_ib_md_t *md, size_t length,
-                               unsigned mem_flags, int relaxed_order,
+                               unsigned mem_flags, int strict_order_mr,
                                size_t memh_base_size, size_t mr_size,
                                uct_ib_mem_t **memh_p);
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -376,7 +376,7 @@ uct_ib_md_is_relaxed_order(const uct_ib_md_t *md)
 }
 
 static UCS_F_ALWAYS_INLINE int
-uct_ib_md_needs_strict_order_mr(
+uct_ib_md_is_strict_order_mr_required(
         const uct_ib_md_t *md, const uct_md_mem_reg_params_t *params)
 {
     ucs_memory_type_t mem_type;

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -130,21 +130,6 @@ typedef struct {
 } uct_ib_mem_t;
 
 
-/**
- * PCIe relaxed-ordering mode for IB memory registrations.
- * Mirrors UCT_IB_PCI_RELAXED_ORDERING configuration values.
- */
-typedef enum {
-    UCT_IB_RELAXED_ORDERING_NO   = UCS_NO,   /**< Disable relaxed ordering */
-    UCT_IB_RELAXED_ORDERING_YES  = UCS_YES,  /**< Enable; warn if unsupported */
-    UCT_IB_RELAXED_ORDERING_TRY  = UCS_TRY,  /**< Enable when supported */
-    UCT_IB_RELAXED_ORDERING_AUTO = UCS_AUTO, /**< Honor firmware relaxed-only
-                                               *   requirement; otherwise derive
-                                               *   from CPU preference */
-    UCT_IB_RELAXED_ORDERING_ONLY            /**< Force relaxed-only keys */
-} uct_ib_relaxed_ordering_t;
-
-
 typedef struct {
     struct ibv_mr           *ib;
 } uct_ib_mr_t;
@@ -155,7 +140,7 @@ typedef enum {
     UCT_IB_MR_DEFAULT,
     /* Additional strict-order memory region allocated alongside the default
      * relaxed-order MR, only when relaxed_order is set and
-     * relaxed_order_required is not (i.e. the device supports both modes) */
+     * relaxed_order_required is not (i.e. the policy allows both modes) */
     UCT_IB_MR_STRICT_ORDER,
     UCT_IB_MR_LAST
 } uct_ib_mr_type_t;
@@ -230,7 +215,7 @@ typedef struct uct_ib_md_config {
     int                      mlx5dv; /**< mlx5 support */
     int                      devx; /**< DEVX support */
     uint64_t                 devx_objs;    /**< Objects to be created by DevX */
-    uct_ib_relaxed_ordering_t mr_relaxed_order; /**< Relaxed-ordering mode */
+    ucs_ternary_auto_value_t  mr_relaxed_order; /**< Relaxed-ordering mode */
     int                      enable_gpudirect_rdma; /**< Enable GPUDirect RDMA */
     int                      xgvmi_umr_enable; /**< Enable UMR workflow for XGVMI */
 } uct_ib_md_config_t;
@@ -348,11 +333,10 @@ static inline uint16_t uct_ib_md_atomic_offset(uint8_t atomic_mr_id)
 /**
  * Return the MR type to use for atomic operations on @a md.
  *
- * When relaxed ordering is enabled but NOT required (i.e. the device provides
- * both a relaxed-order default MR and a companion strict-order MR), atomics
- * must use the strict-order MR (@c UCT_IB_MR_STRICT_ORDER). In all other
- * cases, relaxed ordering is either disabled or required, and the default MR
- * is used.
+ * When relaxed ordering is enabled but NOT required, the memory domain has a
+ * relaxed-order default MR and a companion strict-order MR. Atomics must use
+ * the strict-order MR (@c UCT_IB_MR_STRICT_ORDER). In all other cases, relaxed
+ * ordering is either disabled or required, and the default MR is used.
  */
 static UCS_F_ALWAYS_INLINE uct_ib_mr_type_t
 uct_ib_memh_get_atomic_mr_type(const uct_ib_mem_t *memh)
@@ -441,13 +425,12 @@ static UCS_F_ALWAYS_INLINE uint8_t uct_ib_md_get_atomic_mr_id(uct_ib_md_t *md)
 /**
  * Return non-zero when relaxed-only memory keys are required, either because
  * the firmware capability @a fw_required is set or the user selected
- * UCT_IB_RELAXED_ORDERING_ONLY via configuration.
+ * UCS_YES via configuration.
  */
 static UCS_F_ALWAYS_INLINE int uct_ib_md_is_relaxed_order_required(
         const uct_ib_md_config_t *md_config, int fw_required)
 {
-    return fw_required ||
-           (md_config->mr_relaxed_order == UCT_IB_RELAXED_ORDERING_ONLY);
+    return fw_required || (md_config->mr_relaxed_order == UCS_YES);
 }
 
 /**

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -130,6 +130,15 @@ typedef struct {
 } uct_ib_mem_t;
 
 
+typedef enum {
+    UCT_IB_RELAXED_ORDERING_NO   = UCS_NO,
+    UCT_IB_RELAXED_ORDERING_YES  = UCS_YES,
+    UCT_IB_RELAXED_ORDERING_TRY  = UCS_TRY,
+    UCT_IB_RELAXED_ORDERING_AUTO = UCS_AUTO,
+    UCT_IB_RELAXED_ORDERING_ONLY
+} uct_ib_relaxed_ordering_t;
+
+
 typedef struct {
     struct ibv_mr           *ib;
 } uct_ib_mr_t;
@@ -164,6 +173,7 @@ typedef struct uct_ib_md {
     uint64_t                 subnet_filter;
     double                   pci_bw;
     uint64_t                 relaxed_order_mem_types;
+    int                      relaxed_order_required;
     int                      fork_init;
     uint64_t                 reg_mem_types;
     uint64_t                 gva_mem_types;
@@ -213,7 +223,7 @@ typedef struct uct_ib_md_config {
     int                      mlx5dv; /**< mlx5 support */
     int                      devx; /**< DEVX support */
     uint64_t                 devx_objs;    /**< Objects to be created by DevX */
-    ucs_ternary_auto_value_t mr_relaxed_order; /**< Allow reorder memory accesses */
+    uct_ib_relaxed_ordering_t mr_relaxed_order; /**< Allow reorder memory accesses */
     int                      enable_gpudirect_rdma; /**< Enable GPUDirect RDMA */
     int                      xgvmi_umr_enable; /**< Enable UMR workflow for XGVMI */
 } uct_ib_md_config_t;
@@ -364,6 +374,10 @@ uct_ib_memh_is_relaxed_order(uct_ib_md_t *md,
 {
     ucs_memory_type_t mem_type;
 
+    if (md->relaxed_order_required) {
+        return 0;
+    }
+
     mem_type = (params == NULL) ? UCS_MEMORY_TYPE_HOST :
                UCT_MD_MEM_REG_FIELD_VALUE(params, mem_type, FIELD_MEM_TYPE,
                                           UCS_MEMORY_TYPE_HOST);
@@ -371,6 +385,14 @@ uct_ib_memh_is_relaxed_order(uct_ib_md_t *md,
     ucs_assert(mem_type < UCS_MEMORY_TYPE_LAST);
 
     return !!(md->relaxed_order_mem_types & UCS_BIT(mem_type));
+}
+
+static UCS_F_ALWAYS_INLINE uint64_t
+uct_ib_md_access_flags(const uct_ib_md_t *md, uint64_t access_flags)
+{
+    return md->relaxed_order_required ?
+                   (access_flags | IBV_ACCESS_RELAXED_ORDERING) :
+                   access_flags;
 }
 
 static UCS_F_ALWAYS_INLINE uint32_t uct_ib_memh_get_lkey(uct_mem_h memh)
@@ -396,9 +418,16 @@ static UCS_F_ALWAYS_INLINE uint8_t uct_ib_md_get_atomic_mr_id(uct_ib_md_t *md)
     return md->flush_rkey >> 8;
 }
 
-void uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
-                                   const uct_ib_md_config_t *md_config,
-                                   int is_supported);
+static UCS_F_ALWAYS_INLINE int uct_ib_md_is_relaxed_order_required(
+        const uct_ib_md_config_t *md_config, int fw_required)
+{
+    return fw_required ||
+           (md_config->mr_relaxed_order == UCT_IB_RELAXED_ORDERING_ONLY);
+}
+
+ucs_status_t uct_ib_md_parse_relaxed_order(uct_ib_md_t *md,
+                                           const uct_ib_md_config_t *md_config,
+                                           int is_supported, int is_required);
 
 ucs_status_t uct_ib_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr);
 

--- a/src/uct/ib/base/ib_md.h
+++ b/src/uct/ib/base/ib_md.h
@@ -215,7 +215,7 @@ typedef struct uct_ib_md_config {
     int                      mlx5dv; /**< mlx5 support */
     int                      devx; /**< DEVX support */
     uint64_t                 devx_objs;    /**< Objects to be created by DevX */
-    ucs_ternary_auto_value_t  mr_relaxed_order; /**< Relaxed-ordering mode */
+    ucs_ternary_auto_value_t mr_relaxed_order; /**< Relaxed-ordering mode */
     int                      enable_gpudirect_rdma; /**< Enable GPUDirect RDMA */
     int                      xgvmi_umr_enable; /**< Enable UMR workflow for XGVMI */
 } uct_ib_md_config_t;

--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -361,7 +361,9 @@ struct uct_ib_mlx5_cmd_hca_cap_bits {
     uint8_t    ext_stride_num_range[0x1];
     uint8_t    reserved_at_3a1[0x2];
     uint8_t    log_max_stride_sz_rq[0x5];
-    uint8_t    reserved_at_3a8[0x3];
+    uint8_t    mkc_order_read_after_write[0x1];
+    uint8_t    mkc_order_write_after_write_ro_only[0x1];
+    uint8_t    reserved_at_3aa[0x1];
     uint8_t    log_min_stride_sz_rq[0x5];
     uint8_t    reserved_at_3b0[0x3];
     uint8_t    log_max_stride_sz_sq[0x5];

--- a/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
+++ b/src/uct/ib/mlx5/dv/ib_mlx5_ifc.h
@@ -361,7 +361,7 @@ struct uct_ib_mlx5_cmd_hca_cap_bits {
     uint8_t    ext_stride_num_range[0x1];
     uint8_t    reserved_at_3a1[0x2];
     uint8_t    log_max_stride_sz_rq[0x5];
-    uint8_t    mkc_order_read_after_write[0x1];
+    uint8_t    reserved_at_3a8[0x1];
     uint8_t    mkc_order_write_after_write_ro_only[0x1];
     uint8_t    reserved_at_3aa[0x1];
     uint8_t    log_min_stride_sz_rq[0x5];

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -805,6 +805,7 @@ uct_ib_mlx5_direct_nic_reg_mr(uct_ib_mlx5_md_t *md, void *address,
 
     dmabuf_offset = UCS_PARAM_VALUE(UCT_MD_MEM_REG_FIELD, params, dmabuf_offset,
                                     DMABUF_OFFSET, 0);
+    access_flags  = uct_ib_md_access_flags(&md->super, access_flags);
     start_time    = ucs_get_time();
 
     mr = UCS_PROFILE_CALL_ALWAYS(mlx5dv_reg_dmabuf_mr, md->super.pd, 0,
@@ -834,7 +835,7 @@ uct_ib_mlx5_devx_memh_has_ro(uct_ib_mlx5_md_t *md,
         return md->flags & UCT_IB_MLX5_MD_FLAG_GVA_RO;
     }
 
-    return memh->super.flags & UCT_IB_MEM_RELAXED_ORDER;
+    return uct_ib_memh_uses_strict_order_mr(&memh->super);
 }
 
 static ucs_status_t
@@ -929,20 +930,6 @@ uct_ib_mlx5_devx_memh_alloc(uct_ib_mlx5_md_t *md, size_t length,
     return UCS_OK;
 }
 
-static int uct_ib_mlx5_devx_memh_has_strict_order_mr(
-        uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mem_t *memh)
-{
-    if (md->super.relaxed_order_required) {
-        return 0;
-    }
-
-    if (memh->super.flags & UCT_IB_MEM_FLAG_GVA) {
-        return md->flags & UCT_IB_MLX5_MD_FLAG_GVA_RO;
-    }
-
-    return memh->super.flags & UCT_IB_MEM_RELAXED_ORDER;
-}
-
 static ucs_status_t
 uct_ib_mlx5_devx_mem_reg_gva(uct_md_h uct_md, unsigned flags, uct_mem_h *memh_p)
 {
@@ -952,11 +939,14 @@ uct_ib_mlx5_devx_mem_reg_gva(uct_md_h uct_md, unsigned flags, uct_mem_h *memh_p)
     uint64_t access_flags;
     ucs_status_t status;
     int relaxed_order;
+    int strict_order_mr;
 
     relaxed_order = md->flags & UCT_IB_MLX5_MD_FLAG_GVA_RO;
+    strict_order_mr = relaxed_order && !md->super.relaxed_order_required;
     status = uct_ib_mlx5_devx_memh_alloc(md, SIZE_MAX,
                                          UCT_MD_MEM_FLAG_NONBLOCK | flags,
-                                         relaxed_order, sizeof(memh->mrs[0]),
+                                         strict_order_mr,
+                                         sizeof(memh->mrs[0]),
                                          &memh);
     if (status != UCS_OK) {
         goto err;
@@ -970,7 +960,7 @@ uct_ib_mlx5_devx_mem_reg_gva(uct_md_h uct_md, unsigned flags, uct_mem_h *memh_p)
         goto err_reg;
     }
 
-    if (relaxed_order && !md->super.relaxed_order_required) {
+    if (strict_order_mr) {
         status = uct_ib_reg_mr(&md->super, NULL, SIZE_MAX, &params,
                                access_flags & ~IBV_ACCESS_RELAXED_ORDERING,
                                NULL,
@@ -1003,15 +993,15 @@ uct_ib_mlx5_devx_mem_reg(uct_md_h uct_md, void *address, size_t length,
     uct_ib_mlx5_devx_mem_t *memh;
     ucs_status_t status;
     uint32_t dummy_mkey;
-    int relaxed_order;
+    int strict_order_mr;
 
     if (flags & UCT_MD_MEM_GVA) {
         return uct_ib_mlx5_devx_mem_reg_gva(uct_md, flags, memh_p);
     }
 
-    relaxed_order = uct_ib_memh_is_relaxed_order(&md->super, params);
-    status        = uct_ib_mlx5_devx_memh_alloc(md, length, flags,
-                                                relaxed_order,
+    strict_order_mr =
+            uct_ib_md_needs_strict_order_mr(&md->super, params);
+    status = uct_ib_mlx5_devx_memh_alloc(md, length, flags, strict_order_mr,
                                          sizeof(memh->mrs[0]), &memh);
     if (status != UCS_OK) {
         goto err;
@@ -1028,7 +1018,7 @@ uct_ib_mlx5_devx_mem_reg(uct_md_h uct_md, void *address, size_t length,
         uct_ib_mlx5_devx_reg_symmetric(md, memh, address);
     }
 
-    if (uct_ib_mlx5_devx_memh_has_strict_order_mr(md, memh)) {
+    if (uct_ib_memh_uses_strict_order_mr(&memh->super)) {
         status = uct_ib_mlx5_devx_reg_mr(md, memh, address, length, params,
                                          UCT_IB_MR_STRICT_ORDER,
                                          ~IBV_ACCESS_RELAXED_ORDERING,
@@ -1696,7 +1686,7 @@ uct_ib_mlx5_devx_mem_dereg(uct_md_h uct_md,
     }
 
     if (!(memh->super.flags & UCT_IB_MEM_IMPORTED)) {
-        if (uct_ib_mlx5_devx_memh_has_strict_order_mr(md, memh)) {
+        if (uct_ib_memh_uses_strict_order_mr(&memh->super)) {
             status = uct_ib_mlx5_devx_dereg_mr(md, memh,
                                                UCT_IB_MR_STRICT_ORDER);
             if (status != UCS_OK) {
@@ -3017,7 +3007,7 @@ uct_ib_mlx5_devx_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
      */
     if (ucs_unlikely(memh->atomic_dvmr == NULL) &&
         ((memh->super.flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC) ||
-         uct_ib_mlx5_devx_memh_has_strict_order_mr(md, memh)) &&
+         uct_ib_memh_uses_strict_order_mr(&memh->super)) &&
         !(memh->super.flags & UCT_IB_MEM_IMPORTED) &&
         !(memh->super.flags & UCT_IB_MEM_DIRECT_NIC) &&
         md->super.config.enable_indirect_atomic &&

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -159,6 +159,8 @@ uct_ib_mlx5_devx_reg_ksm(uct_ib_mlx5_md_t *md, uint64_t address, size_t length,
     UCT_IB_MLX5DV_SET(mkc, mkc, rr, 1);
     UCT_IB_MLX5DV_SET(mkc, mkc, lw, 1);
     UCT_IB_MLX5DV_SET(mkc, mkc, lr, 1);
+    UCT_IB_MLX5DV_SET(mkc, mkc, relaxed_ordering_write,
+                      md->super.relaxed_order_required);
     UCT_IB_MLX5DV_SET(mkc, mkc, pd, uct_ib_mlx5_devx_md_get_pdn(md));
     UCT_IB_MLX5DV_SET(mkc, mkc, translations_octword_size, list_size);
     UCT_IB_MLX5DV_SET(mkc, mkc, log_entity_size, ucs_ilog2(entity_size));
@@ -927,6 +929,21 @@ uct_ib_mlx5_devx_memh_alloc(uct_ib_mlx5_md_t *md, size_t length,
     return UCS_OK;
 }
 
+static int uct_ib_mlx5_devx_memh_has_strict_order_mr(
+        uct_ib_mlx5_md_t *md, uct_ib_mlx5_devx_mem_t *memh)
+{
+    if (md->super.relaxed_order_required) {
+        return 0;
+    }
+
+    if (memh->super.flags & UCT_IB_MEM_FLAG_GVA) {
+        return md->flags & UCT_IB_MLX5_MD_FLAG_GVA_RO;
+    }
+
+    return memh->super.flags & UCT_IB_MEM_RELAXED_ORDER;
+}
+
+
 static ucs_status_t
 uct_ib_mlx5_devx_mem_reg_gva(uct_md_h uct_md, unsigned flags, uct_mem_h *memh_p)
 {
@@ -954,7 +971,7 @@ uct_ib_mlx5_devx_mem_reg_gva(uct_md_h uct_md, unsigned flags, uct_mem_h *memh_p)
         goto err_reg;
     }
 
-    if (relaxed_order) {
+    if (relaxed_order && !md->super.relaxed_order_required) {
         status = uct_ib_reg_mr(&md->super, NULL, SIZE_MAX, &params,
                                access_flags & ~IBV_ACCESS_RELAXED_ORDERING,
                                NULL,
@@ -1012,7 +1029,7 @@ uct_ib_mlx5_devx_mem_reg(uct_md_h uct_md, void *address, size_t length,
         uct_ib_mlx5_devx_reg_symmetric(md, memh, address);
     }
 
-    if (uct_ib_mlx5_devx_memh_has_ro(md, memh)) {
+    if (uct_ib_mlx5_devx_memh_has_strict_order_mr(md, memh)) {
         status = uct_ib_mlx5_devx_reg_mr(md, memh, address, length, params,
                                          UCT_IB_MR_STRICT_ORDER,
                                          ~IBV_ACCESS_RELAXED_ORDERING,
@@ -1680,7 +1697,7 @@ uct_ib_mlx5_devx_mem_dereg(uct_md_h uct_md,
     }
 
     if (!(memh->super.flags & UCT_IB_MEM_IMPORTED)) {
-        if (uct_ib_mlx5_devx_memh_has_ro(md, memh)) {
+        if (uct_ib_mlx5_devx_memh_has_strict_order_mr(md, memh)) {
             status = uct_ib_mlx5_devx_dereg_mr(md, memh,
                                                UCT_IB_MR_STRICT_ORDER);
             if (status != UCS_OK) {
@@ -2183,7 +2200,8 @@ uct_ib_mlx5_devx_device_mem_alloc(uct_md_h uct_md, size_t *length_p,
         goto err_free_dm;
     }
 
-    reg_params.field_mask = 0;
+    reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS;
+    reg_params.flags      = flags & UCT_MD_MEM_FLAG_HIDE_ERRORS;
     status = uct_ib_reg_mr(md, address, dm_attr.length, &reg_params,
                            UCT_IB_MEM_ACCESS_FLAGS, dm,
                            &memh->mrs[UCT_IB_MR_DEFAULT].super.ib);
@@ -2281,7 +2299,8 @@ static void uct_ib_mlx5dv_check_dm_ksm_reg(uct_ib_mlx5_md_t *md)
 
     status = uct_ib_mlx5_devx_device_mem_alloc(uct_md, &length, &address,
                                                UCS_MEMORY_TYPE_RDMA,
-                                               UCS_SYS_DEVICE_ID_UNKNOWN, 0,
+                                               UCS_SYS_DEVICE_ID_UNKNOWN,
+                                               UCT_MD_MEM_FLAG_HIDE_ERRORS,
                                                "check dm ksm registration",
                                                &memh);
     if (status != UCS_OK) {
@@ -2329,6 +2348,7 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
     ucs_mpool_params_t mp_params;
     int ksm_atomic;
     int odp_version;
+    int relaxed_order_required;
     uint64_t devx_objs;
 
     buf = ucs_calloc(1, total_len, "mlx5_devx_buffers");
@@ -2395,6 +2415,14 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
     if (status != UCS_OK) {
         goto err_lru_cleanup;
     }
+
+    relaxed_order_required = UCT_IB_MLX5DV_GET(
+            cmd_hca_cap, cap, mkc_order_write_after_write_ro_only);
+    ucs_debug("%s: mkey ordering: read-after-write=%d relaxed-only=%d",
+              uct_ib_device_name(dev),
+              UCT_IB_MLX5DV_GET(cmd_hca_cap, cap,
+                                mkc_order_read_after_write),
+              relaxed_order_required);
 
     UCS_STATIC_ASSERT(UCS_MASK(UCT_IB_MLX5_MD_MAX_DCI_CHANNELS) <= UINT8_MAX);
     md->log_max_dci_stream_channels = UCT_IB_MLX5DV_GET(cmd_hca_cap, cap,
@@ -2621,12 +2649,21 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
             ksm_atomic           = 1;
         }
 
-        uct_ib_mlx5dv_check_dm_ksm_reg(md);
     }
 
-    /* Enable relaxed order only if we would be able to create an indirect key
-       (with offset) for strict order access */
-    uct_ib_md_parse_relaxed_order(&md->super, md_config, ksm_atomic);
+    /* Optional relaxed ordering requires an indirect strict-order key. A
+     * relaxed-only device cannot create that key and uses the default key for
+     * all access instead. */
+    status = uct_ib_md_parse_relaxed_order(
+            &md->super, md_config, ksm_atomic || relaxed_order_required,
+            relaxed_order_required);
+    if (status != UCS_OK) {
+        goto err_zero_mem_free;
+    }
+
+    if (md->flags & UCT_IB_MLX5_MD_FLAG_KSM) {
+        uct_ib_mlx5dv_check_dm_ksm_reg(md);
+    }
 
     uct_ib_mlx5_devx_init_flush_mr(md);
 
@@ -2642,7 +2679,8 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
         if (status == UCS_OK) {
             md->super.cap_flags |= UCT_MD_FLAG_EXPORTED_MKEY;
 
-            if (md_config->xgvmi_umr_enable == UCS_YES) {
+            if ((md_config->xgvmi_umr_enable == UCS_YES) &&
+                !md->super.relaxed_order_required) {
                 md->flags |= UCT_IB_MLX5_MD_FLAG_XGVMI_UMR;
             }
         }
@@ -2655,6 +2693,8 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
     ucs_free(buf);
     return UCS_OK;
 
+err_zero_mem_free:
+    uct_ib_mlx5_md_buf_free(md, md->zero_buf, &md->zero_mem);
 err_dbrec_mpool_cleanup:
     ucs_mpool_cleanup(&md->dbrec_pool, 0);
 err_lock_destroy:
@@ -2978,7 +3018,7 @@ uct_ib_mlx5_devx_mkey_pack(uct_md_h uct_md, uct_mem_h uct_memh,
      */
     if (ucs_unlikely(memh->atomic_dvmr == NULL) &&
         ((memh->super.flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC) ||
-         uct_ib_mlx5_devx_memh_has_ro(md, memh)) &&
+         uct_ib_mlx5_devx_memh_has_strict_order_mr(md, memh)) &&
         !(memh->super.flags & UCT_IB_MEM_IMPORTED) &&
         !(memh->super.flags & UCT_IB_MEM_DIRECT_NIC) &&
         md->super.config.enable_indirect_atomic &&
@@ -3400,7 +3440,7 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
     dev->flags    |= UCT_IB_DEVICE_FLAG_MLX5_PRM;
     md->super.name = UCT_IB_MD_NAME(mlx5);
 
-    uct_ib_md_parse_relaxed_order(&md->super, md_config, 0);
+    (void)uct_ib_md_parse_relaxed_order(&md->super, md_config, 0, 0);
     uct_ib_md_ece_check(&md->super);
     uct_ib_md_check_odp(&md->super, md_config);
     md->direct_nic_sys_dev =

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -2651,9 +2651,9 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
 
     }
 
-    /* Optional relaxed ordering requires an indirect strict-order key. A
-     * relaxed-only device cannot create that key and uses the default key for
-     * all access instead. */
+    /* Optional relaxed ordering requires an indirect strict-order key.
+     * Relaxed-only policy omits that key and uses the default key for all
+     * access instead. */
     status = uct_ib_md_parse_relaxed_order(
             &md->super, md_config, ksm_atomic || relaxed_order_required,
             relaxed_order_required);

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -943,7 +943,6 @@ static int uct_ib_mlx5_devx_memh_has_strict_order_mr(
     return memh->super.flags & UCT_IB_MEM_RELAXED_ORDER;
 }
 
-
 static ucs_status_t
 uct_ib_mlx5_devx_mem_reg_gva(uct_md_h uct_md, unsigned flags, uct_mem_h *memh_p)
 {

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -1000,7 +1000,7 @@ uct_ib_mlx5_devx_mem_reg(uct_md_h uct_md, void *address, size_t length,
     }
 
     strict_order_mr =
-            uct_ib_md_needs_strict_order_mr(&md->super, params);
+            uct_ib_md_is_strict_order_mr_required(&md->super, params);
     status = uct_ib_mlx5_devx_memh_alloc(md, length, flags, strict_order_mr,
                                          sizeof(memh->mrs[0]), &memh);
     if (status != UCS_OK) {

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -3440,7 +3440,10 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
     dev->flags    |= UCT_IB_DEVICE_FLAG_MLX5_PRM;
     md->super.name = UCT_IB_MD_NAME(mlx5);
 
-    (void)uct_ib_md_parse_relaxed_order(&md->super, md_config, 0, 0);
+    status = uct_ib_md_parse_relaxed_order(&md->super, md_config, 0, 0);
+    if (status != UCS_OK) {
+        goto err_md_free;
+    }
     uct_ib_md_ece_check(&md->super);
     uct_ib_md_check_odp(&md->super, md_config);
     md->direct_nic_sys_dev =

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -3431,7 +3431,7 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
 
     status = uct_ib_md_parse_relaxed_order(&md->super, md_config, 0, 0);
     if (status != UCS_OK) {
-        goto err_md_free;
+        goto err_md_close;
     }
     uct_ib_md_ece_check(&md->super);
     uct_ib_md_check_odp(&md->super, md_config);
@@ -3444,6 +3444,8 @@ static ucs_status_t uct_ib_mlx5dv_md_open(struct ibv_device *ibv_device,
     *p_md = &md->super;
     return UCS_OK;
 
+err_md_close:
+    uct_ib_md_close_common(&md->super);
 err_md_free:
     uct_ib_md_free(&md->super);
 err_free_context:

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -2407,10 +2407,7 @@ ucs_status_t uct_ib_mlx5_devx_md_open_common(const char *name, size_t size,
 
     relaxed_order_required = UCT_IB_MLX5DV_GET(
             cmd_hca_cap, cap, mkc_order_write_after_write_ro_only);
-    ucs_debug("%s: mkey ordering: read-after-write=%d relaxed-only=%d",
-              uct_ib_device_name(dev),
-              UCT_IB_MLX5DV_GET(cmd_hca_cap, cap,
-                                mkc_order_read_after_write),
+    ucs_debug("%s: relaxed-only memory keys %d", uct_ib_device_name(dev),
               relaxed_order_required);
 
     UCS_STATIC_ASSERT(UCS_MASK(UCT_IB_MLX5_MD_MAX_DCI_CHANNELS) <= UINT8_MAX);

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -399,6 +399,7 @@ static UCS_CLASS_INIT_FUNC(uct_gga_mlx5_ep_t, const uct_ep_params_t *params)
     uct_iface_t *tl_iface   = UCT_EP_PARAM_VALUE(params, iface, IFACE, NULL);
     uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
     uct_ib_mlx5_md_t *md    = ucs_derived_of(iface->md, uct_ib_mlx5_md_t);
+    uint64_t access_flags;
     int ret;
     ucs_status_t status;
 
@@ -413,15 +414,17 @@ static UCS_CLASS_INIT_FUNC(uct_gga_mlx5_ep_t, const uct_ep_params_t *params)
         goto err;
     }
 
+    access_flags        = uct_ib_md_access_flags(&md->super,
+                                                 IBV_ACCESS_LOCAL_WRITE);
     self->dma_opaque.mr = ibv_reg_mr(md->super.pd, self->dma_opaque.buf,
                                      UCT_GGA_MLX5_OPAQUE_BUF_LEN,
-                                     IBV_ACCESS_LOCAL_WRITE);
+                                     access_flags);
 
     if (self->dma_opaque.mr == NULL) {
-        ucs_error("ibv_reg_mr(pd=%p, buf=%p, len=%d, 0x%x) failed to register "
+        ucs_error("ibv_reg_mr(pd=%p, buf=%p, len=%d, 0x%lx) failed to register "
                   "DMA/MMO opaque buffer: %m", md->super.pd,
                   self->dma_opaque.buf, UCT_GGA_MLX5_OPAQUE_BUF_LEN,
-                  IBV_ACCESS_LOCAL_WRITE);
+                  (unsigned long)access_flags);
         status = UCS_ERR_IO_ERROR;
         goto err_free_buf;
     }

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -421,10 +421,10 @@ static UCS_CLASS_INIT_FUNC(uct_gga_mlx5_ep_t, const uct_ep_params_t *params)
                                      access_flags);
 
     if (self->dma_opaque.mr == NULL) {
-        ucs_error("ibv_reg_mr(pd=%p, buf=%p, len=%d, 0x%lx) failed to register "
-                  "DMA/MMO opaque buffer: %m", md->super.pd,
+        ucs_error("ibv_reg_mr(pd=%p, buf=%p, len=%d, 0x%" PRIx64 ") failed "
+                  "to register DMA/MMO opaque buffer: %m", md->super.pd,
                   self->dma_opaque.buf, UCT_GGA_MLX5_OPAQUE_BUF_LEN,
-                  (unsigned long)access_flags);
+                  access_flags);
         status = UCS_ERR_IO_ERROR;
         goto err_free_buf;
     }

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -1046,6 +1046,10 @@ uct_rc_mlx5_iface_common_dm_init(uct_rc_mlx5_iface_common_t *iface,
         goto fallback;
     }
 
+    if (uct_ib_iface_md(&rc_iface->super)->relaxed_order_required) {
+        goto fallback;
+    }
+
     if (!(uct_ib_mlx5_iface_md(&rc_iface->super)->flags &
           UCT_IB_MLX5_MD_FLAG_UAR_USE_WC)) {
         goto fallback;

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -148,6 +148,7 @@ void test_ib_md::ib_md_umr_check(void *rkey_buffer, bool amo_access,
 {
     ucs_status_t status;
     size_t alloc_size;
+    bool has_strict_mr;
     void *buffer;
     int ret;
 
@@ -188,18 +189,17 @@ void test_ib_md::ib_md_umr_check(void *rkey_buffer, bool amo_access,
         EXPECT_FALSE(ib_memh->flags & UCT_IB_MEM_ACCESS_REMOTE_ATOMIC);
     }
 
-    check_mlx5_mr(ib_memh, false,
-                  uct_ib_md_is_relaxed_order(&ib_md()));
+    has_strict_mr = uct_ib_md_is_relaxed_order(&ib_md()) &&
+                    !ib_md().relaxed_order_required;
+    check_mlx5_mr(ib_memh, false, has_strict_mr);
 
     status = uct_md_mkey_pack(md(), memh, rkey_buffer);
     EXPECT_UCS_OK(status);
 
     status = uct_md_mkey_pack(md(), memh, rkey_buffer);
     EXPECT_UCS_OK(status);
-    check_mlx5_mr(ib_memh,
-                  (amo_access && has_ksm()) ||
-                          uct_ib_md_is_relaxed_order(&ib_md()),
-                  uct_ib_md_is_relaxed_order(&ib_md()));
+    check_mlx5_mr(ib_memh, (amo_access && has_ksm()) || has_strict_mr,
+                  has_strict_mr);
 
     status = uct_md_mem_dereg(md(), memh);
     EXPECT_UCS_OK(status);
@@ -229,6 +229,23 @@ UCS_TEST_P(test_ib_md, relaxed_order, "IB_PCI_RELAXED_ORDERING=try") {
 
     ib_md_umr_check(&rkey_buffer[0], false);
     ib_md_umr_check(&rkey_buffer[0], true);
+}
+
+UCS_TEST_P(test_ib_md, relaxed_order_only_config) {
+    uct_ib_md_config_t *md_config;
+
+    ASSERT_UCS_OK(uct_config_modify(m_md_config, "IB_PCI_RELAXED_ORDERING",
+                                    "only"));
+    md_config = ucs_derived_of((uct_md_config_t*)m_md_config,
+                               uct_ib_md_config_t);
+    EXPECT_EQ(UCT_IB_RELAXED_ORDERING_ONLY, md_config->mr_relaxed_order);
+    EXPECT_TRUE(uct_ib_md_is_relaxed_order_required(md_config, 0));
+
+    ASSERT_UCS_OK(uct_config_modify(m_md_config, "IB_PCI_RELAXED_ORDERING",
+                                    "auto"));
+    EXPECT_EQ(UCT_IB_RELAXED_ORDERING_AUTO, md_config->mr_relaxed_order);
+    EXPECT_FALSE(uct_ib_md_is_relaxed_order_required(md_config, 0));
+    EXPECT_TRUE(uct_ib_md_is_relaxed_order_required(md_config, 1));
 }
 
 UCS_TEST_P(test_ib_md, aligned) {

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -78,28 +78,28 @@ TEST(test_ib_md_relaxed_order_policy, strict_order_mr_mem_type)
 
     md.relaxed_order_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
 
-    EXPECT_FALSE(uct_ib_md_needs_strict_order_mr(&md, NULL));
-    EXPECT_FALSE(uct_ib_md_needs_strict_order_mr(&md, &params));
+    EXPECT_FALSE(uct_ib_md_is_strict_order_mr_required(&md, NULL));
+    EXPECT_FALSE(uct_ib_md_is_strict_order_mr_required(&md, &params));
 
     params.field_mask = UCT_MD_MEM_REG_FIELD_MEM_TYPE;
     params.mem_type   = UCS_MEMORY_TYPE_CUDA;
-    EXPECT_TRUE(uct_ib_md_needs_strict_order_mr(&md, &params));
+    EXPECT_TRUE(uct_ib_md_is_strict_order_mr_required(&md, &params));
 
     params.mem_type = UCS_MEMORY_TYPE_HOST;
-    EXPECT_FALSE(uct_ib_md_needs_strict_order_mr(&md, &params));
+    EXPECT_FALSE(uct_ib_md_is_strict_order_mr_required(&md, &params));
 
     params.mem_type = UCS_MEMORY_TYPE_CUDA;
-    EXPECT_TRUE(uct_ib_md_needs_strict_order_mr(&md, &params));
+    EXPECT_TRUE(uct_ib_md_is_strict_order_mr_required(&md, &params));
 
     params.mem_type = UCS_MEMORY_TYPE_RDMA;
-    EXPECT_FALSE(uct_ib_md_needs_strict_order_mr(&md, &params));
+    EXPECT_FALSE(uct_ib_md_is_strict_order_mr_required(&md, &params));
 
     params.mem_type = UCS_MEMORY_TYPE_HOST;
-    EXPECT_FALSE(uct_ib_md_needs_strict_order_mr(&md, &params));
+    EXPECT_FALSE(uct_ib_md_is_strict_order_mr_required(&md, &params));
 
     md.relaxed_order_required = 1;
     params.mem_type           = UCS_MEMORY_TYPE_CUDA;
-    EXPECT_FALSE(uct_ib_md_needs_strict_order_mr(&md, &params));
+    EXPECT_FALSE(uct_ib_md_is_strict_order_mr_required(&md, &params));
 }
 
 void test_ib_md::init() {

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -71,31 +71,35 @@ TEST(test_ib_md_relaxed_order_policy, auto_mem_types)
                       UCS_CPU_VENDOR_INTEL, UCS_CPU_MODEL_INTEL_ICELAKE));
 }
 
-TEST(test_ib_md_relaxed_order_policy, memh_mem_type)
+TEST(test_ib_md_relaxed_order_policy, strict_order_mr_mem_type)
 {
     uct_md_mem_reg_params_t params = {};
     uct_ib_md_t md                 = {};
 
     md.relaxed_order_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
 
-    EXPECT_FALSE(uct_ib_memh_is_relaxed_order(&md, NULL));
-    EXPECT_FALSE(uct_ib_memh_is_relaxed_order(&md, &params));
+    EXPECT_FALSE(uct_ib_md_needs_strict_order_mr(&md, NULL));
+    EXPECT_FALSE(uct_ib_md_needs_strict_order_mr(&md, &params));
 
     params.field_mask = UCT_MD_MEM_REG_FIELD_MEM_TYPE;
     params.mem_type   = UCS_MEMORY_TYPE_CUDA;
-    EXPECT_TRUE(uct_ib_memh_is_relaxed_order(&md, &params));
+    EXPECT_TRUE(uct_ib_md_needs_strict_order_mr(&md, &params));
 
     params.mem_type = UCS_MEMORY_TYPE_HOST;
-    EXPECT_FALSE(uct_ib_memh_is_relaxed_order(&md, &params));
+    EXPECT_FALSE(uct_ib_md_needs_strict_order_mr(&md, &params));
 
     params.mem_type = UCS_MEMORY_TYPE_CUDA;
-    EXPECT_TRUE(uct_ib_memh_is_relaxed_order(&md, &params));
+    EXPECT_TRUE(uct_ib_md_needs_strict_order_mr(&md, &params));
 
     params.mem_type = UCS_MEMORY_TYPE_RDMA;
-    EXPECT_FALSE(uct_ib_memh_is_relaxed_order(&md, &params));
+    EXPECT_FALSE(uct_ib_md_needs_strict_order_mr(&md, &params));
 
     params.mem_type = UCS_MEMORY_TYPE_HOST;
-    EXPECT_FALSE(uct_ib_memh_is_relaxed_order(&md, &params));
+    EXPECT_FALSE(uct_ib_md_needs_strict_order_mr(&md, &params));
+
+    md.relaxed_order_required = 1;
+    params.mem_type           = UCS_MEMORY_TYPE_CUDA;
+    EXPECT_FALSE(uct_ib_md_needs_strict_order_mr(&md, &params));
 }
 
 void test_ib_md::init() {

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -24,6 +24,7 @@ protected:
     void ib_md_umr_check(void *rkey_buffer, bool amo_access,
                          size_t size = 8192, bool aligned = false);
     bool has_ksm() const;
+    bool has_atomic_ksm() const;
 
     bool has_devx() const
     {
@@ -198,7 +199,7 @@ void test_ib_md::ib_md_umr_check(void *rkey_buffer, bool amo_access,
 
     status = uct_md_mkey_pack(md(), memh, rkey_buffer);
     EXPECT_UCS_OK(status);
-    check_mlx5_mr(ib_memh, (amo_access && has_ksm()) || has_strict_mr,
+    check_mlx5_mr(ib_memh, (amo_access && has_atomic_ksm()) || has_strict_mr,
                   has_strict_mr);
 
     status = uct_md_mem_dereg(md(), memh);
@@ -219,14 +220,40 @@ bool test_ib_md::has_ksm() const {
 #endif
 }
 
+bool test_ib_md::has_atomic_ksm() const {
+#if HAVE_DEVX
+    return has_ksm() &&
+           (m_mlx5_flags & UCT_IB_MLX5_MD_FLAG_INDIRECT_ATOMICS) &&
+           ib_md().config.enable_indirect_atomic;
+#else
+    return false;
+#endif
+}
+
 UCS_TEST_P(test_ib_md, ib_md_umr_ksm) {
     std::string rkey_buffer(md_attr().rkey_packed_size, '\0');
-    ib_md_umr_check(&rkey_buffer[0], has_ksm(), UCT_IB_MD_MAX_MR_SIZE + 0x1000);
+    ib_md_umr_check(&rkey_buffer[0], has_atomic_ksm(),
+                    UCT_IB_MD_MAX_MR_SIZE + 0x1000);
 }
 
 UCS_TEST_P(test_ib_md, relaxed_order, "IB_PCI_RELAXED_ORDERING=try") {
     std::string rkey_buffer(md_attr().rkey_packed_size, '\0');
 
+    ib_md_umr_check(&rkey_buffer[0], false);
+    ib_md_umr_check(&rkey_buffer[0], true);
+}
+
+UCS_TEST_P(test_ib_md, relaxed_order_only,
+           "IB_PCI_RELAXED_ORDERING=only")
+{
+    if (!has_atomic_ksm()) {
+        UCS_TEST_SKIP_R("atomic KSM is required");
+    }
+
+    EXPECT_TRUE(ib_md().relaxed_order);
+    EXPECT_TRUE(ib_md().relaxed_order_required);
+
+    std::string rkey_buffer(md_attr().rkey_packed_size, '\0');
     ib_md_umr_check(&rkey_buffer[0], false);
     ib_md_umr_check(&rkey_buffer[0], true);
 }

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -243,8 +243,8 @@ UCS_TEST_P(test_ib_md, relaxed_order, "IB_PCI_RELAXED_ORDERING=try") {
     ib_md_umr_check(&rkey_buffer[0], true);
 }
 
-UCS_TEST_P(test_ib_md, relaxed_order_only,
-           "IB_PCI_RELAXED_ORDERING=only")
+UCS_TEST_P(test_ib_md, relaxed_order_yes,
+           "IB_PCI_RELAXED_ORDERING=yes")
 {
     if (!has_atomic_ksm()) {
         UCS_TEST_SKIP_R("atomic KSM is required");
@@ -258,21 +258,28 @@ UCS_TEST_P(test_ib_md, relaxed_order_only,
     ib_md_umr_check(&rkey_buffer[0], true);
 }
 
-UCS_TEST_P(test_ib_md, relaxed_order_only_config) {
+UCS_TEST_P(test_ib_md, relaxed_order_required_config) {
     uct_ib_md_config_t *md_config;
 
     ASSERT_UCS_OK(uct_config_modify(m_md_config, "IB_PCI_RELAXED_ORDERING",
-                                    "only"));
+                                    "yes"));
     md_config = ucs_derived_of((uct_md_config_t*)m_md_config,
                                uct_ib_md_config_t);
-    EXPECT_EQ(UCT_IB_RELAXED_ORDERING_ONLY, md_config->mr_relaxed_order);
+    EXPECT_EQ(UCS_YES, md_config->mr_relaxed_order);
     EXPECT_TRUE(uct_ib_md_is_relaxed_order_required(md_config, 0));
 
     ASSERT_UCS_OK(uct_config_modify(m_md_config, "IB_PCI_RELAXED_ORDERING",
                                     "auto"));
-    EXPECT_EQ(UCT_IB_RELAXED_ORDERING_AUTO, md_config->mr_relaxed_order);
+    EXPECT_EQ(UCS_AUTO, md_config->mr_relaxed_order);
     EXPECT_FALSE(uct_ib_md_is_relaxed_order_required(md_config, 0));
     EXPECT_TRUE(uct_ib_md_is_relaxed_order_required(md_config, 1));
+
+    {
+        scoped_log_handler slh(hide_errors_logger);
+        EXPECT_EQ(UCS_ERR_INVALID_PARAM,
+                  uct_config_modify(m_md_config, "IB_PCI_RELAXED_ORDERING",
+                                    "only"));
+    }
 }
 
 UCS_TEST_P(test_ib_md, aligned) {

--- a/test/gtest/uct/ib/test_ib_md.cc
+++ b/test/gtest/uct/ib/test_ib_md.cc
@@ -250,7 +250,6 @@ UCS_TEST_P(test_ib_md, relaxed_order_yes,
         UCS_TEST_SKIP_R("atomic KSM is required");
     }
 
-    EXPECT_TRUE(ib_md().relaxed_order);
     EXPECT_TRUE(ib_md().relaxed_order_required);
 
     std::string rkey_buffer(md_attr().rkey_packed_size, '\0');


### PR DESCRIPTION
## What?

Add support for devices that require relaxed-only memory keys.

- Discover the relevant device ordering capabilities.
- Keep the existing `yes`, `no`, `try`, and `auto` values for `UCX_IB_PCI_RELAXED_ORDERING`.
- Make explicit `yes` require relaxed ordering, omit strict-order companion keys and rkeys, and return an error when relaxed ordering is unavailable.
- Preserve `try` as the best-effort mode that retains strict-order companion keys when available.
- Keep `auto` as the default and honor a firmware relaxed-only requirement before considering CPU preference.
- Reject `no` when the device requires relaxed-only operation.

## Why?

Some devices do not support strong-order memory keys. Creating a strict-order companion key on those devices would fail memory registration and prevent UCX from operating.

UCX must recognize this requirement, avoid creating incompatible keys, and reject configuration choices that cannot be satisfied.

## How?

Track whether relaxed ordering is enabled and whether it is mandatory as separate memory-domain states.

When relaxed ordering is mandatory, apply relaxed ordering to required registrations, use the default key for atomic operations, omit strict-order companion keys and exported rkeys, and gate paths that depend on strict-order keys. When it is optional, preserve the existing dual-key behavior.
