### PR TITLE
UCT/IB/MLX5: Extract send doorbell ringing helper

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -636,7 +636,6 @@ uct_ib_mlx5_post_send(uct_ib_mlx5_txwq_t *wq, struct mlx5_wqe_ctrl_seg *ctrl,
     uint16_t sw_pi, num_bb, res_count;
     void *src;
 
-    ucs_assert(((unsigned long)ctrl % UCT_IB_MLX5_WQE_SEG_SIZE) == 0);
     num_bb  = ucs_div_round_up(wqe_size, MLX5_SEND_WQE_BB);
     sw_pi   = wq->sw_pi;
 
@@ -644,7 +643,8 @@ uct_ib_mlx5_post_send(uct_ib_mlx5_txwq_t *wq, struct mlx5_wqe_ctrl_seg *ctrl,
 
     ucs_assert(wqe_size <= UCT_IB_MLX5_BF_REG_SIZE);
 
-    src = uct_ib_mlx5_txwq_ring_doorbell(wq, ctrl, sw_pi + num_bb, num_bb);
+    sw_pi += num_bb;
+    src    = uct_ib_mlx5_txwq_ring_doorbell(wq, ctrl, sw_pi, num_bb);
 
     /*
      * Advance queue pointer.
@@ -657,7 +657,7 @@ uct_ib_mlx5_post_send(uct_ib_mlx5_txwq_t *wq, struct mlx5_wqe_ctrl_seg *ctrl,
     wq->curr        = src;
     wq->prev_sw_pi += res_count;
     ucs_assert(wq->prev_sw_pi == wq->sw_pi);
-    wq->sw_pi       = sw_pi + num_bb;
+    wq->sw_pi       = sw_pi;
 
     return res_count;
 }

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2016. ALL RIGHTS RESERVED.
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
  * Copyright (c) Google, LLC, 2024. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
@@ -573,24 +573,21 @@ void *uct_ib_mlx5_bf_copy(void *dst, void *src, uint16_t num_bb,
     return src;
 }
 
-static UCS_F_ALWAYS_INLINE uint16_t
-uct_ib_mlx5_post_send(uct_ib_mlx5_txwq_t *wq, struct mlx5_wqe_ctrl_seg *ctrl,
-                      unsigned wqe_size, int hw_ci_updated)
+static UCS_F_ALWAYS_INLINE void *
+uct_ib_mlx5_txwq_ring_doorbell(uct_ib_mlx5_txwq_t *wq,
+                               struct mlx5_wqe_ctrl_seg *ctrl,
+                               uint16_t dbrec_pi, uint16_t num_bb)
 {
-    uint16_t sw_pi, num_bb, res_count;
     void *src, *dst;
 
     ucs_assert(((unsigned long)ctrl % UCT_IB_MLX5_WQE_SEG_SIZE) == 0);
-    num_bb  = ucs_div_round_up(wqe_size, MLX5_SEND_WQE_BB);
-    sw_pi   = wq->sw_pi;
-
-    uct_ib_mlx5_txwq_validate(wq, num_bb, hw_ci_updated);
+    ucs_assert(num_bb <= UCT_IB_MLX5_MAX_BB);
 
     /* TODO Put memory store fence here too, to prevent WC being flushed after DBrec */
     ucs_memory_cpu_store_fence();
 
     /* Write doorbell record */
-    *wq->dbrec = htonl(sw_pi += num_bb);
+    *wq->dbrec = htonl(dbrec_pi);
 
     /* Make sure that doorbell record is written before ringing the doorbell */
     ucs_memory_bus_store_fence();
@@ -599,8 +596,6 @@ uct_ib_mlx5_post_send(uct_ib_mlx5_txwq_t *wq, struct mlx5_wqe_ctrl_seg *ctrl,
     dst = wq->reg->addr.ptr;
     src = ctrl;
 
-    ucs_assert(wqe_size <= UCT_IB_MLX5_BF_REG_SIZE);
-    ucs_assert(num_bb <= UCT_IB_MLX5_MAX_BB);
     if (ucs_likely(wq->reg->mode == UCT_IB_MLX5_MMIO_MODE_BF_POST)) {
         src = uct_ib_mlx5_bf_copy(dst, src, num_bb, wq);
         ucs_memory_bus_cacheline_wc_flush();
@@ -628,6 +623,29 @@ uct_ib_mlx5_post_send(uct_ib_mlx5_txwq_t *wq, struct mlx5_wqe_ctrl_seg *ctrl,
     /* We don't want the compiler to reorder instructions and hurt latency */
     ucs_compiler_fence();
 
+    /* Flip BF register */
+    wq->reg->addr.uint ^= UCT_IB_MLX5_BF_REG_SIZE;
+
+    return src;
+}
+
+static UCS_F_ALWAYS_INLINE uint16_t
+uct_ib_mlx5_post_send(uct_ib_mlx5_txwq_t *wq, struct mlx5_wqe_ctrl_seg *ctrl,
+                      unsigned wqe_size, int hw_ci_updated)
+{
+    uint16_t sw_pi, num_bb, res_count;
+    void *src;
+
+    ucs_assert(((unsigned long)ctrl % UCT_IB_MLX5_WQE_SEG_SIZE) == 0);
+    num_bb  = ucs_div_round_up(wqe_size, MLX5_SEND_WQE_BB);
+    sw_pi   = wq->sw_pi;
+
+    uct_ib_mlx5_txwq_validate(wq, num_bb, hw_ci_updated);
+
+    ucs_assert(wqe_size <= UCT_IB_MLX5_BF_REG_SIZE);
+
+    src = uct_ib_mlx5_txwq_ring_doorbell(wq, ctrl, sw_pi + num_bb, num_bb);
+
     /*
      * Advance queue pointer.
      * We return the number of BBs the *previous* WQE has consumed, since CQEs
@@ -639,10 +657,8 @@ uct_ib_mlx5_post_send(uct_ib_mlx5_txwq_t *wq, struct mlx5_wqe_ctrl_seg *ctrl,
     wq->curr        = src;
     wq->prev_sw_pi += res_count;
     ucs_assert(wq->prev_sw_pi == wq->sw_pi);
-    wq->sw_pi       = sw_pi;
+    wq->sw_pi       = sw_pi + num_bb;
 
-    /* Flip BF register */
-    wq->reg->addr.uint ^= UCT_IB_MLX5_BF_REG_SIZE;
     return res_count;
 }
 


### PR DESCRIPTION
## What?
Extract the doorbell ring logic from `uct_ib_mlx5_post_send` into a shared helper.

## Why?
Prepare the logic for reuse by paths that post multiple WQEs with a single doorbell ring.

## How?
Move the existing DB record update, MMIO write, and BF register handling into `uct_ib_mlx5_txwq_ring_doorbell()` without changing behavior.
