### PR TITLE
UCT/IB/MLX5/RC: Implement put_sgl_zcopy

### DIFF
--- a/src/uct/ib/mlx5/rc/rc_mlx5.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -122,6 +122,14 @@ ucs_status_t uct_rc_mlx5_base_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
                                            size_t iovcnt, uint64_t remote_addr,
                                            uct_rkey_t rkey,
                                            uct_completion_t *comp);
+
+ucs_status_t
+uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
+                                  const size_t *lengths, uct_mem_h const *memhs,
+                                  const uint64_t *remote_addrs,
+                                  uct_rkey_t const *rkeys, const size_t *counts,
+                                  const size_t *strides, size_t count,
+                                  uct_completion_t *comp);
 
 ucs_status_t
 uct_rc_mlx5_base_ep_get_bcopy(uct_ep_h tl_ep, uct_unpack_callback_t unpack_cb,

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -24,6 +24,14 @@
                                                         uct_rc_mlx5_iface_common_t)
 
 
+static UCS_F_ALWAYS_INLINE size_t
+uct_rc_mlx5_base_put_sgl_zcopy_max_count(uct_rc_iface_t *iface)
+{
+    return ucs_min((size_t)UCT_RC_MLX5_PUT_SGL_ZCOPY_MAX_COUNT,
+                   iface->config.tx_qp_len);
+}
+
+
 static UCS_F_ALWAYS_INLINE void
 uct_rc_mlx5_ep_fence_put(uct_rc_mlx5_iface_common_t *iface, uct_ib_mlx5_txwq_t *txwq,
                          uct_rkey_t *rkey, uint64_t *addr, uint16_t offset,

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -27,10 +27,8 @@
 static UCS_F_ALWAYS_INLINE size_t
 uct_rc_mlx5_base_put_sgl_zcopy_max_count(uct_rc_mlx5_iface_common_t *iface)
 {
-    size_t max_count = ucs_min((size_t)UCT_RC_MLX5_PUT_SGL_ZCOPY_MAX_COUNT,
-                               iface->super.config.tx_qp_len);
-
-    return ucs_min(max_count, iface->tx.bb_max);
+    /* Cap at half the QP so one SGL cannot monopolize the send queue. */
+    return ucs_min(iface->super.config.tx_qp_len / 2, iface->tx.bb_max);
 }
 
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -27,8 +27,13 @@
 static UCS_F_ALWAYS_INLINE size_t
 uct_rc_mlx5_base_put_sgl_zcopy_max_count(uct_rc_mlx5_iface_common_t *iface)
 {
+    size_t max_count;
+
     /* Cap at half the QP so one SGL cannot monopolize the send queue. */
-    return ucs_min(iface->super.config.tx_qp_len / 2, iface->tx.bb_max);
+    max_count = ucs_min(iface->super.config.tx_qp_len / 2, iface->tx.bb_max);
+
+    return ucs_min(max_count,
+                   uct_rc_iface_tx_cq_capacity(iface->super.config.tx_cq_len));
 }
 
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -25,10 +25,12 @@
 
 
 static UCS_F_ALWAYS_INLINE size_t
-uct_rc_mlx5_base_put_sgl_zcopy_max_count(uct_rc_iface_t *iface)
+uct_rc_mlx5_base_put_sgl_zcopy_max_count(uct_rc_mlx5_iface_common_t *iface)
 {
-    return ucs_min((size_t)UCT_RC_MLX5_PUT_SGL_ZCOPY_MAX_COUNT,
-                   iface->config.tx_qp_len);
+    size_t max_count = ucs_min((size_t)UCT_RC_MLX5_PUT_SGL_ZCOPY_MAX_COUNT,
+                               iface->super.config.tx_qp_len);
+
+    return ucs_min(max_count, iface->tx.bb_max);
 }
 
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 * Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
@@ -32,8 +32,9 @@ uct_rc_mlx5_base_put_sgl_zcopy_max_count(uct_rc_mlx5_iface_common_t *iface)
     /* Cap at half the QP so one SGL cannot monopolize the send queue. */
     max_count = ucs_min(iface->super.config.tx_qp_len / 2, iface->tx.bb_max);
 
-    return ucs_min(max_count,
-                   uct_rc_iface_tx_cq_capacity(iface->super.config.tx_cq_len));
+    max_count = ucs_min(max_count,
+                        uct_rc_iface_tx_cq_capacity(iface->super.config.tx_cq_len));
+    return max_count;
 }
 
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -133,6 +133,9 @@ enum {
     UCT_RC_MLX5_CQE_APP_OP_TM_REMOVE         = 0x6,
     UCT_RC_MLX5_CQE_APP_OP_TM_CONSUMED_MSG   = 0xA
 };
