### PR TITLE
ARCH/X86: Add AVX512 nt-buffer-transfer functions

### DIFF
--- a/src/ucs/Makefile.am
+++ b/src/ucs/Makefile.am
@@ -3,6 +3,7 @@
 # Copyright (C) UT-Battelle, LLC. 2014-2017. ALL RIGHTS RESERVED.
 # Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
 # Copyright (C) Tactical Computing Labs, LLC. 2022. ALL RIGHTS RESERVED.
+# Copyright (C) Advanced Micro Devices, Inc. 2026. ALL RIGHTS RESERVED.
 # See file LICENSE for terms.
 #
 
@@ -96,6 +97,8 @@ noinst_HEADERS = \
 	arch/ppc64/cpu.h \
 	arch/rv64/cpu.h \
 	arch/x86_64/cpu.h \
+	arch/x86_64/cpu_nt_avx512.inl \
+	arch/x86_64/cpu_nt_avx2.inl \
 	arch/cpu.h \
 	config/ucm_opts.h \
 	datastruct/arbiter.h \

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -1,6 +1,6 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2018. ALL RIGHTS RESERVED.
-* Copyright (C) Advanced Micro Devices, Inc. 2019-2024. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2019-2026. ALL RIGHTS RESERVED.
 * Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
@@ -16,6 +16,7 @@
 #include <ucs/debug/log.h>
 #include <ucs/time/time.h>
 #include <ucs/sys/math.h>
+#include <ucs/sys/ptr_arith.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/string.h>
 
@@ -766,429 +767,60 @@ ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes)
 }
 
 #ifdef __AVX__
