### PR TITLE
UCP/RKEY: Keep configurations at stable addresses

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ Ivan Kochin <ikochin@nvidia.com>
 Jakir Kham <jakirkham@gmail.com>
 Jason Gunthorpe <jgg@mellanox.com>
 Jeff Daily <jeff.daily@amd.com>
+Jeff Mahou <jmahou@nvidia.com>
 Jianxin Xiong <jianxin.xiong@intel.com>
 John Snyder <jms285@duke.edu>
 Jonas Zhou <JonasZhou@zhaoxin.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Ivan Kochin <ikochin@nvidia.com>
 Jakir Kham <jakirkham@gmail.com>
 Jason Gunthorpe <jgg@mellanox.com>
 Jeff Daily <jeff.daily@amd.com>
+Jeff Mahou <jmahou@nvidia.com>
 Jianxin Xiong <jianxin.xiong@intel.com>
 John Snyder <jms285@duke.edu>
 Jonas Zhou <JonasZhou@zhaoxin.com>

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -897,18 +897,21 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rkey_proto_resolve,
         buffer_end = (void*)UINTPTR_MAX;
     }
 
+    UCS_ASYNC_BLOCK(&worker->async);
     khiter = kh_get(ucp_worker_rkey_config, &worker->rkey_config_hash,
                     rkey_config_key);
     if (ucs_likely(khiter != kh_end(&worker->rkey_config_hash))) {
         /* Found existing configuration in hash */
         rkey->cfg_index = kh_val(&worker->rkey_config_hash, khiter);
+        UCS_ASYNC_UNBLOCK(&worker->async);
         return UCS_OK;
     }
+    UCS_ASYNC_UNBLOCK(&worker->async);
 
     lanes_distance = ucs_alloca(sizeof(*lanes_distance) * UCP_MAX_LANES);
     ucp_rkey_unpack_lanes_distance(&ucp_ep_config(ep)->key, lanes_distance, p,
                                    buffer_end);
-    return ucp_worker_add_rkey_config(worker, &rkey_config_key, lanes_distance,
+    return ucp_worker_rkey_config_get(worker, &rkey_config_key, lanes_distance,
                                       &rkey->cfg_index);
 }
 
