### PR TITLE
UCP/PROTO/MULTI: Preserve combined minimum for rendezvous

### DIFF
--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -405,7 +405,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     ucp_lane_index_t i, lane, num_lanes, num_fast_lanes;
     ucp_proto_multi_lane_priv_t *lpriv;
     size_t max_frag, min_end_offset, min_chunk;
-    size_t UCS_V_UNUSED min_length;
+    size_t min_length;
     ucp_proto_lane_selection_t selection;
     ucp_md_map_t reg_md_map;
     uint32_t weight_sum;
@@ -471,6 +471,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     perf.recv_overhead      = 0;
     perf.latency            = 0;
     perf.sys_latency        = 0;
+    perf.min_length         = 0;
     max_frag_ratio          = 0;
     min_bandwidth           = DBL_MAX;
 
@@ -627,6 +628,7 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
                    lane_perf->min_length);
 
         weight_sum           += lpriv->weight;
+        perf.min_length       = ucs_max(perf.min_length, min_length);
         min_end_offset       += min_chunk;
         mpriv->min_frag       = ucs_max(mpriv->min_frag, lane_perf->min_length);
         mpriv->max_frag_sum  += lpriv->max_frag;
@@ -660,8 +662,9 @@ ucs_status_t ucp_proto_multi_init(const ucp_proto_multi_init_params_t *params,
     }
     ucs_assert(mpriv->num_lanes == ucs_popcount(selection.lane_map));
 
-    /* Multi-lane protocols with non-zero min_frag pad length if needed */
-    perf.min_length = mpriv->min_frag;
+    if (params->single_lane_min_length) {
+        perf.min_length = mpriv->min_frag;
+    }
 
     if (mpriv->num_lanes == 1) {
         perf.node = lanes_perf[ucs_ffs64(selection.lane_map)].node;

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -125,7 +125,7 @@ typedef struct {
 
     /* Use the largest per-lane minimum as the protocol minimum, allowing short
      * messages that do not use all selected lanes */
-    int                            single_lane_min_length;
+    size_t                         single_lane_min_length;
 
     /* MDs on which the buffer is expected to be already registered, so no need
        to account for the overhead of registering on them */

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -123,6 +123,10 @@ typedef struct {
      * several parts. The goal is to not split below this limit */
     size_t                         min_chunk;
 
+    /* Use the largest per-lane minimum as the protocol minimum, allowing short
+     * messages that do not use all selected lanes */
+    int                            single_lane_min_length;
+
     /* MDs on which the buffer is expected to be already registered, so no need
        to account for the overhead of registering on them */
     ucp_md_map_t                   initial_reg_md_map;

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -219,14 +219,15 @@ ucp_proto_get_offload_zcopy_probe(const ucp_proto_init_params_t *init_params)
         .super.exclude_map   = 0,
         .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
                                                      init_params->select_param),
-        .max_lanes           = context->config.ext.max_rma_lanes,
-        .min_chunk           = context->config.ext.min_rma_chunk_size,
-        .initial_reg_md_map  = 0,
-        .first.tl_cap_flags  = UCT_IFACE_FLAG_GET_ZCOPY,
-        .first.lane_type     = UCP_LANE_TYPE_RMA_BW,
-        .middle.tl_cap_flags = UCT_IFACE_FLAG_GET_ZCOPY,
-        .middle.lane_type    = UCP_LANE_TYPE_RMA_BW,
-        .opt_align_offs      = UCP_PROTO_COMMON_OFFSET_INVALID
+        .max_lanes              = context->config.ext.max_rma_lanes,
+        .min_chunk              = context->config.ext.min_rma_chunk_size,
+        .single_lane_min_length = 1,
+        .initial_reg_md_map     = 0,
+        .first.tl_cap_flags     = UCT_IFACE_FLAG_GET_ZCOPY,
+        .first.lane_type        = UCP_LANE_TYPE_RMA_BW,
+        .middle.tl_cap_flags    = UCT_IFACE_FLAG_GET_ZCOPY,
+        .middle.lane_type       = UCP_LANE_TYPE_RMA_BW,
+        .opt_align_offs         = UCP_PROTO_COMMON_OFFSET_INVALID
     };
 
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_GET))) {

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -1460,6 +1460,40 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_twins_tag, use_single_net_device_2,
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx_twins_tag, rcx, "rc_x")
 
+class test_ucp_proto_mock_rcx_twins_rndv_min :
+    public test_ucp_proto_mock_rcx_twins_tag {
+public:
+    virtual void init() override
+    {
+        auto iface_attr_func = [](uct_iface_attr_t &iface_attr) {
+            iface_attr.cap.am.max_short  = 208;
+            iface_attr.cap.get.min_zcopy = 65;
+            iface_attr.bandwidth.shared  = 28e9;
+            iface_attr.latency.c         = 500e-9;
+            iface_attr.latency.m         = 1e-9;
+        };
+
+        add_mock_iface("mock_0:1", iface_attr_func);
+        add_mock_iface("mock_1:1", iface_attr_func);
+        add_mock_iface("mock_2:1", iface_attr_func);
+        test_ucp_proto_mock::init();
+    }
+};
+
+UCS_TEST_P(test_ucp_proto_mock_rcx_twins_rndv_min,
+           rndv_respects_lane_min_length,
+           "IB_NUM_PATHS?=1", "RNDV_THRESH=1", "RNDV_SCHEME=get_zcopy",
+           "MAX_RNDV_LANES=2")
+{
+    check_config(
+            {{0, 129, "eager short", "rc_mlx5/mock_0:1"},
+             {130, INF, "rendezvous zero-copy read from remote",
+              "50% on rc_mlx5/mock_0:1 and 50% on rc_mlx5/mock_1:1"}});
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx_twins_rndv_min, rcx,
+                              "rc_x")
+
 class test_ucp_proto_mock_rcx_twins_put : public test_ucp_proto_mock_rcx_twins {
 protected:
     void check_config(const proto_select_data_vec_t &data_vec);


### PR DESCRIPTION
## What?
Restore the combined minimum size for multi-lane protocols while preserving short direct GET operations.

## Why?
Multi-rail rendezvous became eligible too early, replacing eager at 128 bytes and causing a CUDA bandwidth regression.
[Internal issue](https://redmine.mellanox.com/issues/5100788)