### PR TITLE
UCP/DEVICE: Require connected EP for remote mem list

### DIFF
--- a/src/ucp/core/ucp_device.c
+++ b/src/ucp/core/ucp_device.c
@@ -643,9 +643,6 @@ static ucs_status_t ucp_device_remote_mem_list_params_check(
     ucp_rkey_h rkey;
     ucp_ep_h ep;
     size_t i;
-    ucs_status_t status;
-    void *addr_ptr;
-    uint64_t remote_addr;
 
     if (remote_elements == NULL || element_size == 0 || num_elements == 0) {
         ucs_error("invalid remote mem list params: remote_elements=%p, "
@@ -668,20 +665,13 @@ static ucs_status_t ucp_device_remote_mem_list_params_check(
             return UCS_ERR_INVALID_PARAM;
         }
 
-        remote_addr = UCS_PARAM_VALUE(UCP_DEVICE_MEM_LIST_ELEM_FIELD,
-                                      remote_element, remote_addr, REMOTE_ADDR,
-                                      0);
-        status      = ucp_rkey_ptr(rkey, remote_addr, &addr_ptr);
-        /* Check if ep is connected only in case cuda_ipc can't be used for transfer */
-        if (status != UCS_OK) {
-            if (!(ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED)) {
-                /*
-                 * Do not log error here because UCS_ERR_NOT_CONNECTED is expected
-                 * during connection establishment. Applications are expected to retry
-                 * with progress.
-                 */
-                return UCS_ERR_NOT_CONNECTED;
-            }
+        if (!(ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED)) {
+            /*
+             * Do not log error here because UCS_ERR_NOT_CONNECTED is expected
+             * during connection establishment. Applications are expected to retry
+             * with progress.
+             */
+            return UCS_ERR_NOT_CONNECTED;
         }
     }
 


### PR DESCRIPTION
## What?
https://nvbugspro.nvidia.com/bug/6471178
Require the remote endpoint to be fully connected before creating a device remote memory list.

## Why?
The connection check was previously skipped when CUDA IPC could access the remote memory. However, a multi-lane memory list may also contain another transport, such as RC GDA, whose endpoint is still in wireup. Attempting to obtain its device endpoint then returns `UCS_ERR_NO_RESOURCE`.

