### PR TITLE
UCT/GDAKI: Expose dev matrix via uct_gdaki_dev_matrix_get

### DIFF
--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -1237,6 +1237,12 @@ typedef struct {
 
 typedef struct {
     ucs_sys_device_t sys_dev;
+    uint64_t         cuda_map;
+    int              direct_nic;
+} uct_gdaki_dev_matrix_elem_t;
+
+typedef struct {
+    ucs_sys_device_t sys_dev;
     ucs_sys_bus_id_t bus_id;
     int              cuda_idx; /* CUDA driver index, -1 if not CUDA-visible */
 } uct_gdaki_gpu_info_t;
@@ -1519,49 +1525,29 @@ out_dev:
     return dmat;
 }
 
-const uct_gdaki_dev_matrix_elem_t *
-uct_gdaki_dev_matrix_get(const uct_ib_md_t *ib_md, size_t *dmat_length_p)
+ucs_status_t
+uct_gdaki_fill_cuda_tl_devices(const uct_ib_md_t *ib_md,
+                               uct_tl_device_resource_t **tl_devices_p,
+                               unsigned *num_tl_devices_p)
 {
     static ucs_init_once_t once = UCS_INIT_ONCE_INITIALIZER;
     static uct_gdaki_dev_matrix_elem_t *dmat;
     static size_t dmat_length;
+    const uct_gdaki_dev_matrix_elem_t *ibdesc;
+    uct_tl_device_resource_t *tl_devices;
+    unsigned num_tl_devices;
+    ucs_status_t status;
+    CUdevice device;
+    int i;
 
     UCS_INIT_ONCE(&once) {
         dmat = uct_gdaki_dev_matrix_init(ib_md, &dmat_length);
     }
 
-    *dmat_length_p = dmat_length;
-    return dmat;
-}
-
-static ucs_status_t
-uct_gdaki_query_tl_devices(uct_md_h tl_md,
-                           uct_tl_device_resource_t **tl_devices_p,
-                           unsigned *num_tl_devices_p)
-{
-    uct_ib_mlx5_md_t *ib_mlx5_md = ucs_derived_of(tl_md, uct_ib_mlx5_md_t);
-    uct_ib_md_t *ib_md           = &ib_mlx5_md->super;
-    const uct_gdaki_dev_matrix_elem_t *dmat, *ibdesc;
-    unsigned num_tl_devices;
-    uct_tl_device_resource_t *tl_devices;
-    ucs_status_t status;
-    size_t dmat_length;
-    CUdevice device;
-    int i;
-
-    if (!(uct_gdaki_get_driver_features(ib_md) & UCT_GDAKI_SUPPORTED)) {
-        ucs_debug("%s: GDAKI is not supported",
-                  uct_ib_device_name(&ib_md->dev));
-        status = UCS_ERR_NO_DEVICE;
-        goto out;
-    }
-
-    dmat = uct_gdaki_dev_matrix_get(ib_md, &dmat_length);
     if (dmat == NULL) {
-        ucs_debug("%s: global device matrix initialization failed",
+        ucs_debug("%s: device matrix initialization failed",
                   uct_ib_device_name(&ib_md->dev));
-        status = UCS_ERR_NO_DEVICE;
-        goto out;
+        return UCS_ERR_NO_DEVICE;
     }
 
     for (ibdesc = dmat; ibdesc - dmat < dmat_length; ibdesc++) {
@@ -1570,21 +1556,22 @@ uct_gdaki_query_tl_devices(uct_md_h tl_md,
         }
     }
 
-    ucs_assertv(ibdesc - dmat < dmat_length, "dev %s",
-                uct_ib_device_name(&ib_md->dev));
+    if (ibdesc - dmat == dmat_length) {
+        ucs_debug("%s: IB device not found in device matrix",
+                  uct_ib_device_name(&ib_md->dev));
+        return UCS_ERR_NO_DEVICE;
+    }
 
     if (ibdesc->cuda_map == 0) {
-        ucs_debug("%s: no assigned gpu found", uct_ib_device_name(&ib_md->dev));
-        status = UCS_ERR_NO_DEVICE;
-        goto out;
+        ucs_debug("%s: no assigned GPU found", uct_ib_device_name(&ib_md->dev));
+        return UCS_ERR_NO_DEVICE;
     }
 
     tl_devices = ucs_malloc(sizeof(*tl_devices) *
                                     ucs_popcount(ibdesc->cuda_map),
                             "gdaki_tl_devices");
     if (tl_devices == NULL) {
-        status = UCS_ERR_NO_MEMORY;
-        goto out;
+        return UCS_ERR_NO_MEMORY;
     }
 
     num_tl_devices = 0;
@@ -1609,8 +1596,25 @@ uct_gdaki_query_tl_devices(uct_md_h tl_md,
 
 err:
     ucs_free(tl_devices);
-out:
     return status;
+}
+
+static ucs_status_t
+uct_gdaki_query_tl_devices(uct_md_h tl_md,
+                           uct_tl_device_resource_t **tl_devices_p,
+                           unsigned *num_tl_devices_p)
+{
+    uct_ib_mlx5_md_t *ib_mlx5_md = ucs_derived_of(tl_md, uct_ib_mlx5_md_t);
+    uct_ib_md_t *ib_md           = &ib_mlx5_md->super;
+
+    if (!(uct_gdaki_get_driver_features(ib_md) & UCT_GDAKI_SUPPORTED)) {
+        ucs_debug("%s: GDAKI is not supported",
+                  uct_ib_device_name(&ib_md->dev));
+        return UCS_ERR_NO_DEVICE;
+    }
+
+    return uct_gdaki_fill_cuda_tl_devices(ib_md, tl_devices_p,
+                                          num_tl_devices_p);
 }
 
 UCT_TL_DEFINE_ENTRY(&uct_ib_component, rc_gda, uct_gdaki_query_tl_devices,

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -1237,12 +1237,6 @@ typedef struct {
 
 typedef struct {
     ucs_sys_device_t sys_dev;
-    uint64_t         cuda_map;
-    int              direct_nic;
-} uct_gdaki_dev_matrix_elem_t;
-
-typedef struct {
-    ucs_sys_device_t sys_dev;
     ucs_sys_bus_id_t bus_id;
     int              cuda_idx; /* CUDA driver index, -1 if not CUDA-visible */
 } uct_gdaki_gpu_info_t;
@@ -1397,7 +1391,7 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
     return UCS_OK;
 }
 
-uct_gdaki_dev_matrix_elem_t *
+static uct_gdaki_dev_matrix_elem_t *
 uct_gdaki_dev_matrix_init(const uct_ib_md_t *ib_md, size_t *dmat_length_p)
 {
     unsigned long ib_per_cuda         = ib_md->config.gda_max_hca_per_gpu;
@@ -1525,22 +1519,35 @@ out_dev:
     return dmat;
 }
 
+const uct_gdaki_dev_matrix_elem_t *
+uct_gdaki_dev_matrix_get(const uct_ib_md_t *ib_md, size_t *dmat_length_p)
+{
+    static ucs_init_once_t once = UCS_INIT_ONCE_INITIALIZER;
+    static uct_gdaki_dev_matrix_elem_t *dmat;
+    static size_t dmat_length;
+
+    UCS_INIT_ONCE(&once) {
+        dmat = uct_gdaki_dev_matrix_init(ib_md, &dmat_length);
+    }
+
+    *dmat_length_p = dmat_length;
+    return dmat;
+}
+
 static ucs_status_t
 uct_gdaki_query_tl_devices(uct_md_h tl_md,
                            uct_tl_device_resource_t **tl_devices_p,
                            unsigned *num_tl_devices_p)
 {
-    uct_ib_mlx5_md_t *ib_mlx5_md     = ucs_derived_of(tl_md, uct_ib_mlx5_md_t);
-    uct_ib_md_t *ib_md               = &ib_mlx5_md->super;
-    static ucs_init_once_t dmat_once = UCS_INIT_ONCE_INITIALIZER;
-    static uct_gdaki_dev_matrix_elem_t *dmat;
-    static size_t dmat_length;
+    uct_ib_mlx5_md_t *ib_mlx5_md = ucs_derived_of(tl_md, uct_ib_mlx5_md_t);
+    uct_ib_md_t *ib_md           = &ib_mlx5_md->super;
+    const uct_gdaki_dev_matrix_elem_t *dmat, *ibdesc;
     unsigned num_tl_devices;
     uct_tl_device_resource_t *tl_devices;
     ucs_status_t status;
+    size_t dmat_length;
     CUdevice device;
     int i;
-    uct_gdaki_dev_matrix_elem_t *ibdesc;
 
     if (!(uct_gdaki_get_driver_features(ib_md) & UCT_GDAKI_SUPPORTED)) {
         ucs_debug("%s: GDAKI is not supported",
@@ -1549,10 +1556,7 @@ uct_gdaki_query_tl_devices(uct_md_h tl_md,
         goto out;
     }
 
-    UCS_INIT_ONCE(&dmat_once) {
-        dmat = uct_gdaki_dev_matrix_init(ib_md, &dmat_length);
-    }
-
+    dmat = uct_gdaki_dev_matrix_get(ib_md, &dmat_length);
     if (dmat == NULL) {
         ucs_debug("%s: global device matrix initialization failed",
                   uct_ib_device_name(&ib_md->dev));

--- a/src/uct/ib/mlx5/gdaki/gdaki.h
+++ b/src/uct/ib/mlx5/gdaki/gdaki.h
@@ -54,13 +54,9 @@ typedef struct uct_rc_gdaki_ep {
     uct_rc_gdaki_channel_block_t     *channel_block;
 } uct_rc_gdaki_ep_t;
 
-typedef struct {
-    ucs_sys_device_t sys_dev;
-    uint64_t         cuda_map;
-    int              direct_nic;
-} uct_gdaki_dev_matrix_elem_t;
-
-const uct_gdaki_dev_matrix_elem_t *
-uct_gdaki_dev_matrix_get(const uct_ib_md_t *ib_md, size_t *dmat_length_p);
+ucs_status_t
+uct_gdaki_fill_cuda_tl_devices(const uct_ib_md_t *ib_md,
+                               uct_tl_device_resource_t **tl_devices_p,
+                               unsigned *num_tl_devices_p);
 
 #endif /* UCT_GDAKI_H */

--- a/src/uct/ib/mlx5/gdaki/gdaki.h
+++ b/src/uct/ib/mlx5/gdaki/gdaki.h
@@ -54,4 +54,13 @@ typedef struct uct_rc_gdaki_ep {
     uct_rc_gdaki_channel_block_t     *channel_block;
 } uct_rc_gdaki_ep_t;
 
+typedef struct {
+    ucs_sys_device_t sys_dev;
+    uint64_t         cuda_map;
+    int              direct_nic;
+} uct_gdaki_dev_matrix_elem_t;
+
+const uct_gdaki_dev_matrix_elem_t *
+uct_gdaki_dev_matrix_get(const uct_ib_md_t *ib_md, size_t *dmat_length_p);
+
 #endif /* UCT_GDAKI_H */


### PR DESCRIPTION
Add uct_gdaki_dev_matrix_elem_t typedef and uct_gdaki_dev_matrix_get declaration to gdaki.h so external transports (e.g. GDP) can look up the IB-device→CUDA affinity matrix without duplicating the computation.

uct_gdaki_dev_matrix_get owns the UCS_INIT_ONCE singleton; callers share one matrix allocation from gdaki.so. uct_gdaki_dev_matrix_init becomes static. uct_gdaki_query_tl_devices is updated to call the new getter.