@@ -1278,8 +1281,8 @@ void ucp_rkey_proto_select_dump(ucp_worker_h worker,
                                 ucp_worker_cfg_index_t rkey_cfg_index,
                                 ucs_string_buffer_t *strb)
 {
-    const ucp_rkey_config_t *rkey_config = &ucs_array_elem(&worker->rkey_config,
-                                                           rkey_cfg_index);
+    const ucp_rkey_config_t *rkey_config = ucs_array_elem(&worker->rkey_config,
+                                                          rkey_cfg_index);
 
     ucp_proto_select_dump_short(&rkey_config->put_short, "put_short", strb);
     ucp_proto_select_info(worker, rkey_config->key.ep_cfg_index, rkey_cfg_index,

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -1278,8 +1278,8 @@ void ucp_rkey_proto_select_dump(ucp_worker_h worker,
                                 ucp_worker_cfg_index_t rkey_cfg_index,
                                 ucs_string_buffer_t *strb)
 {
-    const ucp_rkey_config_t *rkey_config = &ucs_array_elem(&worker->rkey_config,
-                                                           rkey_cfg_index);
+    const ucp_rkey_config_t *rkey_config = ucs_array_elem(&worker->rkey_config,
+                                                          rkey_cfg_index);
 
     ucp_proto_select_dump_short(&rkey_config->put_short, "put_short", strb);
     ucp_proto_select_info(worker, rkey_config->key.ep_cfg_index, rkey_cfg_index,

--- a/src/ucp/core/ucp_rkey.inl
+++ b/src/ucp/core/ucp_rkey.inl
@@ -41,7 +41,7 @@ static UCS_F_ALWAYS_INLINE ucp_rkey_config_t *
 ucp_rkey_config(ucp_worker_h worker, ucp_rkey_h rkey)
 {
     ucs_assert(rkey->cfg_index != UCP_WORKER_CFG_INDEX_NULL);
-    return &ucs_array_elem(&worker->rkey_config, rkey->cfg_index);
+    return ucs_array_elem(&worker->rkey_config, rkey->cfg_index);
 }
 
 static UCS_F_ALWAYS_INLINE uct_rkey_t

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2240,7 +2240,7 @@ out:
 
 static void
 ucp_worker_dump_rkey_config_key(ucs_string_buffer_t *log_strb,
-                                ucp_rkey_config_key_t *key)
+                                const ucp_rkey_config_key_t *key)
 {
     ucs_string_buffer_appendf(
             log_strb,
@@ -2259,6 +2259,7 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
     const ucp_ep_config_t *ep_config = &ucs_array_elem(&worker->ep_config,
                                                        key->ep_cfg_index);
     ucp_worker_cfg_index_t rkey_cfg_index;
+    ucp_rkey_config_t **rkey_config_p;
     ucp_rkey_config_t *rkey_config;
     ucp_lane_index_t lane;
     ucs_status_t status;
@@ -2277,15 +2278,16 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
         /* Dump all rkey config keys */
         ucs_string_buffer_init(&log_strb);
 
-        ucs_array_for_each(rkey_config, &worker->rkey_config) {
+        ucs_array_for_each(rkey_config_p, &worker->rkey_config) {
             ucs_string_buffer_appendf(
                     &log_strb, "rkey [%ld]: ",
-                    rkey_config - ucs_array_begin(&worker->rkey_config));
+                    rkey_config_p - ucs_array_begin(&worker->rkey_config));
+            rkey_config = *rkey_config_p;
             ucp_worker_dump_rkey_config_key(&log_strb, &rkey_config->key);
         }
 
         ucs_string_buffer_appendf(&log_strb, "rkey key new: ");
-        ucp_worker_dump_rkey_config_key(&log_strb, &rkey_config->key);
+        ucp_worker_dump_rkey_config_key(&log_strb, key);
 
         ucs_debug("%s", ucs_string_buffer_cstr(&log_strb));
         ucs_string_buffer_cleanup(&log_strb);
@@ -2298,11 +2300,12 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
                (lanes_distance != NULL));
 
     /* Initialize rkey configuration */
-    rkey_cfg_index      = ucs_array_length(&worker->rkey_config);
-    rkey_config         = ucp_worker_config_array_append(
-                                  worker, &worker->rkey_config,
-                                  status = UCS_ERR_NO_MEMORY;
-                                  goto err;);
+    rkey_cfg_index = ucs_array_length(&worker->rkey_config);
+    rkey_config    = ucs_malloc(sizeof(*rkey_config), "rkey_config");
+    if (rkey_config == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err;
+    }
 
     rkey_config->key = *key;
 
@@ -2318,6 +2321,17 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
                                         sizeof(buf)));
     }
 
+    status = ucp_proto_select_init(&rkey_config->proto_select, worker->epoch);
+    if (status != UCS_OK) {
+        goto err_free_rkey_config;
+    }
+
+    rkey_config_p  = ucp_worker_config_array_append(
+                             worker, &worker->rkey_config,
+                             status = UCS_ERR_NO_MEMORY;
+                             goto err_proto_select_cleanup;);
+    *rkey_config_p = rkey_config;
+
     /* Save key-to-index lookup */
     khiter = kh_put(ucp_worker_rkey_config, &worker->rkey_config_hash, *key,
                     &khret);
@@ -2329,12 +2343,6 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
     /* We should not get into this function if key already exists */
     ucs_assert_always(khret != UCS_KH_PUT_KEY_PRESENT);
     kh_value(&worker->rkey_config_hash, khiter) = rkey_cfg_index;
-
-    /* Initialize protocol selection */
-    status = ucp_proto_select_init(&rkey_config->proto_select, worker->epoch);
-    if (status != UCS_OK) {
-        goto err_kh_del;
-    }
 
     *cfg_index_p = rkey_cfg_index;
 
@@ -2350,10 +2358,12 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
 
     return UCS_OK;
 
-err_kh_del:
-    kh_del(ucp_worker_rkey_config, &worker->rkey_config_hash, khiter);
 err_pop_rkey_config:
     ucs_array_pop_back(&worker->rkey_config);
+err_proto_select_cleanup:
+    ucp_proto_select_cleanup(&rkey_config->proto_select);
+err_free_rkey_config:
+    ucs_free(rkey_config);
 err:
     return status;
 }
