### PR TITLE
UCT/ROCM,UCP/RNDV: Reclaim signals and bound pipeline work

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Alexey Rivkin <arivkin@nvidia.com>
 Alina Sklarevich <alinas@mellanox.com>
 Alma Mastbaum <amastbaum@nvidia.com>
 Anatoly Vildemanov <anatolyv@nvidia.com>
+Andreas Karatzas <Andreas.Karatzas@amd.com>
 Andrey Maslennikov <andreyma@mellanox.com>
 Arnaud Celermajer <acelermajer@nvidia.com>
 Artem Polyakov <artemp@nvidia.com>

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -390,6 +390,12 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "even if invalidation workflow isn't supported",
    ucs_offsetof(ucp_context_config_t, rndv_errh_ppln_enable), UCS_CONFIG_TYPE_BOOL},
 
+  {"RNDV_PIPELINE_MAX_INFLIGHT", "16",
+   "Maximum number of fragments that one rendezvous pipeline request may have\n"
+   "in flight at a time.",
+   ucs_offsetof(ucp_context_config_t, rndv_ppln_max_inflight),
+   UCS_CONFIG_TYPE_UINT},
+
   {"RMA_PPLN_ENABLE", "n",
    "Force-enable the RMA rendezvous put/get protocols.",
    ucs_offsetof(ucp_context_config_t, rma_ppln_enable), UCS_CONFIG_TYPE_BOOL},

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -128,6 +128,8 @@ typedef struct ucp_context_config {
     int                                    rndv_shm_ppln_enable;
     /** Enable error handling for rndv pipeline protocol */
     int                                    rndv_errh_ppln_enable;
+    /** Maximal number of in-flight fragments per RNDV pipeline request */
+    unsigned                               rndv_ppln_max_inflight;
     /** Force-enable the RMA rendezvous put/get protocols */
     int                                    rma_ppln_enable;
     /** Threshold for using tag matching offload capabilities. Smaller buffers

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -327,6 +327,12 @@ struct ucp_request {
                                 struct {
                                     /* Size to send in ack message */
                                     ssize_t ack_data_size;
+                                    /* Number of in-flight fragments */
+                                    unsigned inflight;
+                                    /* Whether a refill callback is scheduled */
+                                    uint8_t refill_scheduled;
+                                    /* Whether fragments are being posted */
+                                    uint8_t posting;
                                 } ppln;
 
                                 /* Used by rndv/rkey_ptr */

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -32,6 +32,15 @@ typedef struct {
     size_t                    frag_proto_min_length; /* Frag proto min length */
 } ucp_proto_rndv_ppln_priv_t;
 