+
+#define UCT_RC_MLX5_PUT_SGL_ZCOPY_MAX_COUNT 128
+
 
 #define UCT_RC_MLX5_RMA_MAX_IOV(_av_size) \
     ((UCT_IB_MLX5_MAX_SEND_WQE_SIZE - ((_av_size) + \

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -133,9 +133,6 @@ enum {
     UCT_RC_MLX5_CQE_APP_OP_TM_REMOVE         = 0x6,
     UCT_RC_MLX5_CQE_APP_OP_TM_CONSUMED_MSG   = 0xA
 };
-
-#define UCT_RC_MLX5_PUT_SGL_ZCOPY_MAX_COUNT 128
-
 
 #define UCT_RC_MLX5_RMA_MAX_IOV(_av_size) \
     ((UCT_IB_MLX5_MAX_SEND_WQE_SIZE - ((_av_size) + \

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -203,13 +203,14 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
                     "put_sgl_zcopy count(%zu) should be limited by %zu", count,
                     max_count);
     ucs_assert(ep->super.flags & UCT_RC_EP_FLAG_CONNECTED);
-    ucs_assert(count > 0);
 
     /* TODO: add strided elements support */
     if (ucs_unlikely((counts != NULL) || (strides != NULL))) {
         ucs_error("put_sgl_zcopy does not support strided elements");
         return UCS_ERR_UNSUPPORTED;
     }
+
+    UCT_SKIP_ZERO_LENGTH(count);
 
     /* Validate all lengths before resource checks and fence state */
     for (i = 0; i < count; i++) {

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -217,13 +217,8 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
                          "put_sgl_zcopy");
     }
 
-    if (iface->super.tx.cq_available < (int)count) {
-        UCS_STATS_UPDATE_COUNTER(iface->super.stats,
-                                 UCT_RC_IFACE_STAT_NO_CQE, 1);
-        UCS_STATS_UPDATE_COUNTER(ep->super.super.stats,
-                                 UCT_EP_STAT_NO_RES, 1);
-        return UCS_ERR_NO_RESOURCE;
-    }
+    UCT_RC_CHECK_CQE_VALUE_RET(&iface->super, &ep->super,
+                               UCS_ERR_NO_RESOURCE, count - 1);
 
     UCT_RC_CHECK_NUM_RDMA_READ_RET(&iface->super, UCS_ERR_NO_RESOURCE);
     UCT_RC_CHECK_TXQP_VALUE_RET(&iface->super, &ep->super,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -196,6 +196,7 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
     uct_rkey_t rkey;
     void *curr;
     size_t UCS_V_UNUSED max_count;
+    int fence;
 
     max_count = uct_rc_mlx5_base_put_sgl_zcopy_max_count(iface);
     UCT_CHECK_PARAM(count <= max_count,
@@ -237,8 +238,8 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
     pi   = sn;
     curr = txwq->curr;
 
-    fence_flag = uct_rc_ep_fm(&iface->super, &txwq->fi, 1) ?
-                 iface->config.put_fence_flag : 0;
+    fence      = uct_rc_ep_fm(&iface->super, &txwq->fi, 1);
+    fence_flag = fence ? iface->config.put_fence_flag : 0;
 
     for (i = 0; i < count; i++) {
         fm_ce_se = ((i == 0) ? fence_flag : 0) |
@@ -249,7 +250,7 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
                                  txwq->super.qp_num, fm_ce_se, 0, wqe_size);
 
         addr = remote_addrs[i];
-        if (fence_flag != 0) {
+        if (fence) {
             rkey = uct_ib_resolve_atomic_rkey(
                     rkeys[i], ep->super.atomic_mr_offset, &addr);
         } else {

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -220,6 +220,12 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
     UCT_RC_CHECK_TXQP_VALUE_RET(&iface->super, &ep->super,
                                 UCS_ERR_NO_RESOURCE, count - 1);
 
+    /* Validate all lengths before consuming the fence state */
+    for (i = 0; i < count; i++) {
+        UCT_CHECK_LENGTH(lengths[i], 0, UCT_IB_MAX_MESSAGE_SIZE,
+                         "put_sgl_zcopy");
+    }
+
     wqe_size = sizeof(*ctrl) + sizeof(*raddr) + sizeof(*dptr);
     sn       = txwq->sw_pi;
 
@@ -233,9 +239,6 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
                  iface->config.put_fence_flag : 0;
 
     for (i = 0; i < count; i++) {
-        UCT_CHECK_LENGTH(lengths[i], 0, UCT_IB_MAX_MESSAGE_SIZE,
-                         "put_sgl_zcopy");
-
         fm_ce_se = ((i == 0) ? fence_flag : 0) |
                    ((i == count - 1) ? MLX5_WQE_CTRL_CQ_UPDATE : 0);
         ctrl     = curr;

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -189,12 +189,13 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
     struct mlx5_wqe_ctrl_seg *ctrl = NULL;
     struct mlx5_wqe_raddr_seg *raddr;
     struct mlx5_wqe_data_seg *dptr;
-    size_t wqe_size, i, max_count;
+    size_t wqe_size, i;
     uint8_t fm_ce_se, fence_flag;
     uint16_t sn, pi, res_count;
     uint64_t addr;
     uct_rkey_t rkey;
     void *curr;
+    size_t UCS_V_UNUSED max_count;
 
     max_count = uct_rc_mlx5_base_put_sgl_zcopy_max_count(iface);
     UCT_CHECK_PARAM(count <= max_count,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -179,10 +179,9 @@ ucs_status_t
 uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
                                   const size_t *lengths, uct_mem_h const *memhs,
                                   const uint64_t *remote_addrs,
-                                  uct_rkey_t const *rkeys,
-                                  const size_t UCS_V_UNUSED *counts,
-                                  const size_t UCS_V_UNUSED *strides,
-                                  size_t count, uct_completion_t *comp)
+                                  uct_rkey_t const *rkeys, const size_t *counts,
+                                  const size_t *strides, size_t count,
+                                  uct_completion_t *comp)
 {
     UCT_RC_MLX5_BASE_EP_DECL(tl_ep, iface, ep);
     uct_ib_mlx5_txwq_t *txwq       = &ep->tx.wq;
@@ -202,6 +201,12 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
                     count, (size_t)UCT_RC_MLX5_PUT_SGL_ZCOPY_MAX_COUNT);
     ucs_assert(ep->super.flags & UCT_RC_EP_FLAG_CONNECTED);
     ucs_assert(count > 0);
+
+    /* TODO: add strided elements support */
+    if (ucs_unlikely((counts != NULL) || (strides != NULL))) {
+        ucs_error("put_sgl_zcopy does not support strided elements");
+        return UCS_ERR_UNSUPPORTED;
+    }
 
     if (iface->super.tx.cq_available < (int)count) {
         UCS_STATS_UPDATE_COUNTER(iface->super.stats,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2019. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -173,6 +173,109 @@ ucs_status_t uct_rc_mlx5_base_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
                                  uct_iov_total_length(iov, iovcnt));
     uct_rc_ep_enable_flush_remote(&ep->super);
     return status;
+}
+
+ucs_status_t
+uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
+                                  const size_t *lengths, uct_mem_h const *memhs,
+                                  const uint64_t *remote_addrs,
+                                  uct_rkey_t const *rkeys,
+                                  const size_t UCS_V_UNUSED *counts,
+                                  const size_t UCS_V_UNUSED *strides,
+                                  size_t count, uct_completion_t *comp)
+{
+    UCT_RC_MLX5_BASE_EP_DECL(tl_ep, iface, ep);
+    uct_ib_mlx5_txwq_t *txwq       = &ep->tx.wq;
+    size_t total                   = 0;
+    struct mlx5_wqe_ctrl_seg *ctrl = NULL;
+    struct mlx5_wqe_raddr_seg *raddr;
+    struct mlx5_wqe_data_seg *dptr;
+    size_t wqe_size, i;
+    uint8_t fm_ce_se, fence_flag;
+    uint16_t sn, pi, res_count;
+    uint64_t addr;
+    uct_rkey_t rkey;
+    void *curr;
+
+    UCT_CHECK_PARAM(count <= UCT_RC_MLX5_PUT_SGL_ZCOPY_MAX_COUNT,
+                    "put_sgl_zcopy count(%zu) should be limited by %zu",
+                    count, (size_t)UCT_RC_MLX5_PUT_SGL_ZCOPY_MAX_COUNT);
+    ucs_assert(ep->super.flags & UCT_RC_EP_FLAG_CONNECTED);
+    ucs_assert(count > 0);
+
+    if (iface->super.tx.cq_available < (int)count) {
+        UCS_STATS_UPDATE_COUNTER(iface->super.stats,
+                                 UCT_RC_IFACE_STAT_NO_CQE, 1);
+        UCS_STATS_UPDATE_COUNTER(ep->super.super.stats,
+                                 UCT_EP_STAT_NO_RES, 1);
+        return UCS_ERR_NO_RESOURCE;
+    }
+
+    UCT_RC_CHECK_NUM_RDMA_READ_RET(&iface->super, UCS_ERR_NO_RESOURCE);
+    UCT_RC_CHECK_TXQP_VALUE_RET(&iface->super, &ep->super,
+                                UCS_ERR_NO_RESOURCE, count - 1);
+
+    wqe_size = sizeof(*ctrl) + sizeof(*raddr) + sizeof(*dptr);
+    sn       = txwq->sw_pi;
+
+    ucs_assert(!(txwq->flags & UCT_IB_MLX5_TXWQ_FLAG_FAILED));
+    ucs_assert(ucs_div_round_up(wqe_size, MLX5_SEND_WQE_BB) == 1);
+
+    pi   = sn;
+    curr = txwq->curr;
+
+    fence_flag = uct_rc_ep_fm(&iface->super, &txwq->fi, 1) ?
+                 iface->config.put_fence_flag : 0;
+
+    for (i = 0; i < count; i++) {
+        UCT_CHECK_LENGTH(lengths[i], 0, UCT_IB_MAX_MESSAGE_SIZE,
+                         "put_sgl_zcopy");
+
+        fm_ce_se = ((i == 0) ? fence_flag : 0) |
+                   ((i == count - 1) ? MLX5_WQE_CTRL_CQ_UPDATE : 0);
+        ctrl     = curr;
+
+        uct_ib_mlx5_set_ctrl_seg(ctrl, pi, MLX5_OPCODE_RDMA_WRITE, 0,
+                                 txwq->super.qp_num, fm_ce_se, 0, wqe_size);
+
+        addr = remote_addrs[i];
+        if (fence_flag != 0) {
+            rkey = uct_ib_resolve_atomic_rkey(
+                    rkeys[i], ep->super.atomic_mr_offset, &addr);
+        } else {
+            rkey = uct_ib_md_direct_rkey(rkeys[i]);
+        }
+
+        raddr = uct_ib_mlx5_txwq_wrap_none(txwq, ctrl + 1);
+        uct_ib_mlx5_ep_set_rdma_seg(raddr, addr, rkey);
+
+        dptr = uct_ib_mlx5_txwq_wrap_none(txwq, raddr + 1);
+        uct_ib_mlx5_set_data_seg(dptr, buffers[i], lengths[i],
+                                 uct_ib_memh_get_lkey(memhs[i]));
+
+        curr = UCS_PTR_BYTE_OFFSET(ctrl, MLX5_SEND_WQE_BB);
+        curr = uct_ib_mlx5_txwq_wrap_exact(txwq, curr);
+        pi++;
+        total += lengths[i];
+    }
+
+    res_count         = pi - 1 - txwq->prev_sw_pi;
+    txwq->prev_sw_pi += res_count;
+    txwq->sw_pi       = pi;
+    txwq->curr        = curr;
+    txwq->sig_pi      = txwq->prev_sw_pi;
+
+    uct_rc_txqp_posted(&ep->super.txqp, &iface->super, res_count, 1);
+    uct_ib_mlx5_txwq_ring_doorbell(txwq, ctrl, txwq->sw_pi, 1);
+
+    uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp,
+                              uct_rc_ep_send_op_completion_handler, comp, sn,
+                              UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY, NULL, 0, total);
+
+    UCT_TL_EP_STAT_OP(&ep->super.super, PUT, ZCOPY, total);
+    uct_rc_ep_enable_flush_remote(&ep->super);
+
+    return UCS_INPROGRESS;
 }
 
 ucs_status_t

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -196,7 +196,7 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
     uct_rkey_t rkey;
     void *curr;
 
-    max_count = uct_rc_mlx5_base_put_sgl_zcopy_max_count(&iface->super);
+    max_count = uct_rc_mlx5_base_put_sgl_zcopy_max_count(iface);
     UCT_CHECK_PARAM(count <= max_count,
                     "put_sgl_zcopy count(%zu) should be limited by %zu", count,
                     max_count);

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -189,16 +189,17 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
     struct mlx5_wqe_ctrl_seg *ctrl = NULL;
     struct mlx5_wqe_raddr_seg *raddr;
     struct mlx5_wqe_data_seg *dptr;
-    size_t wqe_size, i;
+    size_t wqe_size, i, max_count;
     uint8_t fm_ce_se, fence_flag;
     uint16_t sn, pi, res_count;
     uint64_t addr;
     uct_rkey_t rkey;
     void *curr;
 
-    UCT_CHECK_PARAM(count <= UCT_RC_MLX5_PUT_SGL_ZCOPY_MAX_COUNT,
-                    "put_sgl_zcopy count(%zu) should be limited by %zu",
-                    count, (size_t)UCT_RC_MLX5_PUT_SGL_ZCOPY_MAX_COUNT);
+    max_count = uct_rc_mlx5_base_put_sgl_zcopy_max_count(&iface->super);
+    UCT_CHECK_PARAM(count <= max_count,
+                    "put_sgl_zcopy count(%zu) should be limited by %zu", count,
+                    max_count);
     ucs_assert(ep->super.flags & UCT_RC_EP_FLAG_CONNECTED);
     ucs_assert(count > 0);
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -210,6 +210,12 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
         return UCS_ERR_UNSUPPORTED;
     }
 
+    /* Validate all lengths before resource checks and fence state */
+    for (i = 0; i < count; i++) {
+        UCT_CHECK_LENGTH(lengths[i], 0, UCT_IB_MAX_MESSAGE_SIZE,
+                         "put_sgl_zcopy");
+    }
+
     if (iface->super.tx.cq_available < (int)count) {
         UCS_STATS_UPDATE_COUNTER(iface->super.stats,
                                  UCT_RC_IFACE_STAT_NO_CQE, 1);
@@ -221,12 +227,6 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
     UCT_RC_CHECK_NUM_RDMA_READ_RET(&iface->super, UCS_ERR_NO_RESOURCE);
     UCT_RC_CHECK_TXQP_VALUE_RET(&iface->super, &ep->super,
                                 UCS_ERR_NO_RESOURCE, count - 1);
-
-    /* Validate all lengths before consuming the fence state */
-    for (i = 0; i < count; i++) {
-        UCT_CHECK_LENGTH(lengths[i], 0, UCT_IB_MAX_MESSAGE_SIZE,
-                         "put_sgl_zcopy");
-    }
 
     wqe_size = sizeof(*ctrl) + sizeof(*raddr) + sizeof(*dptr);
     sn       = txwq->sw_pi;

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -1034,13 +1034,14 @@ uct_rc_mlx5_ep_put_sgl_zcopy(uct_ep_h ep, void * const *buffers,
 }
 
 static ucs_status_t
-uct_rc_mlx5_iface_query_v2(uct_iface_h UCS_V_UNUSED iface,
+uct_rc_mlx5_iface_query_v2(uct_iface_h tl_iface,
                            uct_iface_attr_v2_t *iface_attr)
 {
-    size_t max_sgl = uct_ib_mlx5_ext_max_put_sgl_zcopy_count();
+    uct_rc_iface_t *iface = ucs_derived_of(tl_iface, uct_rc_iface_t);
+    size_t max_sgl        = uct_ib_mlx5_ext_max_put_sgl_zcopy_count();
 
     if (max_sgl == 0) {
-        max_sgl = UCT_RC_MLX5_PUT_SGL_ZCOPY_MAX_COUNT;
+        max_sgl = uct_rc_mlx5_base_put_sgl_zcopy_max_count(iface);
     }
 
     if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_CAP_FLAGS) {

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -1037,8 +1037,9 @@ static ucs_status_t
 uct_rc_mlx5_iface_query_v2(uct_iface_h tl_iface,
                            uct_iface_attr_v2_t *iface_attr)
 {
-    uct_rc_iface_t *iface = ucs_derived_of(tl_iface, uct_rc_iface_t);
-    size_t max_sgl        = uct_ib_mlx5_ext_max_put_sgl_zcopy_count();
+    uct_rc_mlx5_iface_common_t *iface = ucs_derived_of(tl_iface,
+                                                       uct_rc_mlx5_iface_common_t);
+    size_t max_sgl                    = uct_ib_mlx5_ext_max_put_sgl_zcopy_count();
 
     if (max_sgl == 0) {
         max_sgl = uct_rc_mlx5_base_put_sgl_zcopy_max_count(iface);

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -1012,13 +1012,39 @@ static UCS_CLASS_DEFINE_NEW_FUNC(uct_rc_mlx5_iface_t, uct_iface_t, uct_md_h,
 static UCS_CLASS_DEFINE_DELETE_FUNC(uct_rc_mlx5_iface_t, uct_iface_t);
 
 static ucs_status_t
+uct_rc_mlx5_ep_put_sgl_zcopy(uct_ep_h ep, void * const *buffers,
+                             const size_t *lengths, uct_mem_h const *memhs,
+                             const uint64_t *remote_addrs,
+                             uct_rkey_t const *rkeys, const size_t *counts,
+                             const size_t *strides, size_t count,
+                             uct_completion_t *comp)
+{
+    ucs_status_t status;
+
+    status = uct_ib_mlx5_ext_ep_put_sgl_zcopy(ep, buffers, lengths, memhs,
+                                              remote_addrs, rkeys, counts,
+                                              strides, count, comp);
+    if (status == UCS_ERR_UNSUPPORTED) {
+        status = uct_rc_mlx5_base_ep_put_sgl_zcopy(ep, buffers, lengths, memhs,
+                                                   remote_addrs, rkeys, counts,
+                                                   strides, count, comp);
+    }
+
+    return status;
+}
+
+static ucs_status_t
 uct_rc_mlx5_iface_query_v2(uct_iface_h UCS_V_UNUSED iface,
                            uct_iface_attr_v2_t *iface_attr)
 {
     size_t max_sgl = uct_ib_mlx5_ext_max_put_sgl_zcopy_count();
 
+    if (max_sgl == 0) {
+        max_sgl = UCT_RC_MLX5_PUT_SGL_ZCOPY_MAX_COUNT;
+    }
+
     if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_CAP_FLAGS) {
-        iface_attr->cap.flags = (max_sgl > 0) ? UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY : 0;
+        iface_attr->cap.flags = UCT_IFACE_FLAG_V2_PUT_SGL_ZCOPY;
     }
 
     if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_MAX_PUT_SGL_ZCOPY_COUNT) {
@@ -1040,7 +1066,7 @@ static uct_rc_iface_ops_t uct_rc_mlx5_iface_ops = {
             .iface_is_reachable_v2  = uct_rc_mlx5_iface_is_reachable_v2,
             .ep_is_connected        = uct_rc_mlx5_base_ep_is_connected,
             .ep_get_device_ep       = (uct_ep_get_device_ep_func_t)ucs_empty_function_return_unsupported,
-            .ep_put_sgl_zcopy       = uct_ib_mlx5_ext_ep_put_sgl_zcopy
+            .ep_put_sgl_zcopy       = uct_rc_mlx5_ep_put_sgl_zcopy
         },
         .create_cq      = uct_rc_mlx5_iface_common_create_cq,
         .destroy_cq     = uct_rc_mlx5_iface_common_destroy_cq,

--- a/src/uct/ib/rc/base/rc_ep.c
+++ b/src/uct/ib/rc/base/rc_ep.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2014. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 * Copyright (c) UT-Battelle, LLC. 2015. ALL RIGHTS RESERVED.
 * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
@@ -150,6 +150,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_ep_t, uct_rc_iface_t *iface, uint32_t qp_num,
     self->path_index   = UCT_EP_PARAMS_GET_PATH_INDEX(params);
     self->flags        = 0;
     self->txqp_reserve = 0;
+    self->cq_reserve   = 0;
 
     status = uct_rc_fc_init(&self->fc, iface UCS_STATS_ARG(self->super.stats));
     if (status != UCS_OK) {
@@ -315,7 +316,8 @@ ucs_status_t uct_rc_ep_pending_add(uct_ep_h tl_ep, uct_pending_req_t *n,
     uct_rc_iface_t *iface = ucs_derived_of(tl_ep->iface, uct_rc_iface_t);
     uct_rc_ep_t *ep = ucs_derived_of(tl_ep, uct_rc_ep_t);
 
-    if (uct_rc_ep_has_tx_resources(ep) &&
+    if (uct_rc_ep_have_tx_cqe_avail(ep) &&
+        uct_rc_ep_has_tx_resources(ep) &&
         uct_rc_iface_has_tx_resources(iface)) {
         return UCS_ERR_BUSY;
     }
@@ -346,10 +348,12 @@ ucs_arbiter_cb_result_t uct_rc_ep_process_pending(ucs_arbiter_t *arbiter,
     status = uct_rc_iface_invoke_pending_cb(iface, req);
     if (status == UCS_OK) {
         ep->txqp_reserve = 0;
+        ep->cq_reserve   = 0;
         return UCS_ARBITER_CB_RESULT_REMOVE_ELEM;
     } else if (status == UCS_INPROGRESS) {
         return UCS_ARBITER_CB_RESULT_NEXT_GROUP;
-    } else if (!uct_rc_iface_has_tx_resources(iface)) {
+    } else if (!uct_rc_iface_has_tx_resources(iface) ||
+               !uct_rc_ep_have_tx_cqe_avail(ep)) {
         /* No iface resources */
         return UCS_ARBITER_CB_RESULT_STOP;
     }

--- a/src/uct/ib/rc/base/rc_ep.h
+++ b/src/uct/ib/rc/base/rc_ep.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2014. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -97,12 +97,17 @@ enum {
     /* tx_moderation == 0 for TLs which don't support it */ \
     if (ucs_unlikely((_iface)->tx.cq_available <= \
         (signed)(_iface)->config.tx_moderation)) { \
-        if (!uct_rc_iface_have_tx_cqe_avail(_iface)) { \
-            UCS_STATS_UPDATE_COUNTER((_iface)->stats, UCT_RC_IFACE_STAT_NO_CQE, 1); \
-            UCS_STATS_UPDATE_COUNTER((_ep)->super.stats, UCT_EP_STAT_NO_RES, 1); \
-            return _ret; \
-        } \
+        UCT_RC_CHECK_CQE_VALUE_RET(_iface, _ep, _ret, 0); \
         (_ep)->txqp.unsignaled = RC_UNSIGNALED_INF; \
+    }
+
+#define UCT_RC_CHECK_CQE_VALUE_RET(_iface, _ep, _ret, _value) \
+    if ((_iface)->tx.cq_available <= (signed)(_value)) { \
+        (_ep)->cq_reserve = ucs_max((_ep)->cq_reserve, \
+                                    (uint16_t)(_value)); \
+        UCS_STATS_UPDATE_COUNTER((_iface)->stats, UCT_RC_IFACE_STAT_NO_CQE, 1); \
+        UCS_STATS_UPDATE_COUNTER((_ep)->super.stats, UCT_EP_STAT_NO_RES, 1); \
+        return _ret; \
     }
 
 #define UCT_RC_CHECK_TXQP_RET(_iface, _ep, _ret) \
@@ -225,6 +230,7 @@ struct uct_rc_ep {
     uct_rc_fc_t         fc;
     uint16_t            atomic_mr_offset;
     uint16_t            txqp_reserve;
+    uint16_t            cq_reserve;
     uint8_t             path_index;
     uint8_t             flags;
 };
@@ -354,6 +360,15 @@ static UCS_F_ALWAYS_INLINE int uct_rc_ep_has_tx_resources(uct_rc_ep_t *ep)
 
     return (uct_rc_txqp_available(&ep->txqp) > ep->txqp_reserve) &&
            uct_rc_fc_has_resources(iface, &ep->fc);
+}
+
+static UCS_F_ALWAYS_INLINE int
+uct_rc_ep_have_tx_cqe_avail(uct_rc_ep_t *ep)
+{
+    uct_rc_iface_t *iface = ucs_derived_of(ep->super.super.iface,
+                                           uct_rc_iface_t);
+
+    return iface->tx.cq_available > (signed)ep->cq_reserve;
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2021. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 * Copyright (C) Huawei Technologies Co., Ltd. 2021.  ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
@@ -587,7 +587,7 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_iface_ops_t *tl_ops,
     tx_cq_size                  = uct_ib_cq_size(&self->super, init_attr,
                                                  UCT_IB_DIR_TX);
     /* Prevent title CQE overwriting */
-    self->tx.cq_available       = tx_cq_size - 2;
+    self->tx.cq_available       = uct_rc_iface_tx_cq_capacity(tx_cq_size);
     self->rx.srq.available      = 0;
     self->rx.srq.quota          = 0;
     self->config.tx_qp_len      = config->super.tx.queue_len;

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2014. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -22,6 +22,7 @@
 #define UCT_RC_QP_TABLE_SIZE        UCS_BIT(UCT_RC_QP_TABLE_ORDER)
 #define UCT_RC_QP_TABLE_MEMB_ORDER  (UCT_IB_QPN_ORDER - UCT_RC_QP_TABLE_ORDER)
 #define UCT_RC_QP_MAX_RETRY_COUNT   7
+#define UCT_RC_TX_CQ_RESERVED       2
 
 #define UCT_RC_CHECK_AM_SHORT(_am_id, _length, _header_t, _max_inline) \
      UCT_CHECK_AM_ID(_am_id); \
@@ -485,6 +486,12 @@ static UCS_F_ALWAYS_INLINE int
 uct_rc_iface_have_tx_cqe_avail(uct_rc_iface_t* iface)
 {
     return iface->tx.cq_available > 0;
+}
+
+static UCS_F_ALWAYS_INLINE unsigned
+uct_rc_iface_tx_cq_capacity(unsigned tx_cq_len)
+{
+    return tx_cq_len - UCT_RC_TX_CQ_RESERVED;
 }
 
 /**


### PR DESCRIPTION
## What?
Implement `put_sgl_zcopy` for RC over mlx5.

## Why?
Posts all SGL elements in one submission.

## How?
`uct_rc_mlx5_base_ep_put_sgl_zcopy` writes one RDMA-write WQE per element, then accounts the batch once and rings the doorbell via `uct_ib_mlx5_txwq_ring_doorbell`.