### PR TITLE
UCT/CUDA/CUDA_COPY: Check also mem_flags before mem_query

### DIFF
--- a/src/uct/cuda/cuda_copy/cuda_copy_ep.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_ep.c
@@ -87,7 +87,8 @@ uct_cuda_copy_get_mem_type(uct_md_h md, const void *address, size_t length,
 
     if (ucs_unlikely((status == UCS_ERR_UNSUPPORTED) ||
                      (mem_info.type == UCS_MEMORY_TYPE_UNKNOWN) ||
-                     (mem_info.sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN))) {
+                     ((mem_info.sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) &&
+                     (mem_info.mem_flags == 0)))) {
         mem_attr.field_mask = UCT_MD_MEM_ATTR_V2_FIELD_MEM_TYPE |
                               UCT_MD_MEM_ATTR_V2_FIELD_SYS_DEV;
 


### PR DESCRIPTION
## What?
Narrow down the criteria for calling `uct_cuda_copy_md_mem_query` in `uct_cuda_copy_get_mem_type` by requiring sys_dev to be unknown and mem_flags to be 0.

## Why?
sys_dev can be unknown even after detection, filtering just it may trigger mem_query on every call.