@@ -2372,13 +2382,15 @@ static void ucp_worker_keepalive_reset(ucp_worker_h worker)
 static void ucp_worker_trace_configs(ucp_worker_h worker)
 {
     ucp_ep_config_t *ep_config;
+    ucp_rkey_config_t **rkey_config_p;
     ucp_rkey_config_t *rkey_config;
 
     ucs_array_for_each(ep_config, &worker->ep_config) {
         ucp_proto_select_trace(worker, &ep_config->proto_select);
     }
 
-    ucs_array_for_each(rkey_config, &worker->rkey_config) {
+    ucs_array_for_each(rkey_config_p, &worker->rkey_config) {
+        rkey_config = *rkey_config_p;
         ucp_proto_select_trace(worker, &rkey_config->proto_select);
     }
 }
@@ -2386,6 +2398,7 @@ static void ucp_worker_trace_configs(ucp_worker_h worker)
 static void ucp_worker_destroy_configs(ucp_worker_h worker)
 {
     ucp_ep_config_t *ep_config;
+    ucp_rkey_config_t **rkey_config_p;
     ucp_rkey_config_t *rkey_config;
 
     ucs_array_for_each(ep_config, &worker->ep_config) {
@@ -2393,8 +2406,10 @@ static void ucp_worker_destroy_configs(ucp_worker_h worker)
     }
     ucs_array_cleanup_dynamic(&worker->ep_config);
 
-    ucs_array_for_each(rkey_config, &worker->rkey_config) {
+    ucs_array_for_each(rkey_config_p, &worker->rkey_config) {
+        rkey_config = *rkey_config_p;
         ucp_proto_select_cleanup(&rkey_config->proto_select);
+        ucs_free(rkey_config);
     }
     ucs_array_cleanup_dynamic(&worker->rkey_config);
 }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2293,7 +2293,7 @@ out:
 
 static void
 ucp_worker_dump_rkey_config_key(ucs_string_buffer_t *log_strb,
-                                ucp_rkey_config_key_t *key)
+                                const ucp_rkey_config_key_t *key)
 {
     ucs_string_buffer_appendf(
             log_strb,
@@ -2312,6 +2312,7 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
     const ucp_ep_config_t *ep_config = &ucs_array_elem(&worker->ep_config,
                                                        key->ep_cfg_index);
     ucp_worker_cfg_index_t rkey_cfg_index;
+    ucp_rkey_config_t **rkey_config_p;
     ucp_rkey_config_t *rkey_config;
     ucp_lane_index_t lane;
     ucs_status_t status;
@@ -2330,15 +2331,16 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
         /* Dump all rkey config keys */
         ucs_string_buffer_init(&log_strb);
 
-        ucs_array_for_each(rkey_config, &worker->rkey_config) {
+        ucs_array_for_each(rkey_config_p, &worker->rkey_config) {
             ucs_string_buffer_appendf(
                     &log_strb, "rkey [%ld]: ",
-                    rkey_config - ucs_array_begin(&worker->rkey_config));
+                    rkey_config_p - ucs_array_begin(&worker->rkey_config));
+            rkey_config = *rkey_config_p;
             ucp_worker_dump_rkey_config_key(&log_strb, &rkey_config->key);
         }
 
         ucs_string_buffer_appendf(&log_strb, "rkey key new: ");
-        ucp_worker_dump_rkey_config_key(&log_strb, &rkey_config->key);
+        ucp_worker_dump_rkey_config_key(&log_strb, key);
 
         ucs_debug("%s", ucs_string_buffer_cstr(&log_strb));
         ucs_string_buffer_cleanup(&log_strb);
@@ -2351,11 +2353,12 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
                (lanes_distance != NULL));
 
     /* Initialize rkey configuration */
-    rkey_cfg_index      = ucs_array_length(&worker->rkey_config);
-    rkey_config         = ucp_worker_config_array_append(
-                                  worker, &worker->rkey_config,
-                                  status = UCS_ERR_NO_MEMORY;
-                                  goto err;);
+    rkey_cfg_index = ucs_array_length(&worker->rkey_config);
+    rkey_config    = ucs_malloc(sizeof(*rkey_config), "rkey_config");
+    if (rkey_config == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err;
+    }
 
     rkey_config->key = *key;
 
@@ -2371,6 +2374,17 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
                                         sizeof(buf)));
     }
 
+    status = ucp_proto_select_init(&rkey_config->proto_select, worker->epoch);
+    if (status != UCS_OK) {
+        goto err_free_rkey_config;
+    }
+
+    rkey_config_p  = ucp_worker_config_array_append(
+                             worker, &worker->rkey_config,
+                             status = UCS_ERR_NO_MEMORY;
+                             goto err_proto_select_cleanup;);
+    *rkey_config_p = rkey_config;
+
     /* Save key-to-index lookup */
     khiter = kh_put(ucp_worker_rkey_config, &worker->rkey_config_hash, *key,
                     &khret);
@@ -2382,12 +2396,6 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
     /* We should not get into this function if key already exists */
     ucs_assert_always(khret != UCS_KH_PUT_KEY_PRESENT);
     kh_value(&worker->rkey_config_hash, khiter) = rkey_cfg_index;
-
-    /* Initialize protocol selection */
-    status = ucp_proto_select_init(&rkey_config->proto_select, worker->epoch);
-    if (status != UCS_OK) {
-        goto err_kh_del;
-    }
 
     *cfg_index_p = rkey_cfg_index;
 
@@ -2403,10 +2411,12 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
 
     return UCS_OK;
 
-err_kh_del:
-    kh_del(ucp_worker_rkey_config, &worker->rkey_config_hash, khiter);
 err_pop_rkey_config:
     ucs_array_pop_back(&worker->rkey_config);
+err_proto_select_cleanup:
+    ucp_proto_select_cleanup(&rkey_config->proto_select);
+err_free_rkey_config:
+    ucs_free(rkey_config);
 err:
     return status;
 }
