### PR TITLE
UCP/PROTO/MULTI: Rename single-lane minimum flag

### DIFF
--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -729,7 +729,7 @@ ucp_proto_multi_init_priv(const ucp_proto_multi_init_params_t *params,
     }
     ucs_assert(mpriv->num_lanes == ucs_popcount(selection->lane_map));
 
-    if (params->single_lane_min_length) {
+    if (params->use_single_lane_min_length) {
         perf->min_length = mpriv->min_frag;
     }
     *reg_md_map_p    = reg_md_map;

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -125,7 +125,7 @@ typedef struct {
 
     /* Use the largest per-lane minimum as the protocol minimum, allowing short
      * messages that do not use all selected lanes */
-    size_t                         single_lane_min_length;
+    int                            use_single_lane_min_length;
 
     /* MDs on which the buffer is expected to be already registered, so no need
        to account for the overhead of registering on them */

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -219,15 +219,15 @@ ucp_proto_get_offload_zcopy_probe(const ucp_proto_init_params_t *init_params)
         .super.exclude_map   = 0,
         .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
                                                      init_params->select_param),
-        .max_lanes              = context->config.ext.max_rma_lanes,
-        .min_chunk              = context->config.ext.min_rma_chunk_size,
-        .single_lane_min_length = 1,
-        .initial_reg_md_map     = 0,
-        .first.tl_cap_flags     = UCT_IFACE_FLAG_GET_ZCOPY,
-        .first.lane_type        = UCP_LANE_TYPE_RMA_BW,
-        .middle.tl_cap_flags    = UCT_IFACE_FLAG_GET_ZCOPY,
-        .middle.lane_type       = UCP_LANE_TYPE_RMA_BW,
-        .opt_align_offs         = UCP_PROTO_COMMON_OFFSET_INVALID
+        .max_lanes                  = context->config.ext.max_rma_lanes,
+        .min_chunk                  = context->config.ext.min_rma_chunk_size,
+        .use_single_lane_min_length = 1,
+        .initial_reg_md_map         = 0,
+        .first.tl_cap_flags         = UCT_IFACE_FLAG_GET_ZCOPY,
+        .first.lane_type            = UCP_LANE_TYPE_RMA_BW,
+        .middle.tl_cap_flags        = UCT_IFACE_FLAG_GET_ZCOPY,
+        .middle.lane_type           = UCP_LANE_TYPE_RMA_BW,
+        .opt_align_offs             = UCP_PROTO_COMMON_OFFSET_INVALID
     };
 
     if (!ucp_proto_init_check_op(init_params, UCS_BIT(UCP_OP_ID_GET))) {


### PR DESCRIPTION
## What?
Rename single_lane_min_length to use_single_lane_min_length and change its type to int.