+static unsigned ucp_proto_rndv_ppln_refill(void *arg);
+
+static int
+ucp_proto_rndv_ppln_refill_remove_filter(const ucs_callbackq_elem_t *elem,
+                                          void *arg)
+{
+    return (elem->cb == ucp_proto_rndv_ppln_refill) && (elem->arg == arg);
+}
+
 static ucs_status_t
 ucp_proto_rndv_ppln_add_overhead(ucp_proto_perf_t *ppln_perf, size_t frag_size)
 {
@@ -208,14 +217,43 @@ ucp_proto_rndv_ppln_frag_complete(ucp_request_t *freq, int send_ack, int abort,
                                   const char *title)
 {
     ucp_request_t *req = ucp_request_get_super(freq);
+    size_t unposted;
 
     if (send_ack) {
         req->send.rndv.ppln.ack_data_size += freq->send.state.dt_iter.length;
     }
 
+    if (abort) {
+        if (req->send.rndv.ppln.refill_scheduled) {
+            ucs_callbackq_remove_oneshot(
+                    &req->send.ep->worker->uct->progress_q,
+                    req->send.ep->worker,
+                    ucp_proto_rndv_ppln_refill_remove_filter, req);
+            req->send.rndv.ppln.refill_scheduled = 0;
+        }
+
+        if (!ucp_datatype_iter_is_end(&req->send.state.dt_iter)) {
+            unposted = req->send.state.dt_iter.length -
+                       req->send.state.dt_iter.offset;
+            req->send.state.completed_size += unposted;
+            req->send.state.dt_iter.offset = req->send.state.dt_iter.length;
+        }
+    }
+
+    ucs_assert(req->send.rndv.ppln.inflight > 0);
+    --req->send.rndv.ppln.inflight;
+
     /* In case of abort we don't destroy super request until all fragments are
      * completed */
     if (!ucp_proto_rndv_frag_complete(req, freq, title)) {
+        if (!abort && !req->send.rndv.ppln.posting &&
+            !ucp_datatype_iter_is_end(&req->send.state.dt_iter) &&
+            !req->send.rndv.ppln.refill_scheduled) {
+            req->send.rndv.ppln.refill_scheduled = 1;
+            ucs_callbackq_add_oneshot(&req->send.ep->worker->uct->progress_q,
+                                      req->send.ep->worker,
+                                      ucp_proto_rndv_ppln_refill, req);
+        }
         return NULL;
     }
 
@@ -232,6 +270,16 @@ ucp_proto_rndv_ppln_frag_complete(ucp_request_t *freq, int send_ack, int abort,
     } else {
         return req;
     }
+}
+
+static unsigned ucp_proto_rndv_ppln_refill(void *arg)
+{
+    ucp_request_t *req = arg;
+
+    ucs_assert(req->send.rndv.ppln.refill_scheduled);
+    req->send.rndv.ppln.refill_scheduled = 0;
+    ucp_request_send(req);
+    return 1;
 }
 
 void ucp_proto_rndv_ppln_send_frag_complete(ucp_request_t *freq, int send_ack)
@@ -266,6 +314,7 @@ static ucs_status_t ucp_proto_rndv_ppln_progress(uct_pending_req_t *uct_req)
     ucs_status_t status;
     ucp_request_t *freq;
     size_t overlap;
+    unsigned max_inflight;
 
     /* Nested pipeline is prevented during protocol selection */
     ucs_assert(!(req->flags & UCP_REQUEST_FLAG_RNDV_FRAG));
@@ -273,13 +322,25 @@ static ucs_status_t ucp_proto_rndv_ppln_progress(uct_pending_req_t *uct_req)
     /* Zero-length is not supported */
     ucs_assert(req->send.state.dt_iter.length > 0);
 
-    req->send.state.completed_size    = 0;
-    req->send.rndv.ppln.ack_data_size = 0;
-    rpriv                             = req->send.proto_config->priv;
+    if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
+        req->send.state.completed_size             = 0;
+        req->send.rndv.ppln.ack_data_size          = 0;
+        req->send.rndv.ppln.inflight               = 0;
+        req->send.rndv.ppln.refill_scheduled       = 0;
+        req->send.rndv.ppln.posting                = 0;
+        req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
+    }
 
-    while (!ucp_datatype_iter_is_end(&req->send.state.dt_iter)) {
+    rpriv        = req->send.proto_config->priv;
+    max_inflight = ucs_max(1u,
+                           worker->context->config.ext.rndv_ppln_max_inflight);
+
+    req->send.rndv.ppln.posting = 1;
+    while ((req->send.rndv.ppln.inflight < max_inflight) &&
+           !ucp_datatype_iter_is_end(&req->send.state.dt_iter)) {
         status = ucp_proto_rndv_frag_request_alloc(worker, req, &freq);
         if (status != UCS_OK) {
+            req->send.rndv.ppln.posting = 0;
             ucp_proto_request_abort(req, status);
             return UCS_OK;
         }
@@ -308,11 +369,12 @@ static ucs_status_t ucp_proto_rndv_ppln_progress(uct_pending_req_t *uct_req)
 
         ucp_trace_req(req, "send freq %p offset %zu size %zu", freq,
                       freq->send.rndv.offset, freq->send.state.dt_iter.length);
-        UCS_PROFILE_CALL_VOID_ALWAYS(ucp_request_send, freq);
-
         ucp_datatype_iter_copy_position(&req->send.state.dt_iter, &next_iter,
                                         UCS_BIT(UCP_DATATYPE_CONTIG));
+        ++req->send.rndv.ppln.inflight;
+        UCS_PROFILE_CALL_VOID_ALWAYS(ucp_request_send, freq);
     }
+    req->send.rndv.ppln.posting = 0;
 
     return UCS_OK;
 }