@@ -2425,13 +2435,15 @@ static void ucp_worker_keepalive_reset(ucp_worker_h worker)
 static void ucp_worker_trace_configs(ucp_worker_h worker)
 {
     ucp_ep_config_t *ep_config;
+    ucp_rkey_config_t **rkey_config_p;
     ucp_rkey_config_t *rkey_config;
 
     ucs_array_for_each(ep_config, &worker->ep_config) {
         ucp_proto_select_trace(worker, &ep_config->proto_select);
     }
 
-    ucs_array_for_each(rkey_config, &worker->rkey_config) {
+    ucs_array_for_each(rkey_config_p, &worker->rkey_config) {
+        rkey_config = *rkey_config_p;
         ucp_proto_select_trace(worker, &rkey_config->proto_select);
     }
 }
@@ -2439,6 +2451,7 @@ static void ucp_worker_trace_configs(ucp_worker_h worker)
 static void ucp_worker_destroy_configs(ucp_worker_h worker)
 {
     ucp_ep_config_t *ep_config;
+    ucp_rkey_config_t **rkey_config_p;
     ucp_rkey_config_t *rkey_config;
 
     ucs_array_for_each(ep_config, &worker->ep_config) {
@@ -2446,8 +2459,10 @@ static void ucp_worker_destroy_configs(ucp_worker_h worker)
     }
     ucs_array_cleanup_dynamic(&worker->ep_config);
 
-    ucs_array_for_each(rkey_config, &worker->rkey_config) {
+    ucs_array_for_each(rkey_config_p, &worker->rkey_config) {
+        rkey_config = *rkey_config_p;
         ucp_proto_select_cleanup(&rkey_config->proto_select);
+        ucs_free(rkey_config);
     }
     ucs_array_cleanup_dynamic(&worker->rkey_config);
 }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2335,8 +2335,8 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
             ucs_string_buffer_appendf(
                     &log_strb, "rkey [%ld]: ",
                     rkey_config_p - ucs_array_begin(&worker->rkey_config));
-            rkey_config = *rkey_config_p;
-            ucp_worker_dump_rkey_config_key(&log_strb, &rkey_config->key);
+            ucp_worker_dump_rkey_config_key(&log_strb,
+                                            &(*rkey_config_p)->key);
         }
 
         ucs_string_buffer_appendf(&log_strb, "rkey key new: ");
@@ -2436,15 +2436,13 @@ static void ucp_worker_trace_configs(ucp_worker_h worker)
 {
     ucp_ep_config_t *ep_config;
     ucp_rkey_config_t **rkey_config_p;
-    ucp_rkey_config_t *rkey_config;
 
     ucs_array_for_each(ep_config, &worker->ep_config) {
         ucp_proto_select_trace(worker, &ep_config->proto_select);
     }
 
     ucs_array_for_each(rkey_config_p, &worker->rkey_config) {
-        rkey_config = *rkey_config_p;
-        ucp_proto_select_trace(worker, &rkey_config->proto_select);
+        ucp_proto_select_trace(worker, &(*rkey_config_p)->proto_select);
     }
 }
 
@@ -2452,7 +2450,6 @@ static void ucp_worker_destroy_configs(ucp_worker_h worker)
 {
     ucp_ep_config_t *ep_config;
     ucp_rkey_config_t **rkey_config_p;
-    ucp_rkey_config_t *rkey_config;
 
     ucs_array_for_each(ep_config, &worker->ep_config) {
         ucp_ep_config_cleanup(worker, ep_config);
@@ -2460,9 +2457,8 @@ static void ucp_worker_destroy_configs(ucp_worker_h worker)
     ucs_array_cleanup_dynamic(&worker->ep_config);
 
     ucs_array_for_each(rkey_config_p, &worker->rkey_config) {
-        rkey_config = *rkey_config_p;
-        ucp_proto_select_cleanup(&rkey_config->proto_select);
-        ucs_free(rkey_config);
+        ucp_proto_select_cleanup(&(*rkey_config_p)->proto_select);
+        ucs_free(*rkey_config_p);
     }
     ucs_array_cleanup_dynamic(&worker->rkey_config);
 }

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -293,7 +293,7 @@ UCS_PTR_MAP_TYPE(ep, 1);
 UCS_PTR_MAP_TYPE(request, 0);
 
 /* rkey configuration storage */
-UCS_ARRAY_DECLARE_TYPE(ucp_rkey_config_arr_t, unsigned, ucp_rkey_config_t);
+UCS_ARRAY_DECLARE_TYPE(ucp_rkey_config_arr_t, unsigned, ucp_rkey_config_t*);
 
 
 /**

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -298,7 +298,7 @@ UCS_PTR_MAP_TYPE(ep, 1);
 UCS_PTR_MAP_TYPE(request, 0);
 
 /* rkey configuration storage */
-UCS_ARRAY_DECLARE_TYPE(ucp_rkey_config_arr_t, unsigned, ucp_rkey_config_t);
+UCS_ARRAY_DECLARE_TYPE(ucp_rkey_config_arr_t, unsigned, ucp_rkey_config_t*);
 
 
 /**

--- a/src/ucp/core/ucp_worker.inl
+++ b/src/ucp/core/ucp_worker.inl
@@ -35,14 +35,21 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_worker_rkey_config_get(
         const ucs_sys_dev_distance_t *lanes_distance,
         ucp_worker_cfg_index_t *cfg_index_p)
 {
-    khiter_t khiter = kh_get(ucp_worker_rkey_config, &worker->rkey_config_hash,
-                             *key);
+    khiter_t khiter;
+    ucs_status_t status;
+
+    UCS_ASYNC_BLOCK(&worker->async);
+    khiter = kh_get(ucp_worker_rkey_config, &worker->rkey_config_hash, *key);
     if (ucs_likely(khiter != kh_end(&worker->rkey_config_hash))) {
         *cfg_index_p = kh_val(&worker->rkey_config_hash, khiter);
+        UCS_ASYNC_UNBLOCK(&worker->async);
         return UCS_OK;
     }
 
-    return ucp_worker_add_rkey_config(worker, key, lanes_distance, cfg_index_p);
+    status = ucp_worker_add_rkey_config(worker, key, lanes_distance,
+                                        cfg_index_p);
+    UCS_ASYNC_UNBLOCK(&worker->async);
+    return status;
 }
 
 static UCS_F_ALWAYS_INLINE khint_t

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -438,8 +438,8 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
 
     /* For remote memory access, consider remote system topology distance */
     if (params->flags & UCP_PROTO_COMMON_INIT_FLAG_REMOTE_ACCESS) {
-        rkey_config = &ucs_array_elem(&worker->rkey_config,
-                                      params->super.rkey_cfg_index);
+        rkey_config = ucs_array_elem(&worker->rkey_config,
+                                     params->super.rkey_cfg_index);
         distance    = rkey_config->lanes_distance[lane];
         ucp_proto_common_update_lane_perf_by_distance(
                 tl_perf, &distance, "remote system", "sys-dev %d %s",

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -484,7 +484,7 @@ void ucp_proto_select_info_str(ucp_worker_h worker,
         }
 
         ucp_rkey_config_dump_brief(
-                &ucs_array_elem(&worker->rkey_config, rkey_cfg_index).key,
+                &ucs_array_elem(&worker->rkey_config, rkey_cfg_index)->key,
                 strb);
     }
 

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -483,7 +483,7 @@ void ucp_proto_select_info_str(ucp_worker_h worker,
         }
 
         ucp_rkey_config_dump_brief(
-                &ucs_array_elem(&worker->rkey_config, rkey_cfg_index).key,
+                &ucs_array_elem(&worker->rkey_config, rkey_cfg_index)->key,
                 strb);
     }
 

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -209,7 +209,7 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
         init_params.rkey_config_key = NULL;
     } else {
         init_params.rkey_config_key =
-                &ucs_array_elem(&worker->rkey_config, rkey_cfg_index).key;
+                &ucs_array_elem(&worker->rkey_config, rkey_cfg_index)->key;
 
         /* rkey configuration must be for the same ep */
         ucs_assertv_always(
@@ -866,7 +866,7 @@ ucp_proto_select_get(ucp_worker_h worker, ucp_worker_cfg_index_t ep_cfg_index,
         return &ucs_array_elem(&worker->ep_config, ep_cfg_index).proto_select;
     } else {
         rkey_config_key =
-                ucs_array_elem(&worker->rkey_config, rkey_cfg_index).key;
+                ucs_array_elem(&worker->rkey_config, rkey_cfg_index)->key;
 
         rkey_config_key.ep_cfg_index = ep_cfg_index;
         status = ucp_worker_rkey_config_get(worker, &rkey_config_key, NULL,
@@ -877,7 +877,7 @@ ucp_proto_select_get(ucp_worker_h worker, ucp_worker_cfg_index_t ep_cfg_index,
         }
 
         return &ucs_array_elem(&worker->rkey_config, *new_rkey_cfg_index)
-                        .proto_select;
+                        ->proto_select;
     }
 }
 

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -207,7 +207,7 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
         init_params.rkey_config_key = NULL;
     } else {
         init_params.rkey_config_key =
-                &ucs_array_elem(&worker->rkey_config, rkey_cfg_index).key;
+                &ucs_array_elem(&worker->rkey_config, rkey_cfg_index)->key;
 
         /* rkey configuration must be for the same ep */
         ucs_assertv_always(
@@ -870,7 +870,7 @@ ucp_proto_select_get(ucp_worker_h worker, ucp_worker_cfg_index_t ep_cfg_index,
         return &ucs_array_elem(&worker->ep_config, ep_cfg_index).proto_select;
     } else {
         rkey_config_key =
-                ucs_array_elem(&worker->rkey_config, rkey_cfg_index).key;
+                ucs_array_elem(&worker->rkey_config, rkey_cfg_index)->key;
 
         rkey_config_key.ep_cfg_index = ep_cfg_index;
         status = ucp_worker_rkey_config_get(worker, &rkey_config_key, NULL,
@@ -881,7 +881,7 @@ ucp_proto_select_get(ucp_worker_h worker, ucp_worker_cfg_index_t ep_cfg_index,
         }
 
         return &ucs_array_elem(&worker->rkey_config, *new_rkey_cfg_index)
-                        .proto_select;
+                        ->proto_select;
     }
 }
 

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -226,7 +226,7 @@ static ucs_status_t ucp_proto_rndv_ctrl_select_remote_proto(
     ucs_trace("rndv select remote protocols rkey_config->md_map=0x%" PRIx64,
               rkey_config_key.md_map);
 
-    rkey_config   = &ucs_array_elem(&worker->rkey_config, rkey_cfg_index);
+    rkey_config   = ucs_array_elem(&worker->rkey_config, rkey_cfg_index);
     *remote_proto = ucp_proto_select_lookup_slow(worker,
                                                  &rkey_config->proto_select, 1,
                                                  ep_cfg_index, rkey_cfg_index,

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -235,7 +235,7 @@ static ucs_status_t ucp_proto_rndv_ctrl_select_remote_proto(
     ucs_trace("rndv select remote protocols rkey_config->md_map=0x%" PRIx64,
               rkey_config_key.md_map);
 
-    rkey_config   = &ucs_array_elem(&worker->rkey_config, rkey_cfg_index);
+    rkey_config   = ucs_array_elem(&worker->rkey_config, rkey_cfg_index);
     *remote_proto = ucp_proto_select_lookup_slow(worker,
                                                  &rkey_config->proto_select, 1,
                                                  ep_cfg_index, rkey_cfg_index,

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -788,8 +788,9 @@ protected:
             setup_progress_mock(ep_config->proto_select, mock);
         }
 
-        ucp_rkey_config_t *rkey_config;
-        ucs_array_for_each(rkey_config, &worker->rkey_config) {
+        ucp_rkey_config_t **rkey_config_p;
+        ucs_array_for_each(rkey_config_p, &worker->rkey_config) {
+            ucp_rkey_config_t *rkey_config = *rkey_config_p;
             setup_progress_mock(rkey_config->proto_select, mock);
         }
     }

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -60,10 +60,10 @@ protected:
                                                 uint8_t flag)
     {
         size_t count = 0;
-        ucp_rkey_config_t *rkey_config;
+        ucp_rkey_config_t **rkey_config_p;
 
-        ucs_array_for_each(rkey_config, &worker->rkey_config) {
-            count += !!(rkey_config->key.flags & flag);
+        ucs_array_for_each(rkey_config_p, &worker->rkey_config) {
+            count += !!((*rkey_config_p)->key.flags & flag);
         }
 
         return count;
@@ -175,8 +175,8 @@ protected:
         if (status != UCS_OK) {
             return nullptr;
         }
-        auto proto_select =
-                &ucs_array_elem(&worker()->rkey_config, rkey_cfg_index).proto_select;
+        auto proto_select = &ucs_array_elem(&worker()->rkey_config,
+                                            rkey_cfg_index)->proto_select;
 
         ucp_proto_select_param_init(
                 &select_param, UCP_OP_ID_RNDV_RECV, 0,
@@ -245,7 +245,7 @@ protected:
         }
 
         proto_select = &ucs_array_elem(&worker()->rkey_config,
-                                       rkey_cfg_index).proto_select;
+                                       rkey_cfg_index)->proto_select;
         ucp_proto_select_param_init(&select_param, UCP_OP_ID_RNDV_SEND, 0,
                                     rndv_op_flag, UCP_DATATYPE_CONTIG,
                                     &mem_info, 1);
@@ -342,8 +342,8 @@ protected:
         if (status != UCS_OK) {
             return nullptr;
         }
-        proto_select =
-                &ucs_array_elem(&worker()->rkey_config, rkey_cfg_index).proto_select;
+        proto_select = &ucs_array_elem(&worker()->rkey_config,
+                                       rkey_cfg_index)->proto_select;
         ucp_proto_select_param_init(&select_param, op_id, 0, 0,
                                     UCP_DATATYPE_CONTIG, &mem_info, 1);
         select_elem = ucp_proto_select_lookup_slow(
@@ -386,8 +386,9 @@ protected:
         }
 
         key.param    = remote_proto_config->select_param;
-        proto_select = &ucs_array_elem(&worker()->rkey_config,
-                                       remote_proto_config->rkey_cfg_index).proto_select;
+        proto_select = &ucs_array_elem(
+                                &worker()->rkey_config,
+                                remote_proto_config->rkey_cfg_index)->proto_select;
         EXPECT_NE(kh_end(proto_select->hash),
                   kh_get(ucp_proto_select_hash, proto_select->hash, key.u64));
     }

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -2063,17 +2063,17 @@ public:
     {
         // One EP & rkey config created during connection establishment
         ucp_worker_h worker = sender().worker();
-        EXPECT_EQ(worker->rkey_config_count, 1);
+        EXPECT_EQ(ucs_array_length(&worker->rkey_config), 1);
         EXPECT_EQ(worker->ep_config.length, 1);
 
         // New rkey config created during first operation
         send(1);
-        EXPECT_EQ(worker->rkey_config_count, 2);
+        EXPECT_EQ(ucs_array_length(&worker->rkey_config), 2);
         EXPECT_EQ(worker->ep_config.length, 1);
 
         // Existing rkey config is used during second operation
         send(1);
-        EXPECT_EQ(worker->rkey_config_count, 2);
+        EXPECT_EQ(ucs_array_length(&worker->rkey_config), 2);
         EXPECT_EQ(worker->ep_config.length, 1);
 
         ucp_proto_select_key_t key = any_key();
@@ -2087,14 +2087,14 @@ public:
         // Reduce port_speed of mock_0:1 by 50%, new EP & rkey configs are created
         set_port_speed("mock_0:1", 14e9);
         send(2);
-        EXPECT_EQ(worker->rkey_config_count, 3);
+        EXPECT_EQ(ucs_array_length(&worker->rkey_config), 3);
         EXPECT_EQ(worker->ep_config.length, 2);
 
         // Slightly change port_speed, so that quantized value remains the same
         // This shouldn't affect EP or rkey config
         set_port_speed("mock_0:1", 14.5e9);
         send(2);
-        EXPECT_EQ(worker->rkey_config_count, 3);
+        EXPECT_EQ(ucs_array_length(&worker->rkey_config), 3);
         EXPECT_EQ(worker->ep_config.length, 2);
 
         check_rkey_config(sender(), {
@@ -2105,7 +2105,7 @@ public:
         // new EP & rkey configs are created
         set_port_speed("mock_1:1", 14e9);
         send(3);
-        EXPECT_EQ(worker->rkey_config_count, 4);
+        EXPECT_EQ(ucs_array_length(&worker->rkey_config), 4);
         EXPECT_EQ(worker->ep_config.length, 3);
 
         check_rkey_config(sender(), {

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -399,8 +399,8 @@ public:
                                   ucp_proto_select_key_t key,
                                   ucp_worker_cfg_index_t rkey_cfg_index)
     {
-        ucp_rkey_config_t *config = &ucs_array_elem(&e.worker()->rkey_config,
-                                                    rkey_cfg_index);
+        ucp_rkey_config_t *config = ucs_array_elem(&e.worker()->rkey_config,
+                                                   rkey_cfg_index);
         check_proto_select(e, config->proto_select, data_vec, key,
                            rkey_cfg_index);
     }

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -429,8 +429,8 @@ public:
                                   ucp_proto_select_key_t key,
                                   ucp_worker_cfg_index_t rkey_cfg_index)
     {
-        ucp_rkey_config_t *config = &ucs_array_elem(&e.worker()->rkey_config,
-                                                    rkey_cfg_index);
+        ucp_rkey_config_t *config = ucs_array_elem(&e.worker()->rkey_config,
+                                                   rkey_cfg_index);
         check_proto_select(e, config->proto_select, data_vec, key,
                            rkey_cfg_index);
     }

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -12,6 +12,7 @@ extern "C" {
 #include <ucp/core/ucp_worker.h>
 #include <ucp/core/ucp_worker.inl>
 #include <ucp/core/ucp_request.h>
+#include <ucp/proto/proto_select.h>
 #include <ucp/wireup/address.h>
 #include <ucp/wireup/wireup_ep.h>
 #include <uct/base/uct_iface.h>
@@ -1065,3 +1066,37 @@ UCS_TEST_P(test_worker_cpu_mask, all_cpus)
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_worker_cpu_mask, all, "all")
+
+class test_ucp_worker_rkey_config : public ucp_test {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant(variants, UCP_FEATURE_RMA);
+    }
+};
+
+UCS_TEST_P(test_ucp_worker_rkey_config, stable_after_array_growth)
+{
+    ucp_worker_h worker             = sender().worker();
+    const size_t initial_capacity   = ucs_array_capacity(
+                                              &worker->rkey_config);
+    ucp_rkey_config_t *first_config = NULL;
+
+    ASSERT_GT(initial_capacity, 0);
+    while (ucs_array_length(&worker->rkey_config) <= initial_capacity) {
+        ucp_rkey_config_t *config = static_cast<ucp_rkey_config_t *>(
+                ucs_calloc(1, sizeof(*config), "test_rkey_config"));
+
+        ASSERT_TRUE(config != NULL);
+        ASSERT_UCS_OK(ucp_proto_select_init(&config->proto_select,
+                                            worker->epoch));
+        *ucs_array_append(&worker->rkey_config, FAIL()) = config;
+        if (first_config == NULL) {
+            first_config = config;
+        }
+    }
+
+    EXPECT_EQ(first_config, ucs_array_elem(&worker->rkey_config, 0));
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_worker_rkey_config, self, "self")

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -14,6 +14,7 @@ extern "C" {
 #include <ucp/core/ucp_worker.h>
 #include <ucp/core/ucp_worker.inl>
 #include <ucp/core/ucp_request.h>
+#include <ucp/proto/proto_select.h>
 #include <ucp/wireup/address.h>
 #include <ucp/wireup/wireup_ep.h>
 #include <uct/base/uct_iface.h>
@@ -1251,3 +1252,37 @@ UCS_TEST_P(test_worker_cpu_mask, all_cpus)
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_worker_cpu_mask, all, "all")
+
+class test_ucp_worker_rkey_config : public ucp_test {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant(variants, UCP_FEATURE_RMA);
+    }
+};
+
+UCS_TEST_P(test_ucp_worker_rkey_config, stable_after_array_growth)
+{
+    ucp_worker_h worker             = sender().worker();
+    const size_t initial_capacity   = ucs_array_capacity(
+                                              &worker->rkey_config);
+    ucp_rkey_config_t *first_config = NULL;
+
+    ASSERT_GT(initial_capacity, 0);
+    while (ucs_array_length(&worker->rkey_config) <= initial_capacity) {
+        ucp_rkey_config_t *config = static_cast<ucp_rkey_config_t *>(
+                ucs_calloc(1, sizeof(*config), "test_rkey_config"));
+
+        ASSERT_TRUE(config != NULL);
+        ASSERT_UCS_OK(ucp_proto_select_init(&config->proto_select,
+                                            worker->epoch));
+        *ucs_array_append(&worker->rkey_config, FAIL()) = config;
+        if (first_config == NULL) {
+            first_config = config;
+        }
+    }
+
+    EXPECT_EQ(first_config, ucs_array_elem(&worker->rkey_config, 0));
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_worker_rkey_config, self, "self")

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -1259,17 +1259,40 @@ public:
     {
         add_variant(variants, UCP_FEATURE_RMA);
     }
+
+protected:
+    void init() override
+    {
+        ucp_test::init();
+        sender().connect(&receiver(), get_ep_params());
+    }
 };
 
 UCS_TEST_P(test_ucp_worker_rkey_config, stable_after_array_growth)
 {
-    ucp_worker_h worker             = sender().worker();
-    const size_t initial_capacity   = ucs_array_capacity(
-                                              &worker->rkey_config);
-    ucp_rkey_config_t *first_config = NULL;
+    ucp_worker_h worker = sender().worker();
+    ucp_rkey_config_key_t key;
+    ucp_worker_cfg_index_t first_config_index;
+    ucp_worker_cfg_index_t config_index;
+    khiter_t khiter;
+
+    key.md_map             = 0;
+    key.ep_cfg_index       = sender().ep()->cfg_index;
+    key.sys_dev            = UCS_SYS_DEVICE_ID_UNKNOWN;
+    key.flags              = 0;
+    key.mem_type           = UCS_MEMORY_TYPE_HOST;
+    key.unreachable_md_map = 0;
+
+    ASSERT_UCS_OK(ucp_worker_rkey_config_get(worker, &key, NULL,
+                                             &first_config_index));
+    ucp_rkey_config_t *first_config = ucs_array_elem(
+            &worker->rkey_config, first_config_index);
+    const ucp_proto_select_short_t first_put_short = first_config->put_short;
+    const size_t initial_capacity = ucs_array_capacity(&worker->rkey_config);
 
     ASSERT_GT(initial_capacity, 0);
-    while (ucs_array_length(&worker->rkey_config) <= initial_capacity) {
+    ASSERT_LE(ucs_array_length(&worker->rkey_config), initial_capacity);
+    while (ucs_array_length(&worker->rkey_config) < initial_capacity) {
         ucp_rkey_config_t *config = static_cast<ucp_rkey_config_t *>(
                 ucs_calloc(1, sizeof(*config), "test_rkey_config"));
 
@@ -1277,12 +1300,32 @@ UCS_TEST_P(test_ucp_worker_rkey_config, stable_after_array_growth)
         ASSERT_UCS_OK(ucp_proto_select_init(&config->proto_select,
                                             worker->epoch));
         *ucs_array_append(&worker->rkey_config, FAIL()) = config;
-        if (first_config == NULL) {
-            first_config = config;
-        }
     }
 
-    EXPECT_EQ(first_config, ucs_array_elem(&worker->rkey_config, 0));
+    /* Use the production insertion path to cross the growth boundary. */
+    do {
+        ++key.md_map;
+        khiter = kh_get(ucp_worker_rkey_config, &worker->rkey_config_hash,
+                        key);
+    } while (khiter != kh_end(&worker->rkey_config_hash));
+
+    ASSERT_EQ(initial_capacity, ucs_array_length(&worker->rkey_config));
+    ASSERT_UCS_OK(ucp_worker_rkey_config_get(worker, &key, NULL,
+                                             &config_index));
+    EXPECT_EQ(initial_capacity, config_index);
+    ASSERT_GT(ucs_array_length(&worker->rkey_config), initial_capacity);
+
+    ucp_rkey_config_t *current_first_config = ucs_array_elem(
+            &worker->rkey_config, first_config_index);
+
+    EXPECT_EQ(first_config, current_first_config);
+    EXPECT_EQ(first_put_short.max_length_host_mem,
+              current_first_config->put_short.max_length_host_mem);
+    EXPECT_EQ(first_put_short.max_length_unknown_mem,
+              current_first_config->put_short.max_length_unknown_mem);
+    EXPECT_EQ(first_put_short.lane, current_first_config->put_short.lane);
+    EXPECT_EQ(first_put_short.rkey_index,
+              current_first_config->put_short.rkey_index);
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_worker_rkey_config, self, "self")


### PR DESCRIPTION
## What?

Store each rkey configuration separately from the resizable index array, and
update its users and tests for pointer-based storage.

This PR now contains only the stable-storage change. It depends on #11817 to
keep protocol selection out of async context; it does not add async locking.

## Why?

Protocol selection can recursively create another rkey configuration. With
inline storage, growing the array copies a partially initialized configuration
while the outer selection continues updating the old address. Later lookups
then use an incomplete copy.

This is reachable without an injected configuration: on Gaia, normal
default-reserve traffic naturally moved the array from 32 to 64 while an outer
rkey configuration was live. A diagnostic consistency check observed
`put_short` diverging between the old and current copies in 4/5 runs.

## How?

The resizable array stores pointers to separately allocated configurations.
Growing the array can move the pointer slots, but it cannot move a live
configuration. Worker cleanup destroys and frees each configuration.

## Validation

- Rebased onto current `master` and updated all current-master rkey-config
  test accesses.
- Exact #11817: 20/20 ordinary runs completed; the observation-only natural
  relocation check detected stale/current state divergence in 4/5 runs.
- Current `master` + #11817 + this PR: clean build, 31/31 selected tests,
  20/20 natural two-node runs, and 5/5 forced 32-to-33 pointer-array
  relocations. Every forced marker reported synchronous context.
