### PR TITLE
UCP/CORE: Restore cached mem_flags for UCX-owned allocations

### DIFF
--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -847,6 +847,15 @@ ucp_memh_create_from_mem(ucp_context_h context,
 
     memh->alloc_md_index = ucp_mem_get_md_index(context, mem->md, mem->method);
     if (memh->alloc_md_index != UCP_NULL_RESOURCE) {
+        /* Pointer detection may depend on a thread-local CUDA context.
+         * UCX-owned allocations from the cached allocation MD should have the
+         * same properties as the allocation used to initialize that cache. */
+        if (context->alloc_md[mem->mem_type].initialized &&
+            (context->alloc_md[mem->mem_type].md_index ==
+             memh->alloc_md_index)) {
+            memh->mem_flags |= context->alloc_md[mem->mem_type].mem_flags;
+        }
+
         memh->uct[memh->alloc_md_index] = mem->memh;
         memh->md_map                   |= UCS_BIT(memh->alloc_md_index);
         ucs_trace("allocated address %p length %zu on md[%d]=%s %p",


### PR DESCRIPTION
### What
When `ucp_memh_create_from_mem()` builds a memory handle for a UCX-owned allocation, restore the memory-type flags (notably `UCS_MEM_FLAG_REGISTRABLE`) from the cached allocation MD instead of relying solely on pointer detection. 

### Why
`memh->mem_flags` drives which MDs the rendezvous protocol must register the buffer on. For CUDA memory, deriving `UCS_MEM_FLAG_REGISTRABLE` via pointer detection can depend on a **thread-local CUDA context** on the calling thread.
NIXL allocates/registers buffers from a thread that does **not** have the CUDA context bound (a worker/progress thread separate from the one that created the context). On that thread, `REGISTRABLE` is silently dropped from the handle.

[Internal Bug](https://nvbugspro.nvidia.com/bug/6461501)