### PR TITLE
UCT/IB/MLX5: Remove redundant wqe_size assert in post_send

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -641,8 +641,6 @@ uct_ib_mlx5_post_send(uct_ib_mlx5_txwq_t *wq, struct mlx5_wqe_ctrl_seg *ctrl,
 
     uct_ib_mlx5_txwq_validate(wq, num_bb, hw_ci_updated);
 
-    ucs_assert(wqe_size <= UCT_IB_MLX5_BF_REG_SIZE);
-
     sw_pi += num_bb;
     src    = uct_ib_mlx5_txwq_ring_doorbell(wq, ctrl, sw_pi, num_bb);
 


### PR DESCRIPTION
## What?
Remove the redundant `ucs_assert(wqe_size <= UCT_IB_MLX5_BF_REG_SIZE)` in `uct_ib_mlx5_post_send`.

## Why?
`uct_ib_mlx5_txwq_validate` already asserts `num_bb <= UCT_IB_MLX5_MAX_BB`, which is the same condition `(MAX_BB * 64 = BF_REG_SIZE)`. 
This redundancy existed before [#11664](https://github.com/openucx/ucx/pull/11664) (which only moved the code into the helper), so it's cleaned up here in a separate PR to keep that one a pure refactor.