--- a/src/uct/rocm/base/rocm_signal.c
+++ b/src/uct/rocm/base/rocm_signal.c
@@ -40,10 +40,11 @@ ucs_mpool_ops_t uct_rocm_base_signal_desc_mpool_ops = {
     .obj_str       = NULL
 };
 
-unsigned uct_rocm_base_progress(ucs_queue_head_t *signal_queue)
+static unsigned
+uct_rocm_base_progress_limit(ucs_queue_head_t *signal_queue,
+                             unsigned max_signals)
 {
-    static const unsigned max_signals = 16;
-    unsigned count                    = 0;
+    unsigned count = 0;
     uct_rocm_base_signal_desc_t *rocm_signal;
     hsa_status_t status;
 
@@ -70,3 +71,12 @@ unsigned uct_rocm_base_progress(ucs_queue_head_t *signal_queue)
     return count;
 }
 
+unsigned uct_rocm_base_progress(ucs_queue_head_t *signal_queue)
+{
+    return uct_rocm_base_progress_limit(signal_queue, 16);
+}
+
+unsigned uct_rocm_base_progress_all(ucs_queue_head_t *signal_queue)
+{
+    return uct_rocm_base_progress_limit(signal_queue, UINT_MAX);
+}

--- a/src/uct/rocm/base/rocm_signal.h
+++ b/src/uct/rocm/base/rocm_signal.h
@@ -17,3 +17,5 @@ typedef struct uct_rocm_base_signal_desc {
 extern ucs_mpool_ops_t uct_rocm_base_signal_desc_mpool_ops;
 
 unsigned uct_rocm_base_progress(ucs_queue_head_t *signal_queue);
+
+unsigned uct_rocm_base_progress_all(ucs_queue_head_t *signal_queue);

--- a/src/uct/rocm/copy/rocm_copy_ep.c
+++ b/src/uct/rocm/copy/rocm_copy_ep.c
@@ -196,6 +196,14 @@ ucs_status_t uct_rocm_copy_ep_zcopy(uct_ep_h tl_ep, uint64_t remote_addr,
 
     rocm_copy_signal = ucs_mpool_get(&iface->signal_pool);
     if (rocm_copy_signal == NULL) {
+        /* The regular progress path intentionally limits completion handling
+         * to keep a single call bounded. On pool exhaustion, however, scan the
+         * whole queue before treating signals as genuinely in flight. */
+        uct_rocm_base_progress_all(&iface->signal_queue);
+        rocm_copy_signal = ucs_mpool_get(&iface->signal_pool);
+    }
+
+    if (rocm_copy_signal == NULL) {
         ucs_error("increase the maximum number of signal pool elements with "
                   "UCX_ROCM_COPY_SIGPOOL_MAX_ELEMS");
         return UCS_ERR_IO_ERROR;

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -307,12 +307,13 @@ if HAVE_GNUXX11
 gtest_SOURCES += \
 	ucm/rocm_hooks.cc
 gtest_CPPFLAGS += \
-	$(HIP_CPPFLAGS)
+	$(HIP_CPPFLAGS) \
+	$(ROCM_CPPFLAGS)
 gtest_CXXFLAGS += \
 	$(HIP_CXXFLAGS)
 gtest_LDADD += \
 	$(HIP_LDFLAGS) \
-	$(HIP_LIBS) \
+	$(HIP_LIBS) $(ROCM_LIBS) \
 	$(top_builddir)/src/uct/rocm/libuct_rocm.la
 endif
 endif

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -406,6 +406,7 @@ public:
          * ucp_proto_rma_rndv_probe_check(); force-enable them so the tests can
          * run on any CPU. */
         modify_config("RMA_PPLN_ENABLE", "y");
+        modify_config("RNDV_PIPELINE_MAX_INFLIGHT", "1");
         modify_config("PROTOS", "put/rndv,get/rndv,rndv/*");
     }
 

--- a/test/gtest/uct/test_p2p_rma.cc
+++ b/test/gtest/uct/test_p2p_rma.cc
@@ -8,6 +8,14 @@
 
 #include <functional>
 
+#if HAVE_ROCM
+extern "C" {
+#include <uct/rocm/base/rocm_base.h>
+#include <uct/rocm/base/rocm_signal.h>
+#include <uct/rocm/copy/rocm_copy_iface.h>
+}
+#endif
+
 
 uct_p2p_rma_test::uct_p2p_rma_test() : uct_p2p_test(0) {
 }
@@ -141,6 +149,66 @@ UCS_TEST_SKIP_COND_P(uct_p2p_rma_test, get_zcopy,
 }
 
 UCT_INSTANTIATE_TEST_CASE(uct_p2p_rma_test)
+
+#if HAVE_ROCM
+class uct_rocm_copy_rma_test : public uct_p2p_rma_test {
+public:
+    void init() override
+    {
+        modify_config("ROCM_COPY_SIGPOOL_MAX_ELEMS", "128");
+        uct_p2p_rma_test::init();
+    }
+
+protected:
+    struct completion {
+        uct_completion_t uct;
+        volatile bool    completed;
+    };
+
+    static void completion_cb(uct_completion_t *uct)
+    {
+        completion *comp = ucs_container_of(uct, completion, uct);
+        comp->completed   = true;
+    }
+};
+
+UCS_TEST_P(uct_rocm_copy_rma_test, completed_signal_reclaim)
+{
+    uct_rocm_copy_iface_t *iface = ucs_derived_of(sender().iface(),
+                                                  uct_rocm_copy_iface_t);
+    mapped_buffer sendbuf(2 * UCS_MBYTE, SEED1, sender(), 0,
+                          UCS_MEMORY_TYPE_ROCM);
+    mapped_buffer recvbuf(2 * UCS_MBYTE, SEED2, receiver(), 0,
+                          UCS_MEMORY_TYPE_ROCM);
+    const uct_iov_t iov = {sendbuf.ptr(), sendbuf.length(), sendbuf.memh(),
+                           0, 1};
+    completion comp = {{completion_cb, 1, UCS_OK}, false};
+    uct_rocm_base_signal_desc_t *signal;
+    ucs_status_t status;
+
+    /* Model a full pool of completed but unreaped operations. */
+    for (unsigned i = 0; i < 128; ++i) {
+        signal = static_cast<uct_rocm_base_signal_desc_t *>(
+                ucs_mpool_get(&iface->signal_pool));
+        ASSERT_NE(nullptr, signal);
+        signal->comp        = nullptr;
+        signal->mapped_addr = nullptr;
+        hsa_signal_store_screlease(signal->signal, 0);
+        ucs_queue_push(&iface->signal_queue, &signal->queue);
+    }
+
+    status = uct_ep_put_zcopy(sender_ep(), &iov, 1, recvbuf.addr(),
+                              recvbuf.rkey(), &comp.uct);
+
+    ASSERT_UCS_STATUS_EQ(UCS_INPROGRESS, status);
+    EXPECT_EQ(1u, ucs_queue_length(&iface->signal_queue));
+    wait_for_flag(&comp.completed);
+    EXPECT_EQ(UCS_OK, comp.uct.status);
+    recvbuf.pattern_check(SEED1);
+}
+
+_UCT_INSTANTIATE_TEST_CASE(uct_rocm_copy_rma_test, rocm_copy)
+#endif
 
 class test_p2p_rma_madvise : private ucs::clear_dontcopy_regions,
                              public uct_p2p_rma_test


### PR DESCRIPTION
- Reclaim completed ROCm copy signals when the signal pool is exhausted.
- Limit in-flight rendezvous pipeline fragments and refill the pipeline as work completes.
- Prevent signal-pool exhaustion without making the pool unbounded.

The ROCm copy transport uses HSA signals for asynchronous staging copies and keeps a fixed pool of 1024 signals. During vLLM/NIXL workloads, the pool could be exhausted even when many signals had already completed but had not yet been reclaimed. Larger transfers could also create nearly 1024 genuinely pending operations because the rendezvous pipeline posted all fragments without a per-request limit. Avoid relying on `UCX_ROCM_COPY_SIGPOOL_MAX_ELEMS=inf`. On pool pressure, reclaim completed copy signals before reporting exhaustion. Also bound the number of active rendezvous fragments per request and post more as fragments complete, preserving progress and overlap while applying backpressure.