### PR TITLE
UCP/CORE: Skip port speed for zero shared bandwidth

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -800,6 +800,10 @@ static uint8_t ucp_worker_iface_port_speed(const ucp_worker_iface_t *wiface)
     ucs_status_t status;
     double ratio;
 
+    if (wiface->attr.bandwidth.shared == 0.0) {
+        return 0;
+    }
+
     perf_attr.field_mask = UCT_PERF_ATTR_FIELD_BANDWIDTH;
     status = uct_iface_estimate_perf(wiface->iface, &perf_attr);
     if (status != UCS_OK) {

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -7,6 +7,7 @@
 #include "ucp_test.h"
 #include <uct/api/uct.h>
 #include <uct/api/tl.h>
+#include <fenv.h>
 
 extern "C" {
 #include <ucp/core/ucp_worker.h>
@@ -879,6 +880,23 @@ UCS_TEST_P(test_ucp_worker_address_version, pack_unpack)
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_worker_address_version, self, "self")
+
+class test_ucp_worker_port_speed : public test_ucp_context {
+};
+
+UCS_TEST_P(test_ucp_worker_port_speed, no_fp_exceptions)
+{
+    fenv_t env;
+    int exceptions;
+
+    ASSERT_EQ(0, feholdexcept(&env));
+    create_entity();
+    exceptions = fetestexcept(FE_DIVBYZERO | FE_INVALID);
+    EXPECT_EQ(0, fesetenv(&env));
+    EXPECT_EQ(0, exceptions);
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_worker_port_speed, self, "self")
 
 class test_ucp_modify_uct_cfg : public test_ucp_context {
 public:


### PR DESCRIPTION
## What?

- Return an unavailable port speed when a transport reports zero shared bandwidth, preventing a floating-point exception during UCP worker creation.
- Add focused regression coverage for worker creation with the self transport.

Fixes https://github.com/openucx/ucx/issues/11669

## Why?

Dedicated-only transports can report zero shared bandwidth. Using that value as a divisor while calculating port speed can raise a floating-point exception when applications enable floating-point traps.