### PR TITLE
UCP/PROTO: Initialize protocol range endpoint

### DIFF
--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -360,6 +360,7 @@ ucp_proto_select_elem_init_thresh(ucp_worker_h worker,
      * possible message sizes until SIZE_MAX.
      */
     msg_length = 0;
+    max_length = SIZE_MAX;
     do {
         ucs_array_init_dynamic(&perf_list);
         ucs_array_init_dynamic(&envelope);


### PR DESCRIPTION
## What?

Initialize the protocol-selection range endpoint before entering the selection loop.

Fixes https://github.com/openucx/ucx/issues/11590

## Why?

GCC 11 cannot always prove that the range helper assigns the endpoint before it is used by the loop condition, which can trigger a `-Werror=maybe-uninitialized` compilation failure. Explicitly initializing it to the same upper bound used by the helper prevents the warning without changing protocol-selection behavior.