### PR TITLE
TOOLS/PERF: Support AM receive copy to device memory

### DIFF
--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -41,6 +41,8 @@ public:
         m_am_rx_buffer(NULL),
         m_am_rx_length(0ul)
     {
+        unsigned am_flags = UCP_AM_FLAG_WHOLE_MSG;
+
         memset(&m_am_rx_params, 0, sizeof(m_am_rx_params));
         memset(&m_send_params, 0, sizeof(m_send_params));
         memset(&m_send_get_info_params, 0, sizeof(m_send_get_info_params));
@@ -48,7 +50,11 @@ public:
 
         ucs_assert_always(m_max_outstanding > 0);
 
-        set_am_handler(AM_ID, am_data_handler, this, UCP_AM_FLAG_WHOLE_MSG);
+        if (m_perf.params.flags & UCX_PERF_TEST_FLAG_AM_RECV_COPY) {
+            am_flags |= UCP_AM_FLAG_PERSISTENT_DATA;
+        }
+
+        set_am_handler(AM_ID, am_data_handler, this, am_flags);
         set_am_handler(UCP_PERF_DAEMON_AM_ID_SEND_CMPL,
                        am_daemon_send_ack_handler, this, UCP_AM_FLAG_WHOLE_MSG);
         set_am_handler(UCP_PERF_DAEMON_AM_ID_RECV_CMPL,
@@ -273,10 +279,11 @@ public:
         return ucs_likely(status == UCS_OK) ? length : status;
     }
 
-    ucs_status_t am_rndv_recv(void *data, size_t length,
-                              const ucp_am_recv_param_t *rx_params)
+    ucs_status_t am_recv(void *data, size_t length,
+                         const ucp_am_recv_param_t *rx_params)
     {
-        ucs_assert(!(rx_params->recv_attr & UCP_AM_RECV_ATTR_FLAG_DATA));
+        ucs_assert(rx_params->recv_attr & (UCP_AM_RECV_ATTR_FLAG_DATA |
+                                           UCP_AM_RECV_ATTR_FLAG_RNDV));
         ucs_assertv(length == m_am_rx_length,
                     "length=%zu expected=%zu index=%u", length, m_am_rx_length,
                     rte_call(&m_perf, group_index));
@@ -325,15 +332,9 @@ public:
     {
         ucp_perf_test_runner *test = (ucp_perf_test_runner*)arg;
 
-        if (param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV) {
-            return test->am_rndv_recv(data, length, param);
-        }
-
-        if (test->m_perf.params.flags & UCX_PERF_TEST_FLAG_AM_RECV_COPY) {
-            ucs_assertv(length == test->m_am_rx_length,
-                        "wrong buffer length %ld != %ld",
-                        length, test->m_am_rx_length);
-            memcpy(test->m_am_rx_buffer, data, length);
+        if ((param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV) ||
+            (test->m_perf.params.flags & UCX_PERF_TEST_FLAG_AM_RECV_COPY)) {
+            return test->am_recv(data, length, param);
         }
 
         test->recv_completed();

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -8,6 +8,7 @@
 
 #include "ucp_test.h"
 
+#include <common/mem_buffer.h>
 #include <common/test_perf.h>
 #include <ucp/core/ucp_types.h>
 
@@ -375,6 +376,43 @@ UCS_TEST_SKIP_COND_P(test_ucp_perf, envelope, has_transport("self"))
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_perf)
+
+class test_ucp_perf_cuda : public test_ucp_perf {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant(variants, 0);
+    }
+};
+
+UCS_TEST_P(test_ucp_perf_cuda, am_recv_copy)
+{
+    if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
+        UCS_TEST_SKIP_R("CUDA is not supported");
+    }
+
+    std::stringstream ss;
+    ss << GetParam().transports;
+    /* coverity[tainted_string_argument] */
+    ucs::scoped_setenv tls("UCX_TLS", ss.str().c_str());
+
+    test_spec test = {"am cuda receive copy", "Mpps",
+                      UCX_PERF_API_UCP, UCX_PERF_CMD_AM,
+                      UCX_PERF_TEST_TYPE_STREAM_UNI,
+                      UCX_PERF_WAIT_MODE_POLL,
+                      UCP_PERF_DATATYPE_CONTIG, 0, 1, {8}, 1, 1000lu,
+                      ucs_offsetof(ucx_perf_result_t, msgrate.total_average),
+                      1e-6, 0.0, std::numeric_limits<double>::max(),
+                      UCX_PERF_TEST_FLAG_AM_RECV_COPY,
+                      UCS_MEMORY_TYPE_CUDA, UCS_MEMORY_TYPE_CUDA};
+
+    run_test(test, 0, false, "", "");
+
+    test.test_flags |= UCX_PERF_TEST_FLAG_PREREG;
+    run_test(test, 0, false, "", "");
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_perf_cuda, tcp, "tcp,cuda_copy")
 
 class test_ucp_loopback : public test_ucp_perf {};
 

--- a/test/gtest/ucp/test_ucp_perf.cc
+++ b/test/gtest/ucp/test_ucp_perf.cc
@@ -395,6 +395,7 @@ UCS_TEST_P(test_ucp_perf_cuda, am_recv_copy)
     ss << GetParam().transports;
     /* coverity[tainted_string_argument] */
     ucs::scoped_setenv tls("UCX_TLS", ss.str().c_str());
+    ucs::scoped_setenv warn_invalid("UCX_WARN_INVALID_CONFIG", "no");
 
     test_spec test = {"am cuda receive copy", "Mpps",
                       UCX_PERF_API_UCP, UCX_PERF_CMD_AM,
@@ -412,7 +413,7 @@ UCS_TEST_P(test_ucp_perf_cuda, am_recv_copy)
     run_test(test, 0, false, "", "");
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_perf_cuda, tcp, "tcp,cuda_copy")
+UCP_INSTANTIATE_TEST_CASE_GPU_AWARE(test_ucp_perf_cuda)
 
 class test_ucp_loopback : public test_ucp_perf {};
 


### PR DESCRIPTION
## What

Fix active-message receive-copy mode for device-memory buffers by routing eager and rendezvous data through `ucp_am_recv_data_nbx()`. Add focused coverage for regular and preregistered CUDA receive buffers.

## Why

Receive-copy mode used CPU `memcpy()` directly on the selected receive buffer. CUDA device memory is not CPU-accessible, causing the receiver to fault and leaving the peer waiting indefinitely.

UCP already provides memory-type-aware data unpacking for persistent eager descriptors and rendezvous descriptors. Using that operation supports device memory and registered buffers without adding memory-type-specific logic to the performance tool.