### PR TITLE
UCP/RMA/RMA_RNDV: Disable rma_rndv protocols when not running on vera

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -390,6 +390,10 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "even if invalidation workflow isn't supported",
    ucs_offsetof(ucp_context_config_t, rndv_errh_ppln_enable), UCS_CONFIG_TYPE_BOOL},
 
+  {"RMA_PPLN_ENABLE", "n",
+   "Force-enable the RMA rendezvous put/get protocols.",
+   ucs_offsetof(ucp_context_config_t, rma_ppln_enable), UCS_CONFIG_TYPE_BOOL},
+
   {"FLUSH_WORKER_EPS", "y",
    "Enable flushing the worker by flushing its endpoints. Allows completing\n"
    "the flush operation in a bounded time even if there are new requests on\n"

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -128,6 +128,8 @@ typedef struct ucp_context_config {
     int                                    rndv_shm_ppln_enable;
     /** Enable error handling for rndv pipeline protocol */
     int                                    rndv_errh_ppln_enable;
+    /** Force-enable the RMA rendezvous put/get protocols */
+    int                                    rma_ppln_enable;
     /** Threshold for using tag matching offload capabilities. Smaller buffers
      *  will not be posted to the transport. */
     size_t                                 tm_thresh;

--- a/src/ucp/rma/rma_rndv.c
+++ b/src/ucp/rma/rma_rndv.c
@@ -19,6 +19,7 @@
 #include <ucp/proto/proto_init.h>
 #include <ucp/proto/proto_single.inl>
 #include <ucp/rndv/proto_rndv.inl>
+#include <ucs/arch/cpu.h>
 
 
 #define UCP_PROTO_RMA_RNDV_RTS_NAME             "RMA_RTS"
@@ -33,6 +34,12 @@ ucp_proto_rma_rndv_probe_check(const ucp_proto_init_params_t *init_params,
                                ucp_operation_id_t op_id)
 {
     const ucp_proto_select_param_t *sel_param = init_params->select_param;
+
+    /* TODO: We prefer to use direct zcopy when possible, remove this check when
+     * prioritization of protocols is implemented. */
+    if (ucs_arch_get_cpu_model() != UCS_CPU_MODEL_NVIDIA_VERA) {
+        return 0;
+    }
 
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(op_id)) ||
         ucp_proto_rndv_init_params_is_ppln_frag(init_params) ||

--- a/src/ucp/rma/rma_rndv.c
+++ b/src/ucp/rma/rma_rndv.c
@@ -34,10 +34,12 @@ ucp_proto_rma_rndv_probe_check(const ucp_proto_init_params_t *init_params,
                                ucp_operation_id_t op_id)
 {
     const ucp_proto_select_param_t *sel_param = init_params->select_param;
+    const ucp_context_h context               = init_params->worker->context;
 
     /* TODO: We prefer to use direct zcopy when possible, remove this check when
      * prioritization of protocols is implemented. */
-    if (ucs_arch_get_cpu_model() != UCS_CPU_MODEL_NVIDIA_VERA) {
+    if (!context->config.ext.rma_ppln_enable &&
+        (ucs_arch_get_cpu_model() != UCS_CPU_MODEL_NVIDIA_VERA)) {
         return 0;
     }
 

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -23,6 +23,7 @@ extern "C" {
 #include <ucs/datastruct/linear_func.h>
 #include <ucp/proto/proto_select.inl>
 #include <ucp/core/ucp_worker.inl>
+#include <ucs/arch/cpu.h>
 #include <uct/api/v2/uct_v2.h>
 }
 
@@ -400,6 +401,13 @@ UCS_TEST_P(test_ucp_proto_cuda_async_non_reg,
     uint8_t sg_count;
     const ucp_proto_config_t *no_flag_remote_proto_config;
     const ucp_proto_config_t *can_reg_remote_proto_config;
+
+    /* RMA rndv get/put is gated to NVIDIA Vera CPUs in
+     * ucp_proto_rma_rndv_probe_check(), so get/rndv is not selected on other
+     * CPUs. */
+    if (ucs_arch_get_cpu_model() != UCS_CPU_MODEL_NVIDIA_VERA) {
+        UCS_TEST_SKIP_R("RMA rndv put/get is only enabled on NVIDIA Vera");
+    }
 
     if (!mem_buffer::is_async_supported(UCS_MEMORY_TYPE_CUDA)) {
         UCS_TEST_SKIP_R("CUDA async allocation is not supported");

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -23,7 +23,6 @@ extern "C" {
 #include <ucs/datastruct/linear_func.h>
 #include <ucp/proto/proto_select.inl>
 #include <ucp/core/ucp_worker.inl>
-#include <ucs/arch/cpu.h>
 #include <uct/api/v2/uct_v2.h>
 }
 
@@ -382,7 +381,7 @@ UCS_TEST_P(test_ucp_proto_cuda_async_non_reg, cuda_async_registrable_filter)
 
 UCS_TEST_P(test_ucp_proto_cuda_async_non_reg,
            cuda_async_rndv_get_zcopy_proto_filter, "RNDV_THRESH=0",
-           "RNDV_SCHEME=get_zcopy")
+           "RNDV_SCHEME=get_zcopy", "RMA_PPLN_ENABLE=y")
 {
     /* Keep the real CUDA allocation small, but inspect a large protocol range
      * where RMA GET/RNDV is selected. */
@@ -401,13 +400,6 @@ UCS_TEST_P(test_ucp_proto_cuda_async_non_reg,
     uint8_t sg_count;
     const ucp_proto_config_t *no_flag_remote_proto_config;
     const ucp_proto_config_t *can_reg_remote_proto_config;
-
-    /* RMA rndv get/put is gated to NVIDIA Vera CPUs in
-     * ucp_proto_rma_rndv_probe_check(), so get/rndv is not selected on other
-     * CPUs. */
-    if (ucs_arch_get_cpu_model() != UCS_CPU_MODEL_NVIDIA_VERA) {
-        UCS_TEST_SKIP_R("RMA rndv put/get is only enabled on NVIDIA Vera");
-    }
 
     if (!mem_buffer::is_async_supported(UCS_MEMORY_TYPE_CUDA)) {
         UCS_TEST_SKIP_R("CUDA async allocation is not supported");

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -12,6 +12,7 @@ extern "C" {
 #include <ucp/core/ucp_mm.h> /* for UCP_MEM_IS_ACCESSIBLE_FROM_CPU */
 #include <ucp/core/ucp_ep.inl>
 #include <ucp/core/ucp_rkey.h>
+#include <ucs/arch/cpu.h>
 #include <ucs/sys/sys.h>
 #include <uct/api/v2/uct_v2.h>
 }
@@ -407,12 +408,23 @@ public:
 
     void init() override
     {
+        skip_if_rma_rndv_disabled();
         m_env.push_back(
                 new ucs::scoped_setenv("UCX_IB_GPU_DIRECT_RDMA", "n"));
         test_ucp_rma::init();
     }
 
 protected:
+    /* The RMA rendezvous put/get protocols are gated to NVIDIA Vera CPUs in
+     * ucp_proto_rma_rndv_probe_check(); on any other CPU they are never
+     * offered, so the forced-rndv tests cannot run. */
+    static void skip_if_rma_rndv_disabled()
+    {
+        if (ucs_arch_get_cpu_model() != UCS_CPU_MODEL_NVIDIA_VERA) {
+            UCS_TEST_SKIP_R("RMA rndv put/get is only enabled on NVIDIA Vera");
+        }
+    }
+
     static bool is_rndv_mem_type_pair(ucs_memory_type_t local_mem_type,
                                       ucs_memory_type_t remote_mem_type)
     {
@@ -470,6 +482,7 @@ class test_ucp_rma_rndv_cuda_async : public test_ucp_rma_rndv {
 public:
     void init() override
     {
+        skip_if_rma_rndv_disabled();
         if (!mem_buffer::is_async_supported(UCS_MEMORY_TYPE_CUDA)) {
             UCS_TEST_SKIP_R("asynchronous CUDA memory is not supported");
         }

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -12,7 +12,6 @@ extern "C" {
 #include <ucp/core/ucp_mm.h> /* for UCP_MEM_IS_ACCESSIBLE_FROM_CPU */
 #include <ucp/core/ucp_ep.inl>
 #include <ucp/core/ucp_rkey.h>
-#include <ucs/arch/cpu.h>
 #include <ucs/sys/sys.h>
 #include <uct/api/v2/uct_v2.h>
 }
@@ -403,28 +402,21 @@ public:
 
     test_ucp_rma_rndv()
     {
+        /* The RMA rendezvous put/get protocols are gated to NVIDIA Vera CPUs in
+         * ucp_proto_rma_rndv_probe_check(); force-enable them so the tests can
+         * run on any CPU. */
+        modify_config("RMA_PPLN_ENABLE", "y");
         modify_config("PROTOS", "put/rndv,get/rndv,rndv/*");
     }
 
     void init() override
     {
-        skip_if_rma_rndv_disabled();
         m_env.push_back(
                 new ucs::scoped_setenv("UCX_IB_GPU_DIRECT_RDMA", "n"));
         test_ucp_rma::init();
     }
 
 protected:
-    /* The RMA rendezvous put/get protocols are gated to NVIDIA Vera CPUs in
-     * ucp_proto_rma_rndv_probe_check(); on any other CPU they are never
-     * offered, so the forced-rndv tests cannot run. */
-    static void skip_if_rma_rndv_disabled()
-    {
-        if (ucs_arch_get_cpu_model() != UCS_CPU_MODEL_NVIDIA_VERA) {
-            UCS_TEST_SKIP_R("RMA rndv put/get is only enabled on NVIDIA Vera");
-        }
-    }
-
     static bool is_rndv_mem_type_pair(ucs_memory_type_t local_mem_type,
                                       ucs_memory_type_t remote_mem_type)
     {
@@ -482,7 +474,6 @@ class test_ucp_rma_rndv_cuda_async : public test_ucp_rma_rndv {
 public:
     void init() override
     {
-        skip_if_rma_rndv_disabled();
         if (!mem_buffer::is_async_supported(UCS_MEMORY_TYPE_CUDA)) {
             UCS_TEST_SKIP_R("asynchronous CUDA memory is not supported");
         }


### PR DESCRIPTION
## What?
Disable rndv put/get when cpu type is not UCS_CPU_MODEL_NVIDIA_VERA

## Why?
There is no good way to prioritize zcopy over these protocols, so disable it. These protocols are needed for vera.
