### PR TITLE
TOOLS/PERF: swap deprecated omp pragma master to masked

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -138,6 +138,7 @@ Zhu Yanjun <yanjunz@mellanox.com>
 Zihao Zhao <zizhao@nvidia.com>
 lzhang2 <cherry.zhang@intel.com>
 michaelzli <michaelzli@tencent.com>
+whispers <whispersofthedawn@duck.com>
 
 In addition we would like to acknowledge the following members of UCX community
 for their participation in annual face-to-face meeting, design discussions, and

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -243,7 +243,11 @@ static void sock_rte_barrier(void *rte_group, void (*progress)(void *arg),
 {
 #if _OPENMP
 #  pragma omp barrier
-#  pragma omp master
+#  if _OPENMP >= 202011
+#    pragma omp masked
+#  else
+#    pragma omp master
+#  endif
 #endif
   {
     sock_rte_group_t *group = rte_group;


### PR DESCRIPTION
## What?
This PR swaps `#pragma omp master` to `#pragma omp masked` in `perftest.c` in order to better align with OpenMP version 5.1 and above.

## Why?
As of OpenMP 5.1, the 'master' construct has been deprecated in favor of 'masked'. As per the OpenMP specification:

> The directive-name `master` may be used as a synonym to `masked` if no clauses are speciﬁed. This syntax has been deprecated.

https://www.openmp.org/spec-html/5.2/openmpse61.html

This causes a warning under GCC 16, which is made into a build failure by -Werror.

This closes #11061. See that issue for an example error, which I've reproduced with GCC version 16.1.0 on x86_64-linux.

## How?
On OpenMP versions which support it (5.1, or `202011`), this changes to using `#pragma omp masked` while conditionally leaving `#pragma omp master` on older versions.

I apologize for any procedural mistakes here, trying to figure out how these CI systems work as I go.