-static size_t ucs_x86_nt_all_buffer_transfer(void *dst, const void *src, size_t len)
-{
-    size_t offset;
-    __m256i y0, y1, y2, y3, y4, y5, y6, y7;
+#if defined(__AVX512BW__)
+#include "cpu_nt_avx512.inl"
+#else
+#include "cpu_nt_avx2.inl"
+#endif
 
-    /* copy 64 bytes unconditionally */
-    y0 = _mm256_loadu_si256(src);
-    y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, 32));
-    _mm256_storeu_si256(dst, y0);
-    _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, 32), y1);
-
-    offset = 64 - ((uintptr_t)dst & 0x1f);
-    len   -= offset;
-
-    if (ucs_likely((size_t)UCS_PTR_BYTE_OFFSET(src, offset) & 0x1f)) {
-        /* src address is not aligned to 32 byte */
-        while (len >= 256) {
-            y4 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset));
-            y5 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
-            y6 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 64));
-            y7 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 96));
-            y0 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 128));
-            y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 160));
-            y2 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 192));
-            y3 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 224));
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y4);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y5);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 64), y6);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 96), y7);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 128), y0);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 160), y1);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 192), y2);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 224), y3);
-
-            if ((len > 1024) && (((offset >> 8) & 3) == 0)) {
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (8 * 64)));
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (9 * 64)));
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (10 * 64)));
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (11 * 64)));
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (12 * 64)));
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (13 * 64)));
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (14 * 64)));
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (15 * 64)));
-            }
-
-            offset += 256;
-            len    -= 256;
-        }
-    } else {
-        /* src address aligned to 32 byte */
-        while (len >= 256) {
-            y4 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset));
-            y5 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
-            y6 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 64));
-            y7 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 96));
-            y0 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 128));
-            y1 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 160));
-            y2 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 192));
-            y3 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 224));
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y4);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y5);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 64), y6);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 96), y7);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 128), y0);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 160), y1);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 192), y2);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 224), y3);
-
-            if ((len > 1024) && (((offset >> 8) & 3) == 0)) {
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (8 * 64)));
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (9 * 64)));
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (10 * 64)));
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (11 * 64)));
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (12 * 64)));
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (13 * 64)));
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (14 * 64)));
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (15 * 64)));
-            }
-
-            offset += 256;
-            len    -= 256;
-        }
-    }
-
-    while (len >= 64) {
-        y4 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset));
-        y5 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
-        _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y4);
-        _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y5);
-        offset += 64;
-        len    -= 64;
-    }
-
-    /* make the writes visible to the other core */
-    ucs_memory_bus_store_fence();
-
-    /* Handle the remaining bytes <= 63 */
-    return len;
-}
-
-static UCS_F_ALWAYS_INLINE
-size_t ucs_x86_nt_dst_buffer_transfer(void *dst, const void *src, size_t len,
-                                      size_t total_len)
-{
-    const size_t switch_to_nt_store_size = 2048;
-    size_t offset, prefetch_tail;
-    __m256i y0, y1, y2, y3, y4, y5, y6, y7;
-
-    ucs_nt_write_prefetch(dst);
-    ucs_nt_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, 64));
-    ucs_nt_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, 128));
-
-    /* copy 64 bytes unconditionally */
-    y0 = _mm256_loadu_si256(src);
-    y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, 32));
-    _mm256_storeu_si256(dst, y0);
-    _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, 32), y1);
-
-    if (ucs_unlikely(total_len > switch_to_nt_store_size)) {
-        offset = 64 - ((uintptr_t)dst & 0x1f);
-        len   -= offset;
-
-        if (ucs_likely((size_t)UCS_PTR_BYTE_OFFSET(src, offset) & 0x1f)) {
-            /* src address is not aligned to 32 byte */
-            while (len >= 256) {
-                y4 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset));
-                y5 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
-                y6 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 64));
-                y7 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 96));
-                y0 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 128));
-                y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 160));
-                y2 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 192));
-                y3 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 224));
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y4);
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y5);
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 64), y6);
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 96), y7);
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 128), y0);
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 160), y1);
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 192), y2);
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 224), y3);
-
-                offset += 256;
-                len    -= 256;
-            }
-        } else {
-            /* src address aligned to 32 byte */
-            while (len >= 256) {
-                y4 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset));
-                y5 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
-                y6 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 64));
-                y7 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 96));
-                y0 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 128));
-                y1 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 160));
-                y2 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 192));
-                y3 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 224));
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y4);
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y5);
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 64), y6);
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 96), y7);
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 128), y0);
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 160), y1);
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 192), y2);
-                _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 224), y3);
-
-                offset += 256;
-                len    -= 256;
-            }
-        }
-
-        while (len >= 64) {
-            y4 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset));
-            y5 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y4);
-            _mm256_stream_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y5);
-            offset += 64;
-            len    -= 64;
-        }
-
-        if (len) {
-            ucs_nt_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, offset));
-        }
-
-        /* make the writes visible to the other core */
-        ucs_memory_bus_store_fence();
-    } else {
-        /* copy next 64 bytes unconditionally */
-        y2 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, 64));
-        y3 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, 96));
-        _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, 64), y2);
-        _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, 96), y3);
-
-        offset        = 128 - ((uintptr_t)dst & 0x1f);
-        prefetch_tail = 192 - (offset + ((uintptr_t)dst & 0x3f));
-        len          -= offset;
-
-        if (len > prefetch_tail) {
-            ucs_nt_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, 192));
-            if (len > (prefetch_tail + 64)) {
-                ucs_nt_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, 256));
-            }
-        }
-
-        while (len >= 128) {
-            if (len > (prefetch_tail + 128)) {
-                ucs_nt_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, offset + (3 * 64)));
-                if (len > (prefetch_tail + 192)) {
-                    ucs_nt_write_prefetch(UCS_PTR_BYTE_OFFSET(dst, offset + (4 * 64)));
-                }
-            }
-
-            y0 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset));
-            y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
-            y2 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 64));
-            y3 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 96));
-
-            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y0);
-            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y1);
-            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 64), y2);
-            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 96), y3);
-
-            offset += 128;
-            len    -= 128;
-        }
-    }
-
-    /* Handle the remaining bytes <= 127 */
-    return len;
-}
-
-static UCS_F_ALWAYS_INLINE
-size_t ucs_x86_nt_src_buffer_transfer(void *dst, const void *src, size_t len)
-{
-    __m256i y0, y1, y2, y3;
-    size_t offset, prefetch_tail;
-
-    ucs_nt_read_prefetch(src);
-    ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, 64));
-    ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, 128));
-
-    /* copy 128 bytes unconditionally */
-    y0 = _mm256_loadu_si256(src);
-    y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, 32));
-    y2 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, 64));
-    y3 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, 96));
-    _mm256_storeu_si256(dst, y0);
-    _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, 32), y1);
-    _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, 64), y2);
-    _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, 96), y3);
-
-    offset        = 128 - ((uintptr_t)dst & 0x1f);
-    prefetch_tail = 192 - (offset + ((uintptr_t)src & 0x3f));
-    len          -= offset;
-
-    if (len > prefetch_tail) {
-        ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, 192));
-        if (len > (prefetch_tail + 64)) {
-            ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, 256));
-        }
-    }
-
-    if (ucs_likely((size_t)UCS_PTR_BYTE_OFFSET(src, offset) & 0x1f)) {
-        if (len > (prefetch_tail + 128)) {
-            ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, 320));
-            if (len > (prefetch_tail + 192)) {
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, 384));
-            }
-        }
-
-        while (len >= 128) {
-            y0 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset));
-            y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
-            y2 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 64));
-            y3 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, offset + 96));
-            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y0);
-            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y1);
-            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 64), y2);
-            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 96), y3);
-
-            if (len > (prefetch_tail + 256)) {
-                ucs_nt_read_prefetch(
-                    UCS_PTR_BYTE_OFFSET(src, prefetch_tail + offset + (4 * 64)));
-                if (len > (prefetch_tail + 320)) {
-                    ucs_nt_read_prefetch(
-                        UCS_PTR_BYTE_OFFSET(src, prefetch_tail + offset + (5 * 64)));
-                }
-            }
-
-            offset += 128;
-            len    -= 128;
-        }
-    } else {
-        while (len >= 128) {
-            if (len > (prefetch_tail + 128)) {
-                ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (3 * 64)));
-                if (len > (prefetch_tail + 192)) {
-                    ucs_nt_read_prefetch(UCS_PTR_BYTE_OFFSET(src, offset + (4 * 64)));
-                }
-            }
-
-            /* Can we use streaming loads on normal memory type? */
-            y0 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset));
-            y1 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 32));
-            y2 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 64));
-            y3 = _mm256_load_si256(UCS_PTR_BYTE_OFFSET(src, offset + 96));
-            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset), y0);
-            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 32), y1);
-            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 64), y2);
-            _mm256_store_si256(UCS_PTR_BYTE_OFFSET(dst, offset + 96), y3);
-
-            offset += 128;
-            len    -= 128;
-        }
-    }
-
-    /* Handle the remaining bytes <= 127 */
-    return len;
-}
-
-static UCS_F_ALWAYS_INLINE void
-ucs_x86_copy_bytes_le_128(void *dst, const void *src, uint32_t len)
-{
-    __m256i y0, y1, y2, y3;
-    /* Handle lengths that fall usually within eager short range */
-    switch (ucs_count_leading_zero_bits(len)) {
-    /* 0 */
-    case 32:
-        break;
-    /* 1 */
-    case 31:
-        *(uint8_t *)dst = *(uint8_t *)src;
-        break;
-    /* 2 - 3 */
-    case 30:
-        *(uint16_t *)dst = *(uint16_t *)src;
-        *(uint16_t *)UCS_PTR_BYTE_OFFSET(dst, len - 2) = \
-            *(uint16_t *)UCS_PTR_BYTE_OFFSET(src, len - 2);
-        break;
-    /* 4 - 7 */
-    case 29:
-        *(uint32_t *)dst = *(uint32_t *)src;
-        *(uint32_t *)UCS_PTR_BYTE_OFFSET(dst, len - 4) = \
-            *(uint32_t *)UCS_PTR_BYTE_OFFSET(src, len - 4);
-        break;
-    /* 8 - 15 */
-    case 28:
-        *(uint64_t *)dst = *(uint64_t *)src;
-        *(uint64_t *)UCS_PTR_BYTE_OFFSET(dst, len - 8) = \
-            *(uint64_t *)UCS_PTR_BYTE_OFFSET(src, len - 8);
-        break;
-    /* 16 - 31 */
-    case 27:
-        *(uint64_t *)dst = *(uint64_t *)src;
-        *(uint64_t *)UCS_PTR_BYTE_OFFSET(dst, 8) = \
-            *(uint64_t *)UCS_PTR_BYTE_OFFSET(src, 8);
-        *(uint64_t *)UCS_PTR_BYTE_OFFSET(dst, len - 16) = \
-            *(uint64_t *)UCS_PTR_BYTE_OFFSET(src, len - 16);
-        *(uint64_t *)UCS_PTR_BYTE_OFFSET(dst, len - 8) = \
-            *(uint64_t *)UCS_PTR_BYTE_OFFSET(src, len - 8);
-        break;
-    /* 32 - 63 */
-    case 26:
-        y0 = _mm256_loadu_si256(src);
-        y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src,  len - 32));
-        _mm256_storeu_si256(dst, y0);
-        _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, len - 32), y1);
-        break;
-    /* 64 - 128 */
-    default:
-        y0 = _mm256_loadu_si256(src);
-        y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, 32));
-        y2 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, len - 64));
-        y3 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, len - 32));
-        _mm256_storeu_si256(dst, y0);
-        _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, 32), y1);
-        _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, len - 64), y2);
-        _mm256_storeu_si256(UCS_PTR_BYTE_OFFSET(dst, len - 32), y3);
-        break;
-    }
-}
-
-/* This is an adaptation of the memcpy code from https://github.com/amd/aocl-libmem
- * TODO: Provide an option to copy from backwards, in this way
- * application can choose the cache hotness of the final buffer
- */
 void ucs_x86_nt_buffer_transfer(void *dst, const void *src, size_t len,
                                 ucs_arch_memcpy_hint_t hint, size_t total_len)
 {
-    size_t tail_bytes;
-
-    if (ucs_likely(len <= 128)) {
-        goto copy_bytes_le_128;
+    /* Use non-temporal copies only for large enough buffers; hand smaller
+     * ones to memcpy(). */
+    if (ucs_likely(len < 3072)) {
+        memcpy(dst, src, len);
+        return;
     }
 
+    /* force nontemporal stores for large transfers */
     if (ucs_unlikely(total_len > ucs_global_opts.arch.nt_dest_threshold)) {
-        if (hint & UCS_ARCH_MEMCPY_NT_SOURCE) {
-            /*
-             * If the lines prefetched with 'NTA' are in 'MODIFIED' state
-             * evicting them will result in a memory write, along
-             * with the already committed streaming stores to destination
-             * buffer, it can make this path more bandwidth intensive.
-             */
-            tail_bytes = ucs_x86_nt_all_buffer_transfer(dst, src, len);
-        } else {
-            tail_bytes = ucs_x86_nt_dst_buffer_transfer(dst, src, len, total_len);
-        }
-    } else {
-        if (hint & UCS_ARCH_MEMCPY_NT_DEST) {
-            tail_bytes = ucs_x86_nt_dst_buffer_transfer(dst, src, len, total_len);
-        } else if (hint & UCS_ARCH_MEMCPY_NT_SOURCE) {
-            tail_bytes = ucs_x86_nt_src_buffer_transfer(dst, src, len);
-        } else {
-            memcpy(dst, src, len);
-            tail_bytes = 0;
-        }
+        hint = UCS_ARCH_MEMCPY_NT_DEST;
     }
 
-    dst = UCS_PTR_BYTE_OFFSET(dst, len - tail_bytes);
-    src = UCS_PTR_BYTE_OFFSET(src, len - tail_bytes);
-    len = tail_bytes;
+    if (hint & UCS_ARCH_MEMCPY_NT_DEST) {
+        ucs_x86_nt_dst_buffer_transfer(dst, src, len);
+        return;
+    }
 
-copy_bytes_le_128:
-    ucs_x86_copy_bytes_le_128(dst, src, len);
+    /*
+     * NT_SOURCE (copy-out) path, taken for the UCS_ARCH_MEMCPY_NT_SOURCE
+     * hint. We do not non-temporally prefetch the source: an NT prefetch on
+     * a source line still in the Modified state can trigger a write-back, so
+     * a copy-out would generate writes for both the source (evicted) and the
+     * destination and double the receiver's memory-write pressure.  The
+     * UCS_ARCH_MEMCPY_NT_SOURCE hint is therefore serviced as a plain
+     * cache-respecting copy-out with two possible implementations:
+     *
+     *   - rep movsb (ERMS): UCX's built-in copy, whose size window is
+     *     already tuned per platform via the BUILTIN_MEMCPY knobs.
+     *   - an optimized vectorized copy routine (fallback when ERMS is
+     *     disabled for this size).
+     *
+     * ERMS is gated in two places. The outer gate in ucs_memcpy_relaxed()
+     * (cpu.h) runs rep movsb for its whole size window and returns, so while
+     * that window covers our sizes this function is never reached at all.
+     * Reaching this NT path therefore requires closing that outer window at
+     * run time by setting UCX_BUILTIN_MEMCPY_MAX=0 (e.g. on the mpirun
+     * command line). The inner gate here (len > builtin_memcpy_min) then
+     * selects rep movsb, otherwise the vectorized routine runs.
+     */
+    if (len > ucs_global_opts.arch.builtin_memcpy_min) {
+        ucs_x86_memcpy_erms(dst, src, len);
+        return;
+    }
+
+    ucs_x86_nt_src_buffer_transfer(dst, src, len);
 }
 #endif
 

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -804,15 +804,15 @@ void ucs_x86_nt_buffer_transfer(void *dst, const void *src, size_t len,
      * UCS_ARCH_MEMCPY_NT_SOURCE hint is therefore serviced as a plain
      * cache-respecting copy-out with two possible implementations:
      *
-     *   - rep movsb (ERMS): UCX's built-in copy, whose size window is
-     *     already tuned per platform via the BUILTIN_MEMCPY knobs.
+     *   - rep movsb (ERMS), selected when len exceeds builtin_memcpy_min.
      *   - an optimized vectorized copy routine (fallback when ERMS is
      *     disabled for this size).
      *
-     * ERMS is gated in two places. When NT_BUFFER_TRANSFER_MIN is set
-     * explicitly, initialization closes the outer ERMS window in
-     * ucs_memcpy_relaxed(). The inner gate here then selects rep movsb,
-     * otherwise the vectorized routine runs.
+     * ERMS is gated in two places. The outer size window in
+     * ucs_memcpy_relaxed() may return before this function is reached.
+     * Setting NT_BUFFER_TRANSFER_MIN explicitly closes that window during
+     * initialization. The inner gate here then selects rep movsb; otherwise
+     * the vectorized routine runs.
      */
     if (len > ucs_global_opts.arch.builtin_memcpy_min) {
         ucs_x86_memcpy_erms(dst, src, len);

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -638,7 +638,7 @@ static size_t ucs_cpu_nt_bt_thresh_min(size_t user_val)
 static size_t ucs_cpu_nt_dest_thresh()
 {
     if (ucs_arch_get_cpu_vendor() == UCS_CPU_VENDOR_AMD) {
-        return ucs_cpu_get_cache_size(UCS_CPU_CACHE_L3) * 9 / 8;
+        return ucs_cpu_get_cache_size(UCS_CPU_CACHE_L3) * 3 / 4;
     } else {
         return UCS_MEMUNITS_INF;
     }

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -802,7 +802,8 @@ void ucs_x86_nt_buffer_transfer(void *dst, const void *src, size_t len,
      * a copy-out would generate writes for both the source (evicted) and the
      * destination and double the receiver's memory-write pressure.  The
      * UCS_ARCH_MEMCPY_NT_SOURCE hint is therefore serviced as a plain
-     * cache-respecting copy-out with two possible implementations:
+     * cache-respecting copy-out with a vectorized implementation and,
+     * when built-in memcpy is enabled, an ERMS implementation:
      *
      *   - rep movsb (ERMS), selected when len exceeds builtin_memcpy_min.
      *   - an optimized vectorized copy routine (fallback when ERMS is
@@ -814,10 +815,12 @@ void ucs_x86_nt_buffer_transfer(void *dst, const void *src, size_t len,
      * initialization. The inner gate here then selects rep movsb; otherwise
      * the vectorized routine runs.
      */
+#if ENABLE_BUILTIN_MEMCPY
     if (len > ucs_global_opts.arch.builtin_memcpy_min) {
         ucs_x86_memcpy_erms(dst, src, len);
         return;
     }
+#endif
 
     ucs_x86_nt_src_buffer_transfer(dst, src, len);
 }

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -625,8 +625,10 @@ static size_t ucs_cpu_memcpy_thresh(size_t user_val, size_t auto_val)
 static size_t ucs_cpu_nt_bt_thresh_min(size_t user_val)
 {
     if (user_val != UCS_MEMUNITS_AUTO) {
+#if ENABLE_BUILTIN_MEMCPY
         /* Let the NT dispatcher select the copy implementation. */
         ucs_global_opts.arch.builtin_memcpy_max = 0;
+#endif
         return user_val;
     }
 

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -625,6 +625,8 @@ static size_t ucs_cpu_memcpy_thresh(size_t user_val, size_t auto_val)
 static size_t ucs_cpu_nt_bt_thresh_min(size_t user_val)
 {
     if (user_val != UCS_MEMUNITS_AUTO) {
+        /* Let the NT dispatcher select the copy implementation. */
+        ucs_global_opts.arch.builtin_memcpy_max = 0;
         return user_val;
     }
 
@@ -807,13 +809,10 @@ void ucs_x86_nt_buffer_transfer(void *dst, const void *src, size_t len,
      *   - an optimized vectorized copy routine (fallback when ERMS is
      *     disabled for this size).
      *
-     * ERMS is gated in two places. The outer gate in ucs_memcpy_relaxed()
-     * (cpu.h) runs rep movsb for its whole size window and returns, so while
-     * that window covers our sizes this function is never reached at all.
-     * Reaching this NT path therefore requires closing that outer window at
-     * run time by setting UCX_BUILTIN_MEMCPY_MAX=0 (e.g. on the mpirun
-     * command line). The inner gate here (len > builtin_memcpy_min) then
-     * selects rep movsb, otherwise the vectorized routine runs.
+     * ERMS is gated in two places. When NT_BUFFER_TRANSFER_MIN is set
+     * explicitly, initialization closes the outer ERMS window in
+     * ucs_memcpy_relaxed(). The inner gate here then selects rep movsb,
+     * otherwise the vectorized routine runs.
      */
     if (len > ucs_global_opts.arch.builtin_memcpy_min) {
         ucs_x86_memcpy_erms(dst, src, len);

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -778,9 +778,9 @@ ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes)
 void ucs_x86_nt_buffer_transfer(void *dst, const void *src, size_t len,
                                 ucs_arch_memcpy_hint_t hint, size_t total_len)
 {
-    /* Use non-temporal copies only for large enough buffers; hand smaller
-     * ones to memcpy(). */
-    if (ucs_likely(len < 3072)) {
+    const size_t min_nt_buffer_transfer_size = 3072;
+
+    if (ucs_likely(len < min_nt_buffer_transfer_size)) {
         memcpy(dst, src, len);
         return;
     }

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -1,7 +1,7 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2013. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
-* Copyright (C) Advanced Micro Devices, Inc. 2023. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2023-2026. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -100,6 +100,21 @@ static inline void ucs_arch_clear_cache(void *start, void *end)
 }
 #endif
 
+/* ERMS (rep movsb) copy; returns dst advanced by len. */
+static UCS_F_ALWAYS_INLINE void *
+ucs_x86_memcpy_erms(void *dst, const void *src, size_t len)
+{
+    asm volatile ("rep movsb"
+                  : "=D" (dst),
+                  "=S" (src),
+                  "=c" (len)
+                  : "0" (dst),
+                  "1" (src),
+                  "2" (len)
+                  : "memory");
+    return dst;
+}
+
 static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len,
                                        ucs_arch_memcpy_hint_t hint,
                                        size_t total_len)
@@ -107,15 +122,7 @@ static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len,
 #if ENABLE_BUILTIN_MEMCPY
     if (ucs_unlikely((len > ucs_global_opts.arch.builtin_memcpy_min) &&
                      (len < ucs_global_opts.arch.builtin_memcpy_max))) {
-        asm volatile ("rep movsb"
-                      : "=D" (dst),
-                      "=S" (src),
-                      "=c" (len)
-                      : "0" (dst),
-                      "1" (src),
-                      "2" (len)
-                      : "memory");
-        return dst;
+        return ucs_x86_memcpy_erms(dst, src, len);
     }
 #endif
 

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -127,7 +127,7 @@ static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len,
 #endif
 
 #ifdef __AVX__
-    if (ucs_unlikely(total_len >= ucs_global_opts.arch.nt_buffer_transfer_min)) {
+    if (ucs_unlikely(total_len > ucs_global_opts.arch.nt_buffer_transfer_min)) {
         ucs_x86_nt_buffer_transfer(dst, src, len, hint, total_len);
         return dst;
     }

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -129,7 +129,7 @@ static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len,
 #endif
 
 #ifdef __AVX__
-    if (ucs_unlikely(total_len > ucs_global_opts.arch.nt_buffer_transfer_min)) {
+    if (ucs_unlikely(total_len >= ucs_global_opts.arch.nt_buffer_transfer_min)) {
         ucs_x86_nt_buffer_transfer(dst, src, len, hint, total_len);
         return dst;
     }

--- a/src/ucs/arch/x86_64/cpu.h
+++ b/src/ucs/arch/x86_64/cpu.h
@@ -100,6 +100,7 @@ static inline void ucs_arch_clear_cache(void *start, void *end)
 }
 #endif
 
+#if ENABLE_BUILTIN_MEMCPY
 /* ERMS (rep movsb) copy; returns dst advanced by len. */
 static UCS_F_ALWAYS_INLINE void *
 ucs_x86_memcpy_erms(void *dst, const void *src, size_t len)
@@ -114,6 +115,7 @@ ucs_x86_memcpy_erms(void *dst, const void *src, size_t len)
                   : "memory");
     return dst;
 }
+#endif
 
 static inline void *ucs_memcpy_relaxed(void *dst, const void *src, size_t len,
                                        ucs_arch_memcpy_hint_t hint,

--- a/src/ucs/arch/x86_64/cpu_nt_avx2.inl
+++ b/src/ucs/arch/x86_64/cpu_nt_avx2.inl
@@ -1,0 +1,303 @@
+/**
+ * Copyright (C) Advanced Micro Devices, Inc. 2026. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+/* AVX2 NT buffer-transfer implementation.  Defines the inline helpers and
+ * forward kernels used when AVX is enabled without AVX512BW: NT_DEST streams
+ * destination stores and issues an sfence, while NT_SOURCE uses regular stores
+ * without a fence.  The bridge macros at the end bind these kernels to the
+ * generic dispatcher hooks in cpu.c. */
+
+/* Copy a sub-cache-line remainder with overlapping stores.
+ * len in [1,63]; dst is 64B-aligned; src may be unaligned. */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx2_nt_tail_copy(void *dst, const void *src, size_t len)
+{
+    __m256i y0, y1;
+    dst = __builtin_assume_aligned(dst, 64);
+    if (len >= 32) {
+        y0 = _mm256_loadu_si256(src);
+        y1 = _mm256_loadu_si256(UCS_PTR_BYTE_OFFSET(src, len - 32));
+        _mm256_store_si256(dst, y0);
+        _mm256_storeu_si256((__m256i *)UCS_PTR_BYTE_OFFSET(dst, len - 32), y1);
+    } else if (len >= 16) {
+        *(uint64_t *)dst = *(uint64_t *)src;
+        *(uint64_t *)UCS_PTR_BYTE_OFFSET(dst, 8) =
+                *(uint64_t *)UCS_PTR_BYTE_OFFSET(src, 8);
+        *(uint64_t *)UCS_PTR_BYTE_OFFSET(dst, len - 16) =
+                *(uint64_t *)UCS_PTR_BYTE_OFFSET(src, len - 16);
+        *(uint64_t *)UCS_PTR_BYTE_OFFSET(dst, len - 8) =
+                *(uint64_t *)UCS_PTR_BYTE_OFFSET(src, len - 8);
+    } else if (len >= 8) {
+        *(uint64_t *)dst = *(uint64_t *)src;
+        *(uint64_t *)UCS_PTR_BYTE_OFFSET(dst, len - 8) =
+                *(uint64_t *)UCS_PTR_BYTE_OFFSET(src, len - 8);
+    } else if (len >= 4) {
+        *(uint32_t *)dst = *(uint32_t *)src;
+        *(uint32_t *)UCS_PTR_BYTE_OFFSET(dst, len - 4) =
+                *(uint32_t *)UCS_PTR_BYTE_OFFSET(src, len - 4);
+    } else if (len >= 2) {
+        *(uint16_t *)dst = *(uint16_t *)src;
+        *(uint16_t *)UCS_PTR_BYTE_OFFSET(dst, len - 2) =
+                *(uint16_t *)UCS_PTR_BYTE_OFFSET(src, len - 2);
+    } else {
+        *(uint8_t *)dst = *(uint8_t *)src;
+    }
+}
+
+/* 32B store, unaligned dst (overlap edge). */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx2_loadu_storeu_32(void *dst, const void *src)
+{
+    __m256i y0 = _mm256_loadu_si256(src);
+    _mm256_storeu_si256((__m256i *)dst, y0);
+}
+
+/* 32B store. */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx2_loadu_store_32(void *dst, const void *src)
+{
+    __m256i y0 = _mm256_loadu_si256(src);
+    _mm256_store_si256((__m256i *)dst, y0);
+}
+
+/* Prefix fill up to the next 64B cache-line boundary; returns the body-start
+ * offset (dst + offset is 64B-aligned). */
+static UCS_F_ALWAYS_INLINE size_t
+ucs_x86_avx2_nt_prefix_to_line(void *dst, const void *src)
+{
+    const uintptr_t addr = (uintptr_t)dst;
+    size_t prefix_offset;
+
+    ucs_x86_avx2_loadu_storeu_32(dst, src);
+    if ((addr & 63u) < 32u) {
+        prefix_offset = (size_t)(ucs_align_down_pow2(addr + 32, 32) - addr);
+        ucs_x86_avx2_loadu_store_32(UCS_PTR_BYTE_OFFSET(dst, prefix_offset),
+                                    UCS_PTR_BYTE_OFFSET(src, prefix_offset));
+    }
+
+    return (size_t)(ucs_align_down_pow2(addr + 64, 64) - addr);
+}
+
+/* YMM copy helpers.  Except the _storeu_ edge helper, dst is 32B-aligned; src
+ * is aligned only in the _loada_ variants.  _stream_ helpers issue NT
+ * stores. */
+
+/* 64B NT store (2x YMM). */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx2_loadu_stream_64(void *dst, const void *src)
+{
+    const __m256i *sa = src;
+    __m256i *da       = dst;
+    __m256i y0        = _mm256_loadu_si256(sa);
+    __m256i y1        = _mm256_loadu_si256(sa + 1);
+    _mm256_stream_si256(da, y0);
+    _mm256_stream_si256(da + 1, y1);
+}
+
+/* 256B NT store (8x YMM). */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx2_loadu_stream_256(void *dst, const void *src)
+{
+    const __m256i *sa = src;
+    __m256i *da       = dst;
+    __m256i y0        = _mm256_loadu_si256(sa);
+    __m256i y1        = _mm256_loadu_si256(sa + 1);
+    __m256i y2        = _mm256_loadu_si256(sa + 2);
+    __m256i y3        = _mm256_loadu_si256(sa + 3);
+    __m256i y4        = _mm256_loadu_si256(sa + 4);
+    __m256i y5        = _mm256_loadu_si256(sa + 5);
+    __m256i y6        = _mm256_loadu_si256(sa + 6);
+    __m256i y7        = _mm256_loadu_si256(sa + 7);
+    _mm256_stream_si256(da, y0);
+    _mm256_stream_si256(da + 1, y1);
+    _mm256_stream_si256(da + 2, y2);
+    _mm256_stream_si256(da + 3, y3);
+    _mm256_stream_si256(da + 4, y4);
+    _mm256_stream_si256(da + 5, y5);
+    _mm256_stream_si256(da + 6, y6);
+    _mm256_stream_si256(da + 7, y7);
+}
+
+/* 256B NT store (8x YMM), aligned load. */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx2_loada_stream_256(void *dst, const void *src)
+{
+    const __m256i *sa = src;
+    __m256i *da       = dst;
+    __m256i y0        = _mm256_load_si256(sa);
+    __m256i y1        = _mm256_load_si256(sa + 1);
+    __m256i y2        = _mm256_load_si256(sa + 2);
+    __m256i y3        = _mm256_load_si256(sa + 3);
+    __m256i y4        = _mm256_load_si256(sa + 4);
+    __m256i y5        = _mm256_load_si256(sa + 5);
+    __m256i y6        = _mm256_load_si256(sa + 6);
+    __m256i y7        = _mm256_load_si256(sa + 7);
+    _mm256_stream_si256(da, y0);
+    _mm256_stream_si256(da + 1, y1);
+    _mm256_stream_si256(da + 2, y2);
+    _mm256_stream_si256(da + 3, y3);
+    _mm256_stream_si256(da + 4, y4);
+    _mm256_stream_si256(da + 5, y5);
+    _mm256_stream_si256(da + 6, y6);
+    _mm256_stream_si256(da + 7, y7);
+}
+
+/* 64B store (2x YMM). */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx2_loadu_store_64(void *dst, const void *src)
+{
+    const __m256i *sa = src;
+    __m256i *da       = dst;
+    __m256i y0        = _mm256_loadu_si256(sa);
+    __m256i y1        = _mm256_loadu_si256(sa + 1);
+    _mm256_store_si256(da, y0);
+    _mm256_store_si256(da + 1, y1);
+}
+
+/* 256B store (8x YMM). */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx2_loadu_store_256(void *dst, const void *src)
+{
+    const __m256i *sa = src;
+    __m256i *da       = dst;
+    __m256i y0        = _mm256_loadu_si256(sa);
+    __m256i y1        = _mm256_loadu_si256(sa + 1);
+    __m256i y2        = _mm256_loadu_si256(sa + 2);
+    __m256i y3        = _mm256_loadu_si256(sa + 3);
+    __m256i y4        = _mm256_loadu_si256(sa + 4);
+    __m256i y5        = _mm256_loadu_si256(sa + 5);
+    __m256i y6        = _mm256_loadu_si256(sa + 6);
+    __m256i y7        = _mm256_loadu_si256(sa + 7);
+    _mm256_store_si256(da, y0);
+    _mm256_store_si256(da + 1, y1);
+    _mm256_store_si256(da + 2, y2);
+    _mm256_store_si256(da + 3, y3);
+    _mm256_store_si256(da + 4, y4);
+    _mm256_store_si256(da + 5, y5);
+    _mm256_store_si256(da + 6, y6);
+    _mm256_store_si256(da + 7, y7);
+}
+
+/* 256B store (8x YMM), aligned load. */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx2_loada_store_256(void *dst, const void *src)
+{
+    const __m256i *sa = src;
+    __m256i *da       = dst;
+    __m256i y0        = _mm256_load_si256(sa);
+    __m256i y1        = _mm256_load_si256(sa + 1);
+    __m256i y2        = _mm256_load_si256(sa + 2);
+    __m256i y3        = _mm256_load_si256(sa + 3);
+    __m256i y4        = _mm256_load_si256(sa + 4);
+    __m256i y5        = _mm256_load_si256(sa + 5);
+    __m256i y6        = _mm256_load_si256(sa + 6);
+    __m256i y7        = _mm256_load_si256(sa + 7);
+    _mm256_store_si256(da, y0);
+    _mm256_store_si256(da + 1, y1);
+    _mm256_store_si256(da + 2, y2);
+    _mm256_store_si256(da + 3, y3);
+    _mm256_store_si256(da + 4, y4);
+    _mm256_store_si256(da + 5, y5);
+    _mm256_store_si256(da + 6, y6);
+    _mm256_store_si256(da + 7, y7);
+}
+
+/* AVX2 NT_DEST copy-in: NT body stores + trailing sfence; ascending.  A
+ * prefix first fills [dp, dp+offset) up to the next 64B line so dp+offset is
+ * 64B-aligned for the body; the sub-cache-line tail (1..63 B) is copied by
+ * an overlapping-store if-chain.  Precondition: len >= 64. */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_nt_dst_avx2_buffer_transfer(void *dst, const void *src, size_t len)
+{
+    char *dp       = dst;
+    const char *sp = src;
+    size_t offset;
+    int src_aligned;
+
+    /* (1) copy prefix to the next 64B cache-line boundary. */
+    offset = ucs_x86_avx2_nt_prefix_to_line(dp, sp);
+
+    /* (2) ascending 256B NT-stream body to last full 256B. */
+    src_aligned = ((UCS_PTR_BYTE_DIFF(dp, sp) & 31u) == 0u);
+    if (ucs_unlikely(src_aligned)) {
+        while (offset + 256 <= len) {
+            ucs_x86_avx2_loada_stream_256(UCS_PTR_BYTE_OFFSET(dp, offset),
+                                          UCS_PTR_BYTE_OFFSET(sp, offset));
+            offset += 256;
+        }
+    } else {
+        while (offset + 256 <= len) {
+            ucs_x86_avx2_loadu_stream_256(UCS_PTR_BYTE_OFFSET(dp, offset),
+                                          UCS_PTR_BYTE_OFFSET(sp, offset));
+            offset += 256;
+        }
+    }
+
+    /* (3) ascending 64B NT drain to the last full cache line. */
+    while (offset + 64 <= len) {
+        ucs_x86_avx2_loadu_stream_64(UCS_PTR_BYTE_OFFSET(dp, offset),
+                                     UCS_PTR_BYTE_OFFSET(sp, offset));
+        offset += 64;
+    }
+
+    /* (4) if [1,63] remainder copy it.  dp+offset is 64B-aligned. */
+    if (offset != len) {
+        ucs_x86_avx2_nt_tail_copy(UCS_PTR_BYTE_OFFSET(dp, offset),
+                                  UCS_PTR_BYTE_OFFSET(sp, offset),
+                                  len - offset);
+    }
+
+    /* make the streaming writes visible to the other core */
+    ucs_memory_bus_store_fence();
+}
+
+/* AVX2 NT_SOURCE copy-out: body stores, ascending.  A prefix
+ * first fills [dp, dp+offset) up to the next 64B line so dp+offset is
+ * 64B-aligned for the body; the sub-cache-line tail (1..63 B) is copied by
+ * an overlapping-store if-chain.  Precondition: len >= 64. */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_nt_src_avx2_buffer_transfer(void *dst, const void *src, size_t len)
+{
+    char *dp       = dst;
+    const char *sp = src;
+    size_t offset;
+    int src_aligned;
+
+    /* (1) copy prefix to the next 64B cache-line boundary. */
+    offset = ucs_x86_avx2_nt_prefix_to_line(dp, sp);
+
+    /* (2) ascending 256B body to the last full 256B. */
+    src_aligned = ((UCS_PTR_BYTE_DIFF(dp, sp) & 31u) == 0u);
+    if (src_aligned) {
+        while (offset + 256 <= len) {
+            ucs_x86_avx2_loada_store_256(UCS_PTR_BYTE_OFFSET(dp, offset),
+                                         UCS_PTR_BYTE_OFFSET(sp, offset));
+            offset += 256;
+        }
+    } else {
+        while (offset + 256 <= len) {
+            ucs_x86_avx2_loadu_store_256(UCS_PTR_BYTE_OFFSET(dp, offset),
+                                         UCS_PTR_BYTE_OFFSET(sp, offset));
+            offset += 256;
+        }
+    }
+
+    /* (3) ascending 64B drain to the last full cache line. */
+    while (offset + 64 <= len) {
+        ucs_x86_avx2_loadu_store_64(UCS_PTR_BYTE_OFFSET(dp, offset),
+                                    UCS_PTR_BYTE_OFFSET(sp, offset));
+        offset += 64;
+    }
+
+    /* (4) if [1,63] remainder copy it.  dp+offset is 64B-aligned. */
+    if (offset != len) {
+        ucs_x86_avx2_nt_tail_copy(UCS_PTR_BYTE_OFFSET(dp, offset),
+                                  UCS_PTR_BYTE_OFFSET(sp, offset),
+                                  len - offset);
+    }
+}
+
+#define ucs_x86_nt_dst_buffer_transfer ucs_x86_nt_dst_avx2_buffer_transfer
+#define ucs_x86_nt_src_buffer_transfer ucs_x86_nt_src_avx2_buffer_transfer

--- a/src/ucs/arch/x86_64/cpu_nt_avx512.inl
+++ b/src/ucs/arch/x86_64/cpu_nt_avx512.inl
@@ -1,0 +1,256 @@
+/**
+ * Copyright (C) Advanced Micro Devices, Inc. 2026. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+/* AVX-512 NT buffer-transfer implementation.  Defines the inline helpers and
+ * masked-edge kernels used when AVX512BW is enabled: NT_DEST streams forward
+ * destination stores and issues an sfence, while NT_SOURCE uses descending
+ * regular stores without a fence.  The bridge macros at the end bind these
+ * kernels to the generic dispatcher hooks in cpu.c. */
+
+/* Tail edge length for the last (partial) 64B line of [dst, dst+len):
+ * ((dst+len) & 63) mapped 0 -> 64 (full line), else the remainder in [1,64]. */
+static UCS_F_ALWAYS_INLINE size_t
+ucs_x86_avx512_nt_tail_edge_len(const void *dst, size_t len)
+{
+    const size_t rem = ((uintptr_t)dst + len) & 63u;
+    return ((rem - 1u) & 63u) + 1u;
+}
+
+/* Forward body-start offset: dst to the next 64B-aligned line (head edge). */
+static UCS_F_ALWAYS_INLINE size_t
+ucs_x86_avx512_nt_body_off_fwd(const void *dst)
+{
+    const uintptr_t addr = (uintptr_t)dst;
+    return (size_t)(ucs_align_down_pow2(addr + 64, 64) - addr);
+}
+
+/* Byte-masked head edge: copy [dst, dst+edge_len), edge_len in [1,64], onto
+ * the 64B-aligned line containing dst (high edge_len lanes). */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx512_nt_masked_head_64(void *dst, const void *src, size_t edge_len)
+{
+    const size_t head_pad = 64u - edge_len;
+    const __mmask64 k     = (__mmask64)(~0ull << head_pad);
+    __m512i v;
+
+    v = _mm512_maskz_loadu_epi8(k, UCS_PTR_BYTE_OFFSET(src, -head_pad));
+    _mm512_mask_storeu_epi8(UCS_PTR_BYTE_OFFSET(dst, -head_pad), k, v);
+}
+
+/* Byte-masked tail edge: copy [dst+offset, dst+offset+edge_len), edge_len in
+ * [1,64], onto the 64B-aligned base dst+offset (low edge_len lanes). */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx512_nt_masked_tail_64(void *dst, const void *src, size_t offset,
+                                 size_t edge_len)
+{
+    const __mmask64 k = (__mmask64)(~0ull >> (64u - edge_len));
+    __m512i v;
+
+    v = _mm512_maskz_loadu_epi8(k, UCS_PTR_BYTE_OFFSET(src, offset));
+    _mm512_mask_storeu_epi8(UCS_PTR_BYTE_OFFSET(dst, offset), k, v);
+}
+
+/* Vector copy helpers.  Ascending helpers store from the base [dst, dst+n);
+ * descending (_bwd) helpers store from the top [dst-n, dst).  The
+ * ucs_compiler_fence() between the four stores pins their order (they are
+ * independent, so the compiler would otherwise reschedule them). */
+
+/* 64B NT store, ascending. */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx512_loadu_stream_64(void *dst, const void *src)
+{
+    __m512i z = _mm512_loadu_si512(src);
+    _mm512_stream_si512((__m512i *)dst, z);
+}
+
+/* 256B NT store (4x), ascending. */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx512_loadu_stream_256(void *dst, const void *src)
+{
+    const __m512i *sa = src;
+    __m512i *da       = dst;
+    __m512i z0        = _mm512_loadu_si512(sa);
+    __m512i z1        = _mm512_loadu_si512(sa + 1);
+    __m512i z2        = _mm512_loadu_si512(sa + 2);
+    __m512i z3        = _mm512_loadu_si512(sa + 3);
+    _mm512_stream_si512(da, z0);
+    ucs_compiler_fence();
+    _mm512_stream_si512(da + 1, z1);
+    ucs_compiler_fence();
+    _mm512_stream_si512(da + 2, z2);
+    ucs_compiler_fence();
+    _mm512_stream_si512(da + 3, z3);
+}
+
+/* 256B NT store (4x), ascending, aligned load. */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx512_loada_stream_256(void *dst, const void *src)
+{
+    const __m512i *sa = src;
+    __m512i *da       = dst;
+    __m512i z0        = _mm512_load_si512(sa);
+    __m512i z1        = _mm512_load_si512(sa + 1);
+    __m512i z2        = _mm512_load_si512(sa + 2);
+    __m512i z3        = _mm512_load_si512(sa + 3);
+    _mm512_stream_si512(da, z0);
+    ucs_compiler_fence();
+    _mm512_stream_si512(da + 1, z1);
+    ucs_compiler_fence();
+    _mm512_stream_si512(da + 2, z2);
+    ucs_compiler_fence();
+    _mm512_stream_si512(da + 3, z3);
+}
+
+/* 64B store, descending. */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx512_loadu_store_64_bwd(void *dst, const void *src)
+{
+    const __m512i *sa = src;
+    __m512i *da       = dst;
+    __m512i z         = _mm512_loadu_si512(sa - 1);
+    _mm512_store_si512(da - 1, z);
+}
+
+/* 256B store (4x), descending. */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx512_loadu_store_256_bwd(void *dst, const void *src)
+{
+    const __m512i *sa = src;
+    __m512i *da       = dst;
+    __m512i z0        = _mm512_loadu_si512(sa - 1);
+    __m512i z1        = _mm512_loadu_si512(sa - 2);
+    __m512i z2        = _mm512_loadu_si512(sa - 3);
+    __m512i z3        = _mm512_loadu_si512(sa - 4);
+    _mm512_store_si512(da - 1, z0);
+    ucs_compiler_fence();
+    _mm512_store_si512(da - 2, z1);
+    ucs_compiler_fence();
+    _mm512_store_si512(da - 3, z2);
+    ucs_compiler_fence();
+    _mm512_store_si512(da - 4, z3);
+}
+
+/* 256B store (4x), descending, aligned load. */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_avx512_loada_store_256_bwd(void *dst, const void *src)
+{
+    const __m512i *sa = src;
+    __m512i *da       = dst;
+    __m512i z0        = _mm512_load_si512(sa - 1);
+    __m512i z1        = _mm512_load_si512(sa - 2);
+    __m512i z2        = _mm512_load_si512(sa - 3);
+    __m512i z3        = _mm512_load_si512(sa - 4);
+    _mm512_store_si512(da - 1, z0);
+    ucs_compiler_fence();
+    _mm512_store_si512(da - 2, z1);
+    ucs_compiler_fence();
+    _mm512_store_si512(da - 3, z2);
+    ucs_compiler_fence();
+    _mm512_store_si512(da - 4, z3);
+}
+
+/* AVX-512 NT_DEST copy-in: NT body stores + trailing sfence; ascending.  An
+ * unconditional byte-masked head edge covers [dp, dp+offset) up to the next 64B
+ * line so dp+offset is 64B-aligned for the body; the sub-cache-line tail
+ * (1..63 B) is covered by a byte-masked store.  Precondition: len >= 64. */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_nt_dst_avx512_buffer_transfer(void *dst, const void *src, size_t len)
+{
+    char *dp       = dst;
+    const char *sp = src;
+    size_t offset  = ucs_x86_avx512_nt_body_off_fwd(dp);
+    char *nt_store_ptr;
+    int src_aligned;
+
+    /* (1) unconditional byte-masked head edge [dp, dp+offset); aligned base,
+     * offset==64 when dp is aligned (full first line). */
+    ucs_x86_avx512_nt_masked_head_64(dp, sp, offset);
+
+    /* (2) ascending 256B NT-stream body to last full 256B.  A dedicated
+     * cursor keeps the hot NT stores in base+displacement form. */
+    nt_store_ptr = UCS_PTR_BYTE_OFFSET(dp, offset);
+    src_aligned  = ((UCS_PTR_BYTE_DIFF(dp, sp) & 63u) == 0u);
+    if (ucs_unlikely(src_aligned)) {
+        while (offset + 256 <= len) {
+            ucs_x86_avx512_loada_stream_256(nt_store_ptr,
+                                            UCS_PTR_BYTE_OFFSET(sp, offset));
+            nt_store_ptr += 256;
+            offset       += 256;
+        }
+    } else {
+        while (offset + 256 <= len) {
+            ucs_x86_avx512_loadu_stream_256(nt_store_ptr,
+                                            UCS_PTR_BYTE_OFFSET(sp, offset));
+            nt_store_ptr += 256;
+            offset       += 256;
+        }
+    }
+
+    /* (3) ascending 64B NT drain to the last full cache line. */
+    while (offset + 64 <= len) {
+        ucs_x86_avx512_loadu_stream_64(nt_store_ptr,
+                                       UCS_PTR_BYTE_OFFSET(sp, offset));
+        nt_store_ptr += 64;
+        offset       += 64;
+    }
+
+    /* (4) tail masked edge [dp+offset, dp+len); dp+offset is 64B-aligned. */
+    if (offset != len) {
+        ucs_x86_avx512_nt_masked_tail_64(dp, sp, offset, len - offset);
+    }
+
+    /* make the streaming writes visible to the other core */
+    ucs_memory_bus_store_fence();
+}
+
+/* AVX-512 NT_SOURCE copy-out: body stores, descending.  An unconditional
+ * byte-masked tail edge covers the last (partial) 64B line so the descent
+ * starts 64B-aligned; the sub-cache-line head (1..63 B) is covered by a
+ * byte-masked store.  Precondition: len >= 64. */
+static UCS_F_ALWAYS_INLINE void
+ucs_x86_nt_src_avx512_buffer_transfer(void *dst, const void *src, size_t len)
+{
+    char *dp          = dst;
+    const char *sp    = src;
+    const size_t edge = ucs_x86_avx512_nt_tail_edge_len(dp, len);
+    size_t offset     = len - edge; /* descent start; 64B-aligned */
+    int src_aligned;
+
+    /* (1) unconditional byte-masked tail edge [dp+len-edge, dp+len); aligned
+     * base, edge==64 when the tail is aligned (full last line). */
+    ucs_x86_avx512_nt_masked_tail_64(dp, sp, offset, edge);
+
+    /* (2) descending 256B body to last full 256B. */
+    src_aligned = ((UCS_PTR_BYTE_DIFF(dp, sp) & 63u) == 0u);
+    if (src_aligned) {
+        while (offset >= 256) {
+            ucs_x86_avx512_loada_store_256_bwd(UCS_PTR_BYTE_OFFSET(dp, offset),
+                                               UCS_PTR_BYTE_OFFSET(sp, offset));
+            offset -= 256;
+        }
+    } else {
+        while (offset >= 256) {
+            ucs_x86_avx512_loadu_store_256_bwd(UCS_PTR_BYTE_OFFSET(dp, offset),
+                                               UCS_PTR_BYTE_OFFSET(sp, offset));
+            offset -= 256;
+        }
+    }
+
+    /* (3) descending 64B drain to the last full cache line. */
+    while (offset >= 64) {
+        ucs_x86_avx512_loadu_store_64_bwd(UCS_PTR_BYTE_OFFSET(dp, offset),
+                                          UCS_PTR_BYTE_OFFSET(sp, offset));
+        offset -= 64;
+    }
+
+    /* (4) head masked edge [dp, dp+offset); offset == descent head
+     * remainder. */
+    if (offset != 0u) {
+        ucs_x86_avx512_nt_masked_head_64(dp, sp, offset);
+    }
+}
+
+#define ucs_x86_nt_dst_buffer_transfer ucs_x86_nt_dst_avx512_buffer_transfer
+#define ucs_x86_nt_src_buffer_transfer ucs_x86_nt_src_avx512_buffer_transfer

--- a/src/ucs/arch/x86_64/global_opts.c
+++ b/src/ucs/arch/x86_64/global_opts.c
@@ -28,8 +28,8 @@ ucs_config_field_t ucs_arch_global_opts_table[] = {
 #endif
   {"NT_BUFFER_TRANSFER_MIN", "auto",
    "Minimal threshold of buffer length for using non-temporal buffer "
-   "transfer. Setting it explicitly disables the outer built-in memcpy "
-   "window.",
+   "transfer. When built-in memcpy is enabled, setting it explicitly "
+   "disables the outer built-in memcpy window.",
    ucs_offsetof(ucs_arch_global_opts_t, nt_buffer_transfer_min),
    UCS_CONFIG_TYPE_MEMUNITS},
   {NULL}

--- a/src/ucs/arch/x86_64/global_opts.c
+++ b/src/ucs/arch/x86_64/global_opts.c
@@ -55,7 +55,7 @@ void ucs_arch_print_memcpy_limits(ucs_arch_global_opts_t *config)
                                 &config->nt_buffer_transfer_min, NULL);
     ucs_config_sprintf_memunits(dest_thresh_str, sizeof(dest_thresh_str),
                                 &config->nt_dest_threshold, NULL);
-    printf("# Using nt-buffer-transfer for sizes above %s\n", min_thresh_str);
+    printf("# Using nt-buffer-transfer for sizes from %s\n", min_thresh_str);
     printf("# Using nt-destination-hint for sizes above %s\n", dest_thresh_str);
 }
 #endif

--- a/src/ucs/arch/x86_64/global_opts.c
+++ b/src/ucs/arch/x86_64/global_opts.c
@@ -27,7 +27,9 @@ ucs_config_field_t ucs_arch_global_opts_table[] = {
    UCS_CONFIG_TYPE_MEMUNITS},
 #endif
   {"NT_BUFFER_TRANSFER_MIN", "auto",
-   "Minimal threshold of buffer length for using non-temporal buffer transfer.",
+   "Minimal threshold of buffer length for using non-temporal buffer "
+   "transfer. Setting it explicitly disables the outer built-in memcpy "
+   "window.",
    ucs_offsetof(ucs_arch_global_opts_t, nt_buffer_transfer_min),
    UCS_CONFIG_TYPE_MEMUNITS},
   {NULL}

--- a/src/ucs/arch/x86_64/global_opts.c
+++ b/src/ucs/arch/x86_64/global_opts.c
@@ -55,9 +55,7 @@ void ucs_arch_print_memcpy_limits(ucs_arch_global_opts_t *config)
                                 &config->nt_buffer_transfer_min, NULL);
     ucs_config_sprintf_memunits(dest_thresh_str, sizeof(dest_thresh_str),
                                 &config->nt_dest_threshold, NULL);
-    printf("# Using nt-buffer-transfer for sizes from %s\n",
-           min_thresh_str);
-    printf("# Using nt-destination-hint for sizes from %s\n",
-           dest_thresh_str);
+    printf("# Using nt-buffer-transfer for sizes above %s\n", min_thresh_str);
+    printf("# Using nt-destination-hint for sizes above %s\n", dest_thresh_str);
 }
 #endif

--- a/test/gtest/ucs/arch/test_x86_64.cc
+++ b/test/gtest/ucs/arch/test_x86_64.cc
@@ -1,6 +1,6 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019. ALL RIGHTS RESERVED.
-* Copyright (C) Advanced Micro Devices, Inc. 2024. ALL RIGHTS RESERVED.
+* Copyright (C) Advanced Micro Devices, Inc. 2024-2026. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -186,6 +186,8 @@ UCS_TEST_SKIP_COND_F(test_arch, memcpy, RUNNING_ON_VALGRIND || !ucs::perf_retry_
 }
 
 UCS_TEST_F(test_arch, nt_buffer_transfer_nt_src) {
+    /* Skip the ERMS (rep movsb) branch so the NT_SOURCE kernel is exercised */
+    ucs_global_opts.arch.builtin_memcpy_min = UCS_MEMUNITS_INF;
     nt_buffer_transfer_test(UCS_ARCH_MEMCPY_NT_SOURCE);
 }
 

--- a/test/gtest/ucs/arch/test_x86_64.cc
+++ b/test/gtest/ucs/arch/test_x86_64.cc
@@ -186,8 +186,12 @@ UCS_TEST_SKIP_COND_F(test_arch, memcpy, RUNNING_ON_VALGRIND || !ucs::perf_retry_
 }
 
 UCS_TEST_F(test_arch, nt_buffer_transfer_nt_src) {
-    /* Skip the ERMS (rep movsb) branch so the NT_SOURCE kernel is exercised */
+    /* Exercise the vectorized NT_SOURCE path */
     ucs_global_opts.arch.builtin_memcpy_min = UCS_MEMUNITS_INF;
+    nt_buffer_transfer_test(UCS_ARCH_MEMCPY_NT_SOURCE);
+
+    /* Exercise the ERMS NT_SOURCE path */
+    ucs_global_opts.arch.builtin_memcpy_min = 0;
     nt_buffer_transfer_test(UCS_ARCH_MEMCPY_NT_SOURCE);
 }
 

--- a/test/gtest/ucs/arch/test_x86_64.cc
+++ b/test/gtest/ucs/arch/test_x86_64.cc
@@ -190,9 +190,11 @@ UCS_TEST_F(test_arch, nt_buffer_transfer_nt_src) {
     ucs_global_opts.arch.builtin_memcpy_min = UCS_MEMUNITS_INF;
     nt_buffer_transfer_test(UCS_ARCH_MEMCPY_NT_SOURCE);
 
+#if ENABLE_BUILTIN_MEMCPY
     /* Exercise the ERMS NT_SOURCE path */
     ucs_global_opts.arch.builtin_memcpy_min = 0;
     nt_buffer_transfer_test(UCS_ARCH_MEMCPY_NT_SOURCE);
+#endif
 }
 
 UCS_TEST_F(test_arch, nt_buffer_transfer_nt_dst) {


### PR DESCRIPTION
## What

- Refactor AVX2 kernels into an ISA-specific inline fragment.
- Add AVX-512 masked-edge NT source and destination kernels.
- Share the ERMS copy helper and extend NT-path test coverage.

## Why?
New feature

## How?
Build
AVX2: configure with --enable-optimizations.
AVX-512: add -march=znver5 or another target flag defining __AVX512BW__ into CFLAGS.

Runtime requirements
Currently recommended for workloads using one MPI rank per L3 cache domain.

Required runtime arguments(config params):
UCX_NT_BUFFER_TRANSFER_MIN=0
UCX_BUILTIN_MEMCPY_MAX=0


The default UCX_NT_BUFFER_TRANSFER_MIN start threshold is three-quarters of the detected L3 cache size.