### PR TITLE
NEWS: Update v1.22.x release notes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,12 @@
 ### Features:
 ### Bugfixes:
 
+## 1.22.0-rc3 (July 26, 2026)
+### Bugfixes:
+#### UCP
+ * Fixed rendezvous multi-lane protocol selection to preserve combined minimum sizes
+ * Fixed unnecessary rendezvous PUT fences on ordered transports
+
 ## 1.22.0-rc2 (July 16, 2026)
 ### Features:
 #### UCP


### PR DESCRIPTION
## What

Adds the `1.22.0-rc3` section to `NEWS` and documents the UCP bug fixes that landed after rc2.

## Why

Keeps the v1.22.x release notes current for the next release candidate.