### PR TITLE
AZP/RELEASE: Trust ISRG Root X2 for JUCX Maven publish

### DIFF
--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -91,9 +91,19 @@ jobs:
           echo "allow-loopback-pinentry" > $GNUPGHOME/gpg-agent.conf
           gpg-connect-agent reloadagent /bye || true
 
+          # JDK 1.8 cacerts predates ISRG Root X2, the trust anchor of the
+          # Sonatype Central TLS chain; import it into a local truststore copy
+          truststore=$(gpg_dir)/../truststore.jks
+          cp $JAVA_HOME/jre/lib/security/cacerts $truststore ||
+              cp $JAVA_HOME/lib/security/cacerts $truststore
+          chmod u+w $truststore
+          curl -sSf https://letsencrypt.org/certs/isrg-root-x2.pem -o isrg-root-x2.pem
+          keytool -importcert -noprompt -keystore $truststore \
+              -storepass changeit -alias isrg-root-x2 -file isrg-root-x2.pem
+
           MAVEN_VERSION=$(grep '^VERSION = ' Makefile | cut -d= -f2 | tr -d ' ')
           make -C bindings/java/src/main/native/ ${{ parameters.target }} \
-              ARGS="--settings $(temp_cfg)" \
+              ARGS="--settings $(temp_cfg) -Djavax.net.ssl.trustStore=$truststore" \
               JUCX_VERSION=${MAVEN_VERSION}${SUFFIX}
         displayName: Publish-Maven
         condition: eq(variables['Build.Reason'], 'IndividualCI')


### PR DESCRIPTION
## What
Import Let's Encrypt roots (ISRG Root X1, X2) into a local copy of the JDK 1.8 cacerts and point the JUCX Maven deploy at it.

## Why
JUCX publish fails on both arches in the v1.22.0-rc3 release builds (129441, 129445):
```
Nexus connection problem to URL [https://ossrh-staging-api.central.sonatype.com/ ]:
javax.net.ssl.SSLHandshakeException: PKIX path building failed:
unable to find valid certification path to requested target
```
The endpoint's certificate was renewed on 2026-07-22 and the new chain is anchored on ISRG Root X2, which the JDK 1.8 truststore predates. rc2 (published Jul 16) still passed with the old chain.

## How tested
Cacerts copy + keytool import flow verified locally with the same PEM URLs. Needs a release pipeline run to confirm end to end.