### PR TITLE
UCT/GDAKI: No crash on unknown sys_dev

### DIFF
--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -1566,8 +1566,12 @@ uct_gdaki_query_tl_devices(uct_md_h tl_md,
         }
     }
 
-    ucs_assertv(ibdesc - dmat < dmat_length, "dev %s",
-                uct_ib_device_name(&ib_md->dev));
+    if ((ibdesc - dmat) == dmat_length) {
+        ucs_debug("%s: unknown sys_dev %d", uct_ib_device_name(&ib_md->dev),
+                  ib_md->dev.sys_dev);
+        status = UCS_ERR_NO_DEVICE;
+        goto out;
+    }
 
     if (ibdesc->cuda_map == 0) {
         ucs_debug("%s: no assigned gpu found", uct_ib_device_name(&ib_md->dev));


### PR DESCRIPTION
## Why?
Fix for [UCX] Bug SW [#5162040](https://redmine.mellanox.com/issues/5162040): [UCX][GDAKI][GTEST] gdaki.c:1569 assertion freezes test_ucp_proto_mock_rcx_numa | Assignee: Kovalyov Artemy | Status: Assigned