### PR TITLE
UCP/PROTO: Select transport-recommended GET paths

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -71,6 +71,8 @@
 #define UCP_CPU_EST_BCOPY_BW_DEFAULT         (7000 * UCS_MBYTE)
 #define UCP_CPU_EST_BCOPY_BW_DEFAULT_PROTOV1 (5800 * UCS_MBYTE)
 #define UCP_CPU_EST_BCOPY_BW_AMD_PROTOV1     (5008 * UCS_MBYTE)
+#define UCP_MAX_RNDV_LANES_DEFAULT           2
+#define UCP_MAX_RMA_LANES_DEFAULT            1
 
 #define UCP_TL_AUX_SUFFIX    "aux"
 #define UCP_TL_AUX(_tl_name) _tl_name ":" UCP_TL_AUX_SUFFIX
@@ -228,18 +230,22 @@ static ucs_config_field_t ucp_context_config_table[] = {
    ucs_offsetof(ucp_context_config_t, max_eager_lanes), UCS_CONFIG_TYPE_UINT},
 
   {"MAX_RNDV_LANES", NULL,"",
-   ucs_offsetof(ucp_context_config_t, max_rndv_lanes), UCS_CONFIG_TYPE_UINT},
+   ucs_offsetof(ucp_context_config_t, max_rndv_lanes_config),
+   UCS_CONFIG_TYPE_ULUNITS},
 
-  {"MAX_RNDV_RAILS", "2",
+  {"MAX_RNDV_RAILS", "auto",
    "Maximal number of devices on which a rendezvous operation may be executed in parallel",
-   ucs_offsetof(ucp_context_config_t, max_rndv_lanes), UCS_CONFIG_TYPE_UINT},
+   ucs_offsetof(ucp_context_config_t, max_rndv_lanes_config),
+   UCS_CONFIG_TYPE_ULUNITS},
 
   {"MAX_RMA_LANES", NULL, "",
-   ucs_offsetof(ucp_context_config_t, max_rma_lanes), UCS_CONFIG_TYPE_UINT},
+   ucs_offsetof(ucp_context_config_t, max_rma_lanes_config),
+   UCS_CONFIG_TYPE_ULUNITS},
 
-  {"MAX_RMA_RAILS", "1",
+  {"MAX_RMA_RAILS", "auto",
    "Maximal number of devices on which a RMA operation may be executed in parallel",
-   ucs_offsetof(ucp_context_config_t, max_rma_lanes), UCS_CONFIG_TYPE_UINT},
+   ucs_offsetof(ucp_context_config_t, max_rma_lanes_config),
+   UCS_CONFIG_TYPE_ULUNITS},
 
   {"MIN_RNDV_CHUNK_SIZE", "16k",
    "Minimum chunk size to split the message sent with rendezvous protocol on\n"
@@ -2407,6 +2413,23 @@ static double ucp_context_get_protov1_memcpy_bw()
                    UCP_CPU_EST_BCOPY_BW_DEFAULT_PROTOV1;
 }
 
+static ucs_status_t
+ucp_context_resolve_max_lanes(const char *config_name,
+                              unsigned long config_value,
+                              unsigned default_value, unsigned *value_p)
+{
+    if (config_value == UCS_ULUNITS_AUTO) {
+        *value_p = default_value;
+    } else if (config_value > UCP_MAX_LANES) {
+        ucs_error("%s must not exceed %u", config_name, UCP_MAX_LANES);
+        return UCS_ERR_INVALID_PARAM;
+    } else {
+        *value_p = config_value;
+    }
+
+    return UCS_OK;
+}
+
 static int
 ucp_dynamic_tl_switch_config_valid(const ucp_context_config_t *config)
 {
@@ -2442,6 +2465,22 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
                                           ucp_context_config_table);
     if (status != UCS_OK) {
         goto err;
+    }
+
+    status = ucp_context_resolve_max_lanes(
+            "UCX_MAX_RNDV_RAILS",
+            context->config.ext.max_rndv_lanes_config,
+            UCP_MAX_RNDV_LANES_DEFAULT,
+            &context->config.ext.max_rndv_lanes);
+    if (status != UCS_OK) {
+        goto err_free_config_ext;
+    }
+
+    status = ucp_context_resolve_max_lanes(
+            "UCX_MAX_RMA_RAILS", context->config.ext.max_rma_lanes_config,
+            UCP_MAX_RMA_LANES_DEFAULT, &context->config.ext.max_rma_lanes);
+    if (status != UCS_OK) {
+        goto err_free_config_ext;
     }
 
     if (context->config.ext.estimated_num_eps != UCS_ULUNITS_AUTO) {

--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -152,8 +152,12 @@ typedef struct ucp_context_config {
     int                                    adaptive_progress;
     /** Eager-am multi-lane support */
     unsigned                               max_eager_lanes;
+    /** Raw rendezvous lane limit before resolving the auto value */
+    unsigned long                          max_rndv_lanes_config;
     /** Rendezvous-get multi-lane support */
     unsigned                               max_rndv_lanes;
+    /** Raw RMA lane limit before resolving the auto value */
+    unsigned long                          max_rma_lanes_config;
     /** RMA multi-lane support */
     unsigned                               max_rma_lanes;
     /** Minimum allowed chunk size when splitting rndv message over multiple

--- a/src/ucp/proto/proto_common.c
+++ b/src/ucp/proto/proto_common.c
@@ -321,6 +321,8 @@ static void ucp_proto_common_tl_perf_reset(ucp_proto_common_tl_perf_t *tl_perf)
     tl_perf->send_post_overhead = 0;
     tl_perf->recv_overhead      = 0;
     tl_perf->bandwidth          = 0;
+    tl_perf->num_paths          = 1;
+    tl_perf->num_paths_fixed    = 0;
     tl_perf->latency            = 0;
     tl_perf->sys_latency        = 0;
     tl_perf->min_length         = 0;
@@ -387,7 +389,9 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
                                   UCT_PERF_ATTR_FIELD_RECV_OVERHEAD |
                                   UCT_PERF_ATTR_FIELD_BANDWIDTH |
                                   UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH |
-                                  UCT_PERF_ATTR_FIELD_LATENCY;
+                                  UCT_PERF_ATTR_FIELD_LATENCY |
+                                  UCT_PERF_ATTR_FIELD_NUM_PATHS |
+                                  UCT_PERF_ATTR_FIELD_FLAGS;
     perf_attr.operation         = params->send_op;
     ucp_proto_common_perf_attr_set_mem_type(params, &perf_attr);
 
@@ -404,6 +408,9 @@ ucp_proto_common_get_lane_perf(const ucp_proto_common_init_params_t *params,
     tl_perf->path_ratio         = ucp_proto_common_iface_bandwidth(
                                       context, &perf_attr.path_bandwidth) /
                                   tl_perf->bandwidth;
+    tl_perf->num_paths          = perf_attr.num_paths;
+    tl_perf->num_paths_fixed    = !!(perf_attr.flags &
+                                    UCT_PERF_ATTR_FLAGS_NUM_PATHS_FIXED);
     tl_perf->latency            = ucp_tl_iface_latency(context,
                                                        &perf_attr.latency) +
                                   params->latency;

--- a/src/ucp/proto/proto_common.h
+++ b/src/ucp/proto/proto_common.h
@@ -168,6 +168,12 @@ typedef struct {
     /* Single path ratio of the full bandwidth */
     double path_ratio;
 
+    /* Number of paths recommended for the operation */
+    unsigned num_paths;
+
+    /* Whether the number of paths was set explicitly */
+    int num_paths_fixed;
+
     /* Network latency */
     double latency;
 

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -95,7 +95,7 @@ static ucp_lane_index_t ucp_proto_multi_find_max_avail_bw_lane(
         const ucp_proto_init_params_t *params, const ucp_lane_index_t *lanes,
         const ucp_proto_common_tl_perf_t *lanes_perf,
         const ucp_proto_lane_selection_t *selection, ucp_lane_map_t index_map,
-        unsigned req_sys_dev_ord)
+        unsigned req_sys_dev_ord, int enforce_num_paths)
 {
     /* Initial value is 1Bps, so we don't consider lanes with lower available
      * bandwidth. */
@@ -106,6 +106,7 @@ static ucp_lane_index_t ucp_proto_multi_find_max_avail_bw_lane(
     ucp_lane_index_t i, index, selected_index, first_max_bw_lane;
     const ucp_proto_common_tl_perf_t *lane_perf;
     ucs_sys_device_t sys_dev, selected_sys_dev;
+    ucp_rsc_index_t dev_index;
     unsigned seed;
     double avail_bw;
     int cmp;
@@ -117,6 +118,12 @@ static ucp_lane_index_t ucp_proto_multi_find_max_avail_bw_lane(
     /* Pass 1: find max avail_bw and the set of lanes with that bandwidth. */
     ucs_for_each_bit(index, index_map) {
         lane_perf = &lanes_perf[lanes[index]];
+        dev_index = ucp_proto_common_get_dev_index(params, lanes[index]);
+        if (enforce_num_paths &&
+            (selection->dev_count[dev_index] >= lane_perf->num_paths)) {
+            continue;
+        }
+
         avail_bw = ucp_proto_multi_get_avail_bw(params, lanes[index], lane_perf,
                                                 selection);
         cmp      = ucs_fp_compare(avail_bw, max_avail_bw);
@@ -221,26 +228,23 @@ ucp_proto_multi_select_bw_lanes(const ucp_proto_init_params_t *params,
                                 ucp_lane_index_t max_lanes,
                                 const ucp_proto_common_tl_perf_t *lanes_perf,
                                 int fixed_first_lane,
+                                unsigned req_sys_dev_ord,
                                 ucp_proto_lane_selection_t *selection)
 {
-    ucs_sys_device_t req_sys_dev = params->select_param->sys_dev;
     ucp_lane_index_t i, lane_index;
     ucp_lane_map_t index_map;
-    unsigned req_sys_dev_ord;
 
     memset(selection, 0, sizeof(*selection));
 
     /* Select all available indexes */
     index_map = UCS_MASK(num_lanes);
 
-    /* The requesting device ordinal is constant across the greedy loop, so
-     * resolve it once instead of on every lane selection. */
-    req_sys_dev_ord = ucs_topo_sys_device_get_bdf_class_ordinal(req_sys_dev);
-
     ucs_trace("select bw lanes: proto %s req_sys_dev=%d (%s) "
               "bdf_class_ordinal=%u",
-              ucp_proto_id_field(params->proto_id, name), req_sys_dev,
-              ucs_topo_sys_device_get_name(req_sys_dev), req_sys_dev_ord);
+              ucp_proto_id_field(params->proto_id, name),
+              params->select_param->sys_dev,
+              ucs_topo_sys_device_get_name(params->select_param->sys_dev),
+              req_sys_dev_ord);
 
     if (fixed_first_lane) {
         ucp_proto_select_add_lane(selection, params, lanes[0]);
@@ -253,7 +257,8 @@ ucp_proto_multi_select_bw_lanes(const ucp_proto_init_params_t *params,
                                                             lanes_perf,
                                                             selection,
                                                             index_map,
-                                                            req_sys_dev_ord);
+                                                            req_sys_dev_ord,
+                                                            0);
         if (lane_index == UCP_NULL_LANE) {
             break;
         }
@@ -514,15 +519,85 @@ static void
 ucp_proto_multi_select_lanes(const ucp_proto_multi_init_params_t *params,
                              const ucp_lane_index_t *lanes,
                              ucp_lane_index_t num_lanes,
-                             const ucp_proto_common_tl_perf_t *lanes_perf,
+                             ucp_proto_common_tl_perf_t *lanes_perf,
                              int fixed_first_lane,
                              ucp_proto_lane_selection_t *selection)
 {
+    ucp_proto_common_tl_perf_t *lane_perf;
+    ucp_lane_index_t i, lane, lane_index, max_total_lanes;
+    ucp_rsc_index_t dev_index;
+    ucp_lane_map_t index_map;
+    unsigned req_sys_dev_ord;
+    int num_paths_fixed;
+    double path_ratio, total_ratio;
+
+    req_sys_dev_ord = ucs_topo_sys_device_get_bdf_class_ordinal(
+            params->super.super.select_param->sys_dev);
     ucs_log_indent(1);
 
-    ucp_proto_multi_select_bw_lanes(&params->super.super, lanes, num_lanes,
-                                    params->max_lanes, lanes_perf,
-                                    fixed_first_lane, selection);
+    max_total_lanes = params->select_uct_num_paths ?
+                      params->max_total_lanes : params->max_lanes;
+
+    ucp_proto_multi_select_bw_lanes(
+            &params->super.super, lanes, num_lanes, params->max_lanes,
+            lanes_perf, fixed_first_lane, req_sys_dev_ord, selection);
+
+    if (params->select_uct_num_paths) {
+        num_paths_fixed = 0;
+        for (i = 0; i < selection->num_lanes; ++i) {
+            num_paths_fixed |=
+                    lanes_perf[selection->lanes[i]].num_paths_fixed;
+        }
+
+        if (num_paths_fixed) {
+            max_total_lanes = UCP_PROTO_MAX_LANES;
+        }
+
+        index_map = 0;
+        for (i = 0; i < num_lanes; ++i) {
+            lane      = lanes[i];
+            dev_index = ucp_proto_common_get_dev_index(&params->super.super,
+                                                        lane);
+            if ((selection->dev_count[dev_index] > 0) &&
+                !(selection->lane_map & UCS_BIT(lane))) {
+                index_map |= UCS_BIT(i);
+            }
+        }
+
+        while ((selection->num_lanes < max_total_lanes) &&
+               (index_map != 0)) {
+            lane_index = ucp_proto_multi_find_max_avail_bw_lane(
+                    &params->super.super, lanes, lanes_perf, selection,
+                    index_map, req_sys_dev_ord, 1);
+            if (lane_index == UCP_NULL_LANE) {
+                break;
+            }
+
+            ucp_proto_select_add_lane(selection, &params->super.super,
+                                      lanes[lane_index]);
+            index_map &= ~UCS_BIT(lane_index);
+        }
+    }
+
+    for (i = 0; i < selection->num_lanes; ++i) {
+        lane      = selection->lanes[i];
+        lane_perf = &lanes_perf[lane];
+        dev_index = ucp_proto_common_get_dev_index(&params->super.super, lane);
+        if ((!lane_perf->num_paths_fixed && (lane_perf->num_paths == 1)) ||
+            (selection->dev_count[dev_index] > lane_perf->num_paths)) {
+            continue;
+        }
+
+        /* Preserve the calibrated first-path bandwidth and distribute the
+         * residual interface bandwidth among additional paths. */
+        path_ratio  = ucs_min(lane_perf->path_ratio, 1.0);
+        total_ratio = (lane_perf->num_paths == 1) ? path_ratio :
+                path_ratio + ((selection->dev_count[dev_index] - 1) *
+                              (1.0 - path_ratio) /
+                              (lane_perf->num_paths - 1));
+        lane_perf->bandwidth *= ucs_min(total_ratio, 1.0) /
+                                selection->dev_count[dev_index];
+    }
 
     ucs_assertv(ucs_ilog2(selection->lane_map) < UCP_MAX_LANES,
                 "lane_map exceeds max number of lanes: lane_map=0x%" PRIx64,
@@ -857,18 +932,41 @@ void ucp_proto_multi_probe(const ucp_proto_multi_init_params_t *params)
 {
     const char *proto_name = ucp_proto_id_field(params->super.super.proto_id,
                                                 name);
+    ucp_proto_multi_init_params_t init_params = *params;
+    ucp_lane_index_t max_total_lanes          = params->max_lanes;
+    int allow_short_baseline                  = 1;
     ucp_proto_multi_priv_t mpriv;
     ucp_proto_perf_t *perf;
     ucs_status_t status;
 
-    status = ucp_proto_multi_init(params, proto_name, &perf, &mpriv);
-    if (status != UCS_OK) {
-        return;
-    }
+    do {
+        init_params.max_total_lanes = max_total_lanes;
+        status = ucp_proto_multi_init(&init_params, proto_name, &perf, &mpriv);
+        if (status != UCS_OK) {
+            return;
+        }
 
-    ucp_proto_select_add_proto(&params->super.super, params->super.cfg_thresh,
-                               params->super.cfg_priority, perf, &mpriv,
-                               ucp_proto_multi_priv_size(&mpriv));
+        if (params->select_uct_num_paths &&
+            (mpriv.num_lanes < max_total_lanes)) {
+            if (!allow_short_baseline) {
+                ucp_proto_perf_destroy(perf);
+                return;
+            }
+
+            max_total_lanes = mpriv.num_lanes;
+        }
+
+        ucp_proto_select_add_proto(&params->super.super,
+                                   params->super.cfg_thresh,
+                                   params->super.cfg_priority, perf, &mpriv,
+                                   ucp_proto_multi_priv_size(&mpriv));
+        allow_short_baseline = 0;
+
+        if (!params->select_uct_num_paths ||
+            (mpriv.num_lanes > max_total_lanes)) {
+            return;
+        }
+    } while (++max_total_lanes <= UCP_PROTO_MAX_LANES);
 }
 
 static const ucp_ep_config_key_lane_t *

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -25,7 +25,7 @@
 static UCS_F_ALWAYS_INLINE double
 ucp_proto_multi_get_path_ratio(const ucp_proto_init_params_t *params,
                                const ucp_proto_common_tl_perf_t *lane_perf,
-                               uint8_t path_index)
+                               uint8_t path_index, int use_uct_num_paths)
 {
     /* Minimal path ratio */
     static const double MIN_RATIO = 0.01;
@@ -33,7 +33,12 @@ ucp_proto_multi_get_path_ratio(const ucp_proto_init_params_t *params,
             params->worker->context->config.ext.multi_path_ratio;
     double ratio;
 
-    if (UCS_CONFIG_DBL_IS_AUTO(multi_path_ratio)) {
+    if (use_uct_num_paths) {
+        ratio = ucs_min(lane_perf->path_ratio, 1.0);
+        if ((path_index > 0) && (lane_perf->num_paths > 1)) {
+            ratio = (1.0 - ratio) / (lane_perf->num_paths - 1);
+        }
+    } else if (UCS_CONFIG_DBL_IS_AUTO(multi_path_ratio)) {
         ratio = ucs_min(1.0 - (lane_perf->path_ratio * path_index),
                         lane_perf->path_ratio);
     } else {
@@ -56,12 +61,13 @@ static UCS_F_ALWAYS_INLINE double
 ucp_proto_multi_get_avail_bw(const ucp_proto_init_params_t *params,
                              ucp_lane_index_t lane,
                              const ucp_proto_common_tl_perf_t *lane_perf,
-                             const ucp_proto_lane_selection_t *selection)
+                             const ucp_proto_lane_selection_t *selection,
+                             int enforce_num_paths)
 {
     ucp_rsc_index_t dev_index = ucp_proto_common_get_dev_index(params, lane);
     uint8_t path_index        = selection->dev_count[dev_index];
     double ratio              = ucp_proto_multi_get_path_ratio(
-            params, lane_perf, path_index);
+            params, lane_perf, path_index, enforce_num_paths);
 
     ucs_trace("ratio=%0.3f path_index=%u" UCP_PROTO_BW_FMT(avail_bw)
               " " UCP_PROTO_LANE_FMT, ratio, path_index,
@@ -137,8 +143,8 @@ static ucp_lane_index_t ucp_proto_multi_find_max_avail_bw_lane(
             continue;
         }
 
-        avail_bw = ucp_proto_multi_get_avail_bw(params, lanes[index], lane_perf,
-                                                selection);
+        avail_bw = ucp_proto_multi_get_avail_bw(
+                params, lanes[index], lane_perf, selection, enforce_num_paths);
         cmp      = ucs_fp_compare(avail_bw, max_avail_bw);
         if ((cmp > 0) ||
             (enforce_num_paths && (cmp == 0) &&
@@ -602,16 +608,16 @@ ucp_proto_multi_select_lanes(const ucp_proto_multi_init_params_t *params,
         lane      = selection->lanes[i];
         lane_perf = &lanes_perf[lane];
         dev_index = ucp_proto_common_get_dev_index(&params->super.super, lane);
-        if ((!lane_perf->num_paths_fixed && (lane_perf->num_paths == 1)) ||
+        if (!params->select_uct_num_paths ||
             (selection->dev_count[dev_index] > lane_perf->num_paths)) {
             continue;
         }
 
         total_ratio = 0.0;
         for (path_index = 0;
-             path_index < selection->dev_count[dev_index]; ++path_index) {
+            path_index < selection->dev_count[dev_index]; ++path_index) {
             total_ratio += ucp_proto_multi_get_path_ratio(
-                    &params->super.super, lane_perf, path_index);
+                    &params->super.super, lane_perf, path_index, 1);
         }
 
         lane_perf->bandwidth *= ucs_min(total_ratio, 1.0) /

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -608,7 +608,7 @@ ucp_proto_multi_select_lanes(const ucp_proto_multi_init_params_t *params,
         lane      = selection->lanes[i];
         lane_perf = &lanes_perf[lane];
         dev_index = ucp_proto_common_get_dev_index(&params->super.super, lane);
-        if (!params->select_uct_num_paths ||
+        if ((!lane_perf->num_paths_fixed && (lane_perf->num_paths == 1)) ||
             (selection->dev_count[dev_index] > lane_perf->num_paths)) {
             continue;
         }

--- a/src/ucp/proto/proto_multi.c
+++ b/src/ucp/proto/proto_multi.c
@@ -23,17 +23,14 @@
 
 
 static UCS_F_ALWAYS_INLINE double
-ucp_proto_multi_get_avail_bw(const ucp_proto_init_params_t *params,
-                             ucp_lane_index_t lane,
-                             const ucp_proto_common_tl_perf_t *lane_perf,
-                             const ucp_proto_lane_selection_t *selection)
+ucp_proto_multi_get_path_ratio(const ucp_proto_init_params_t *params,
+                               const ucp_proto_common_tl_perf_t *lane_perf,
+                               uint8_t path_index)
 {
     /* Minimal path ratio */
     static const double MIN_RATIO = 0.01;
-    ucp_context_h context         = params->worker->context;
-    double multi_path_ratio       = context->config.ext.multi_path_ratio;
-    ucp_rsc_index_t dev_index     = ucp_proto_common_get_dev_index(params, lane);
-    uint8_t path_index            = selection->dev_count[dev_index];
+    double multi_path_ratio =
+            params->worker->context->config.ext.multi_path_ratio;
     double ratio;
 
     if (UCS_CONFIG_DBL_IS_AUTO(multi_path_ratio)) {
@@ -48,8 +45,23 @@ ucp_proto_multi_get_avail_bw(const ucp_proto_init_params_t *params,
          * need to assign some minimal BW to the these extra paths in order to
          * select them. We divide min ratio of the iface BW by path_index so
          * that each additional path on the same device has lower bandwidth. */
+        ucs_assert(path_index > 0);
         ratio = MIN_RATIO / path_index;
     }
+
+    return ratio;
+}
+
+static UCS_F_ALWAYS_INLINE double
+ucp_proto_multi_get_avail_bw(const ucp_proto_init_params_t *params,
+                             ucp_lane_index_t lane,
+                             const ucp_proto_common_tl_perf_t *lane_perf,
+                             const ucp_proto_lane_selection_t *selection)
+{
+    ucp_rsc_index_t dev_index = ucp_proto_common_get_dev_index(params, lane);
+    uint8_t path_index        = selection->dev_count[dev_index];
+    double ratio              = ucp_proto_multi_get_path_ratio(
+            params, lane_perf, path_index);
 
     ucs_trace("ratio=%0.3f path_index=%u" UCP_PROTO_BW_FMT(avail_bw)
               " " UCP_PROTO_LANE_FMT, ratio, path_index,
@@ -107,6 +119,7 @@ static ucp_lane_index_t ucp_proto_multi_find_max_avail_bw_lane(
     const ucp_proto_common_tl_perf_t *lane_perf;
     ucs_sys_device_t sys_dev, selected_sys_dev;
     ucp_rsc_index_t dev_index;
+    uint8_t min_dev_count = UINT8_MAX;
     unsigned seed;
     double avail_bw;
     int cmp;
@@ -127,10 +140,15 @@ static ucp_lane_index_t ucp_proto_multi_find_max_avail_bw_lane(
         avail_bw = ucp_proto_multi_get_avail_bw(params, lanes[index], lane_perf,
                                                 selection);
         cmp      = ucs_fp_compare(avail_bw, max_avail_bw);
-        if (cmp > 0) {
-            max_avail_bw = avail_bw;
-            lane_map     = UCS_BIT(index);
-        } else if (cmp == 0) {
+        if ((cmp > 0) ||
+            (enforce_num_paths && (cmp == 0) &&
+             (selection->dev_count[dev_index] < min_dev_count))) {
+            max_avail_bw  = avail_bw;
+            lane_map      = UCS_BIT(index);
+            min_dev_count = selection->dev_count[dev_index];
+        } else if ((cmp == 0) &&
+                   (!enforce_num_paths ||
+                    (selection->dev_count[dev_index] == min_dev_count))) {
             lane_map |= UCS_BIT(index);
         }
     }
@@ -527,9 +545,9 @@ ucp_proto_multi_select_lanes(const ucp_proto_multi_init_params_t *params,
     ucp_lane_index_t i, lane, lane_index, max_total_lanes;
     ucp_rsc_index_t dev_index;
     ucp_lane_map_t index_map;
-    unsigned req_sys_dev_ord;
+    unsigned path_index, req_sys_dev_ord;
     int num_paths_fixed;
-    double path_ratio, total_ratio;
+    double total_ratio;
 
     req_sys_dev_ord = ucs_topo_sys_device_get_bdf_class_ordinal(
             params->super.super.select_param->sys_dev);
@@ -540,7 +558,8 @@ ucp_proto_multi_select_lanes(const ucp_proto_multi_init_params_t *params,
 
     ucp_proto_multi_select_bw_lanes(
             &params->super.super, lanes, num_lanes, params->max_lanes,
-            lanes_perf, fixed_first_lane, req_sys_dev_ord, selection);
+            lanes_perf, fixed_first_lane, req_sys_dev_ord,
+            params->select_uct_num_paths, selection);
 
     if (params->select_uct_num_paths) {
         num_paths_fixed = 0;
@@ -588,13 +607,13 @@ ucp_proto_multi_select_lanes(const ucp_proto_multi_init_params_t *params,
             continue;
         }
 
-        /* Preserve the calibrated first-path bandwidth and distribute the
-         * residual interface bandwidth among additional paths. */
-        path_ratio  = ucs_min(lane_perf->path_ratio, 1.0);
-        total_ratio = (lane_perf->num_paths == 1) ? path_ratio :
-                path_ratio + ((selection->dev_count[dev_index] - 1) *
-                              (1.0 - path_ratio) /
-                              (lane_perf->num_paths - 1));
+        total_ratio = 0.0;
+        for (path_index = 0;
+             path_index < selection->dev_count[dev_index]; ++path_index) {
+            total_ratio += ucp_proto_multi_get_path_ratio(
+                    &params->super.super, lane_perf, path_index);
+        }
+
         lane_perf->bandwidth *= ucs_min(total_ratio, 1.0) /
                                 selection->dev_count[dev_index];
     }

--- a/src/ucp/proto/proto_multi.h
+++ b/src/ucp/proto/proto_multi.h
@@ -119,6 +119,12 @@ typedef struct {
     /* Maximal number of lanes to select */
     ucp_lane_index_t               max_lanes;
 
+    /* Select the lane count according to the transport path recommendation */
+    int                            select_uct_num_paths;
+
+    /* Maximal total lane count for the current automatic candidate */
+    ucp_lane_index_t               max_total_lanes;
+
     /* Minimal chunk size. It defines the minimal size of the fragment to split into
      * several parts. The goal is to not split below this limit */
     size_t                         min_chunk;

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -220,6 +220,8 @@ ucp_proto_get_offload_zcopy_probe(const ucp_proto_init_params_t *init_params)
         .super.reg_mem_info  = ucp_proto_common_select_param_mem_info(
                                                      init_params->select_param),
         .max_lanes              = context->config.ext.max_rma_lanes,
+        .select_uct_num_paths   = context->config.ext.max_rma_lanes_config ==
+                                  UCS_ULUNITS_AUTO,
         .min_chunk              = context->config.ext.min_rma_chunk_size,
         .single_lane_min_length = 1,
         .initial_reg_md_map     = 0,

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -49,6 +49,8 @@ ucp_proto_rndv_get_common_probe(const ucp_proto_init_params_t *init_params,
         .super.exclude_map   = 0,
         .super.reg_mem_info  = *reg_mem_info,
         .max_lanes           = context->config.ext.max_rndv_lanes,
+        .select_uct_num_paths = context->config.ext.max_rndv_lanes_config ==
+                                UCS_ULUNITS_AUTO,
         .min_chunk           = context->config.ext.min_rndv_chunk_size,
         .initial_reg_md_map  = initial_reg_md_map,
         .first.tl_cap_flags  = UCT_IFACE_FLAG_GET_ZCOPY,
@@ -58,6 +60,8 @@ ucp_proto_rndv_get_common_probe(const ucp_proto_init_params_t *init_params,
         .opt_align_offs      = ucs_offsetof(uct_iface_attr_t,
                                             cap.get.opt_zcopy_align),
     };
+    ucp_lane_index_t max_total_lanes = params.max_lanes;
+    int allow_short_baseline         = 1;
     ucp_proto_rndv_bulk_priv_t rpriv;
     ucp_proto_perf_t *perf;
     ucs_status_t status;
@@ -67,16 +71,35 @@ ucp_proto_rndv_get_common_probe(const ucp_proto_init_params_t *init_params,
         return;
     }
 
-    status = ucp_proto_rndv_bulk_init(&params, UCP_PROTO_RNDV_GET_DESC,
-                                      UCP_PROTO_RNDV_ATS_NAME, &perf, &rpriv);
-    if (status != UCS_OK) {
-        return;
-    }
+    do {
+        params.max_total_lanes = max_total_lanes;
+        status = ucp_proto_rndv_bulk_init(&params, UCP_PROTO_RNDV_GET_DESC,
+                                          UCP_PROTO_RNDV_ATS_NAME, &perf,
+                                          &rpriv);
+        if (status != UCS_OK) {
+            return;
+        }
 
-    ucp_proto_select_add_proto(&params.super.super, params.super.cfg_thresh,
-                               params.super.cfg_priority, perf, &rpriv,
-                               UCP_PROTO_MULTI_EXTENDED_PRIV_SIZE(&rpriv,
-                                                                  mpriv));
+        if (params.select_uct_num_paths &&
+            (rpriv.mpriv.num_lanes < max_total_lanes)) {
+            if (!allow_short_baseline) {
+                ucp_proto_perf_destroy(perf);
+                return;
+            }
+            max_total_lanes = rpriv.mpriv.num_lanes;
+        }
+
+        ucp_proto_select_add_proto(
+                &params.super.super, params.super.cfg_thresh,
+                params.super.cfg_priority, perf, &rpriv,
+                UCP_PROTO_MULTI_EXTENDED_PRIV_SIZE(&rpriv, mpriv));
+        allow_short_baseline = 0;
+
+        if (!params.select_uct_num_paths ||
+            (rpriv.mpriv.num_lanes > max_total_lanes)) {
+            return;
+        }
+    } while (++max_total_lanes <= UCP_PROTO_MAX_LANES);
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -100,7 +100,10 @@ enum uct_perf_attr_field {
     UCT_PERF_ATTR_FIELD_MAX_INFLIGHT_EPS   = UCS_BIT(11),
 
     /** Enable @ref uct_perf_attr_t::flags */
-    UCT_PERF_ATTR_FIELD_FLAGS              = UCS_BIT(12)
+    UCT_PERF_ATTR_FIELD_FLAGS              = UCS_BIT(12),
+
+    /** Enable @ref uct_perf_attr_t::num_paths */
+    UCT_PERF_ATTR_FIELD_NUM_PATHS          = UCS_BIT(13)
 };
 
 /**
@@ -111,7 +114,10 @@ enum uct_perf_attr_field {
  */
 typedef enum {
     /** TX operations can depend on unrelated RX operation completion */
-    UCT_PERF_ATTR_FLAGS_TX_RX_SHARED = UCS_BIT(0)
+    UCT_PERF_ATTR_FLAGS_TX_RX_SHARED = UCS_BIT(0),
+
+    /** Number of paths was set by explicit transport configuration */
+    UCT_PERF_ATTR_FLAGS_NUM_PATHS_FIXED = UCS_BIT(1)
 } uct_perf_attr_flags_t;
 
 /**
@@ -217,6 +223,14 @@ typedef struct {
      * Performance characteristics of the network interface.
      */
     uint64_t            flags;
+
+    /**
+     * Recommended number of interface paths for the requested operation. This
+     * value does not exceed @ref uct_iface_attr_t::dev_num_paths. An explicit
+     * transport path configuration may override the automatic recommendation.
+     * This field is set by the UCT layer.
+     */
+    unsigned            num_paths;
 } uct_perf_attr_t;
 
 

--- a/src/uct/base/uct_iface.c
+++ b/src/uct/base/uct_iface.c
@@ -209,6 +209,14 @@ uct_iface_estimate_perf(uct_iface_h tl_iface, uct_perf_attr_t *perf_attr)
 {
     uct_base_iface_t *iface = ucs_derived_of(tl_iface, uct_base_iface_t);
 
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_NUM_PATHS) {
+        perf_attr->num_paths = 1;
+    }
+
+    if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_FLAGS) {
+        perf_attr->flags = 0;
+    }
+
     return iface->internal_ops->iface_estimate_perf(tl_iface, perf_attr);
 }
 

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -13,6 +13,7 @@ extern "C" {
 #include <uct/base/uct_iface.h>
 #include <ucp/proto/proto_debug.h>
 #include <ucp/proto/proto_select.inl>
+#include <ucp/rndv/proto_rndv.h>
 #include <ucs/memory/numa.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/topo/base/topo.h>
@@ -22,6 +23,8 @@ extern "C" {
 #include <uct/ib/base/ib_md.h>
 #endif
 }
+
+#include <cstring>
 
 class mock_iface {
 public:
@@ -230,13 +233,37 @@ private:
 
     static ucs_status_t perf_mock(uct_iface_h iface, uct_perf_attr_t *perf_attr)
     {
-        uct_base_iface_t *base = ucs_derived_of(iface, uct_base_iface_t);
+        uct_base_iface_t *base        = ucs_derived_of(iface, uct_base_iface_t);
+        uct_perf_attr_t put_perf_attr = {};
         uct_iface_attr_t iface_attr;
         ucs_status_t status;
 
         UCS_MOCK_ORIG_FUNC(m_self->m_mock,
                            &base->internal_ops->iface_estimate_perf, iface,
                            perf_attr);
+
+        if (ucs_test_all_flags(perf_attr->field_mask,
+                               UCT_PERF_ATTR_FIELD_OPERATION |
+                               UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD) &&
+            (std::strcmp(m_self->m_tl->name, "rc_mlx5") == 0) &&
+            (perf_attr->operation == UCT_EP_OP_GET_ZCOPY)) {
+            put_perf_attr.field_mask = UCT_PERF_ATTR_FIELD_OPERATION |
+                                       UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD;
+            put_perf_attr.operation  = UCT_EP_OP_PUT_ZCOPY;
+            UCS_MOCK_ORIG_FUNC(
+                    m_self->m_mock,
+                    &base->internal_ops->iface_estimate_perf, iface,
+                    &put_perf_attr);
+            perf_attr->send_pre_overhead = put_perf_attr.send_pre_overhead;
+        }
+
+        if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_NUM_PATHS) {
+            perf_attr->num_paths = 1;
+        }
+
+        if (perf_attr->field_mask & UCT_PERF_ATTR_FIELD_FLAGS) {
+            perf_attr->flags &= ~UCT_PERF_ATTR_FLAGS_NUM_PATHS_FIXED;
+        }
 
         if (perf_attr->field_mask & (UCT_PERF_ATTR_FIELD_BANDWIDTH |
                                      UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH)) {
@@ -460,6 +487,39 @@ protected:
         }
 
         return proto_select_data();
+    }
+
+    static const ucp_proto_select_elem_t *
+    lookup_proto_select_elem(const entity &e, ucp_proto_select_t *proto_select,
+                             ucp_worker_cfg_index_t rkey_cfg_index,
+                             ucp_operation_id_t op_id)
+    {
+        ucp_proto_select_param_t select_param;
+        ucp_memory_info_t mem_info;
+
+        ucp_memory_info_set_host(&mem_info);
+        ucp_proto_select_param_init(&select_param, op_id, 0, 0,
+                                    UCP_DATATYPE_CONTIG, &mem_info, 1);
+        return ucp_proto_select_lookup_slow(
+                e.worker(), proto_select, 0, ep_config_index(e),
+                rkey_cfg_index, &select_param);
+    }
+
+    static unsigned
+    get_selected_path_count(const entity &e,
+                            const ucp_proto_select_elem_t *select_elem,
+                            size_t msg_length)
+    {
+        ucp_proto_query_attr_t attr = {};
+
+        EXPECT_NE(nullptr, select_elem);
+        if ((select_elem == nullptr) ||
+            !ucp_proto_select_elem_query(e.worker(), select_elem, msg_length,
+                                         &attr)) {
+            return 0;
+        }
+
+        return ucs_popcount(attr.lane_map);
     }
 
     static void dump_select_info(const entity &e,
@@ -868,6 +928,170 @@ UCS_TEST_P(test_ucp_proto_mock_rcx, rma_put_2_lanes,
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx, rcx, "rc_x")
+
+class test_ucp_proto_mock_rcx_op_paths : public test_ucp_proto_mock {
+public:
+    test_ucp_proto_mock_rcx_op_paths()
+    {
+        mock_transport("rc_mlx5");
+    }
+
+    virtual void init() override
+    {
+        iface_attr_func_t iface_attr_func = [](uct_iface_attr_t &iface_attr) {
+            iface_attr.cap.am.max_short  = 208;
+            iface_attr.cap.put.max_short = 2048;
+            iface_attr.cap.get.max_zcopy = UCS_MBYTE;
+            iface_attr.bandwidth.shared  = 92e9;
+            iface_attr.latency.c         = 500e-9;
+            iface_attr.latency.m         = 1e-9;
+            iface_attr.dev_num_paths     = 4;
+        };
+        perf_attr_func_t perf_attr_func = [](uct_perf_attr_t &perf_attr) {
+            if (perf_attr.field_mask & UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH) {
+                perf_attr.path_bandwidth.shared = 0.4 * 92e9;
+            }
+
+            if (ucs_test_all_flags(perf_attr.field_mask,
+                                   UCT_PERF_ATTR_FIELD_OPERATION |
+                                   UCT_PERF_ATTR_FIELD_SEND_PRE_OVERHEAD) &&
+                (perf_attr.operation == UCT_EP_OP_GET_ZCOPY)) {
+                perf_attr.send_pre_overhead += 375e-9;
+            }
+
+            if (perf_attr.field_mask & UCT_PERF_ATTR_FIELD_NUM_PATHS) {
+                perf_attr.num_paths =
+                        uct_ep_op_is_get(perf_attr.operation) ? 4 : 1;
+            }
+        };
+        iface_attr_func_t fixed_paths_iface_attr_func =
+                [iface_attr_func](uct_iface_attr_t &iface_attr) {
+                    iface_attr_func(iface_attr);
+                    iface_attr.dev_num_paths = 2;
+                };
+        iface_attr_func_t single_path_iface_attr_func =
+                [iface_attr_func](uct_iface_attr_t &iface_attr) {
+                    iface_attr_func(iface_attr);
+                    iface_attr.dev_num_paths = 1;
+                };
+        perf_attr_func_t fixed_paths_perf_attr_func =
+                [](uct_perf_attr_t &perf_attr) {
+                    if (perf_attr.field_mask & UCT_PERF_ATTR_FIELD_NUM_PATHS) {
+                        perf_attr.num_paths =
+                                uct_ep_op_is_get(perf_attr.operation) ? 2 : 1;
+                    }
+
+                    if ((perf_attr.field_mask & UCT_PERF_ATTR_FIELD_FLAGS) &&
+                        uct_ep_op_is_get(perf_attr.operation)) {
+                        perf_attr.flags |=
+                                UCT_PERF_ATTR_FLAGS_NUM_PATHS_FIXED;
+                    }
+                };
+        add_mock_iface("mock_0:1", iface_attr_func, perf_attr_func);
+        add_mock_iface("mock_1:1", fixed_paths_iface_attr_func,
+                       fixed_paths_perf_attr_func);
+        add_mock_iface("mock_2:1", single_path_iface_attr_func);
+        test_ucp_proto_mock::init();
+    }
+
+protected:
+    unsigned get_rndv_path_count(size_t msg_length)
+    {
+        const ucp_proto_threshold_elem_t *thresh;
+        const ucp_proto_rndv_ctrl_priv_t *rpriv;
+        const ucp_proto_select_elem_t *select_elem;
+        ucp_ep_config_t *config;
+        ucp_proto_query_attr_t attr = {};
+
+        send_recv_am(UCS_MBYTE);
+
+        config = ucp_worker_ep_config(sender().worker(),
+                                      ep_config_index(sender()));
+        select_elem = lookup_proto_select_elem(
+                sender(), &config->proto_select, UCP_WORKER_CFG_INDEX_NULL,
+                UCP_OP_ID_AM_SEND);
+        EXPECT_NE(nullptr, select_elem);
+        if (select_elem == nullptr) {
+            return 0;
+        }
+
+        thresh = ucp_proto_thresholds_search_slow(select_elem->thresholds,
+                                                  msg_length);
+        EXPECT_STREQ("am/rndv", thresh->proto_config.proto->name);
+        if (std::strcmp("am/rndv", thresh->proto_config.proto->name) != 0) {
+            return 0;
+        }
+
+        rpriv = static_cast<const ucp_proto_rndv_ctrl_priv_t *>(
+                thresh->proto_config.priv);
+        EXPECT_STREQ("rndv/get/zcopy", rpriv->remote_proto_config.proto->name);
+        if (std::strcmp("rndv/get/zcopy",
+                        rpriv->remote_proto_config.proto->name) != 0) {
+            return 0;
+        }
+
+        ucp_proto_config_query(sender().worker(), &rpriv->remote_proto_config,
+                               msg_length, &attr);
+        return ucs_popcount(attr.lane_map);
+    }
+
+    unsigned get_rma_path_count(ucp_operation_id_t op_id, size_t msg_length)
+    {
+        const ucp_worker_cfg_index_t rkey_cfg_index =
+                send_recv_rma(UCS_MBYTE, op_id);
+
+        ucp_rkey_config_t *config = &ucs_array_elem(
+                &sender().worker()->rkey_config, rkey_cfg_index);
+        return get_selected_path_count(
+                sender(), lookup_proto_select_elem(
+                                  sender(), &config->proto_select,
+                                  rkey_cfg_index, op_id),
+                msg_length);
+    }
+};
+
+UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_auto_path_selection,
+           "NET_DEVICES=^mock_1:1,mock_2:1", "MAX_RMA_RAILS=auto",
+           "MAX_RNDV_RAILS=auto",
+           "RNDV_SCHEME=get_zcopy", "RNDV_THRESH=0", "ZCOPY_THRESH=0")
+{
+    EXPECT_EQ(1u, get_rma_path_count(UCP_OP_ID_GET, 32 * UCS_KBYTE));
+    EXPECT_EQ(2u, get_rma_path_count(UCP_OP_ID_GET, 64 * UCS_KBYTE));
+    EXPECT_EQ(2u, get_rma_path_count(UCP_OP_ID_GET, 96 * UCS_KBYTE));
+    EXPECT_EQ(3u, get_rma_path_count(UCP_OP_ID_GET, 128 * UCS_KBYTE));
+    EXPECT_EQ(4u, get_rma_path_count(UCP_OP_ID_GET, 256 * UCS_KBYTE));
+    EXPECT_EQ(4u, get_rndv_path_count(UCS_MBYTE));
+    EXPECT_EQ(1u, get_rma_path_count(UCP_OP_ID_PUT, UCS_MBYTE));
+}
+
+UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_fixed_ib_num_paths,
+           "NET_DEVICES=^mock_0:1,mock_2:1", "MAX_RMA_RAILS=auto",
+           "MAX_RNDV_RAILS=auto",
+           "RNDV_SCHEME=get_zcopy", "RNDV_THRESH=0", "ZCOPY_THRESH=0")
+{
+    EXPECT_EQ(2u, get_rma_path_count(UCP_OP_ID_GET, 64 * UCS_KBYTE));
+    EXPECT_EQ(2u, get_rndv_path_count(64 * UCS_KBYTE));
+}
+
+UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_explicit_ucp_path_caps,
+           "NET_DEVICES=^mock_1:1,mock_2:1", "MAX_RMA_RAILS=2",
+           "MAX_RNDV_LANES=2",
+           "RNDV_SCHEME=get_zcopy", "RNDV_THRESH=0", "ZCOPY_THRESH=0")
+{
+    EXPECT_EQ(2u, get_rma_path_count(UCP_OP_ID_GET, UCS_MBYTE));
+    EXPECT_EQ(2u, get_rndv_path_count(UCS_MBYTE));
+}
+
+UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_single_path_fallback,
+           "NET_DEVICES=^mock_0:1,mock_1:1", "MAX_RMA_RAILS=auto",
+           "MAX_RNDV_RAILS=auto", "RNDV_SCHEME=get_zcopy",
+           "RNDV_THRESH=0", "ZCOPY_THRESH=0")
+{
+    EXPECT_EQ(1u, get_rma_path_count(UCP_OP_ID_GET, UCS_MBYTE));
+    EXPECT_EQ(1u, get_rndv_path_count(UCS_MBYTE));
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx_op_paths, rcx, "rc_x")
 
 class test_ucp_proto_mock_rcx2 : public test_ucp_proto_mock {
 public:

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -519,7 +519,46 @@ protected:
             return 0;
         }
 
-        return ucs_popcount(attr.lane_map);
+        return attr.lane_map;
+    }
+
+    static unsigned
+    get_selected_path_count(const entity &e,
+                            const ucp_proto_select_elem_t *select_elem,
+                            size_t msg_length)
+    {
+        return ucs_popcount(
+                get_selected_lane_map(e, select_elem, msg_length));
+    }
+
+    static unsigned
+    get_lane_map_device_count(const entity &e, ucp_lane_map_t lane_map)
+    {
+        uint8_t dev_count[UCP_MAX_RESOURCES] = {};
+        ucp_ep_config_t *config              = ucp_worker_ep_config(
+                e.worker(), ep_config_index(e));
+        unsigned count                       = 0;
+        ucp_rsc_index_t dev_index, rsc_index;
+        ucp_lane_index_t lane;
+
+        ucs_for_each_bit(lane, lane_map) {
+            rsc_index = config->key.lanes[lane].rsc_index;
+            dev_index = e.worker()->context->tl_rscs[rsc_index].dev_index;
+            if (dev_count[dev_index]++ == 0) {
+                ++count;
+            }
+        }
+
+        return count;
+    }
+
+    static unsigned
+    get_selected_device_count(const entity &e,
+                              const ucp_proto_select_elem_t *select_elem,
+                              size_t msg_length)
+    {
+        return get_lane_map_device_count(
+                e, get_selected_lane_map(e, select_elem, msg_length));
     }
 
     static void dump_select_info(const entity &e,
@@ -987,15 +1026,33 @@ public:
                                 UCT_PERF_ATTR_FLAGS_NUM_PATHS_FIXED;
                     }
                 };
+        perf_attr_func_t single_get_path_perf_attr_func =
+                [perf_attr_func](uct_perf_attr_t &perf_attr) {
+                    perf_attr_func(perf_attr);
+                    if (perf_attr.field_mask &
+                        UCT_PERF_ATTR_FIELD_NUM_PATHS) {
+                        perf_attr.num_paths = 1;
+                    }
+                };
         add_mock_iface("mock_0:1", iface_attr_func, perf_attr_func);
         add_mock_iface("mock_1:1", fixed_paths_iface_attr_func,
                        fixed_paths_perf_attr_func);
         add_mock_iface("mock_2:1", single_path_iface_attr_func);
+        add_mock_iface("mock_3:1", iface_attr_func, perf_attr_func);
+        add_mock_iface("mock_4:1", iface_attr_func, perf_attr_func);
+        add_mock_iface("mock_5:1", iface_attr_func, perf_attr_func);
+        add_mock_iface("mock_6:1", single_path_iface_attr_func);
+        add_mock_iface("mock_7:1", fixed_paths_iface_attr_func,
+                       fixed_paths_perf_attr_func);
+        add_mock_iface("mock_8:1", iface_attr_func,
+                       single_get_path_perf_attr_func);
+        add_mock_iface("mock_9:1", iface_attr_func,
+                       single_get_path_perf_attr_func);
         test_ucp_proto_mock::init();
     }
 
 protected:
-    unsigned get_rndv_path_count(size_t msg_length)
+    ucp_lane_map_t get_rndv_lane_map(size_t msg_length)
     {
         const ucp_proto_threshold_elem_t *thresh;
         const ucp_proto_rndv_ctrl_priv_t *rpriv;
@@ -1032,7 +1089,18 @@ protected:
 
         ucp_proto_config_query(sender().worker(), &rpriv->remote_proto_config,
                                msg_length, &attr);
-        return ucs_popcount(attr.lane_map);
+        return attr.lane_map;
+    }
+
+    unsigned get_rndv_path_count(size_t msg_length)
+    {
+        return ucs_popcount(get_rndv_lane_map(msg_length));
+    }
+
+    unsigned get_rndv_device_count(size_t msg_length)
+    {
+        return get_lane_map_device_count(sender(),
+                                         get_rndv_lane_map(msg_length));
     }
 
     unsigned get_rma_path_count(ucp_operation_id_t op_id, size_t msg_length)
@@ -1064,12 +1132,26 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_auto_path_selection,
     EXPECT_EQ(1u, get_rma_path_count(UCP_OP_ID_PUT, UCS_MBYTE));
 }
 
+UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_auto_multi_device_selection,
+           "NET_DEVICES=mock_0:1,mock_3:1,mock_4:1,mock_5:1",
+           "MAX_RMA_RAILS=auto", "MAX_RNDV_RAILS=auto",
+           "RNDV_SCHEME=get_zcopy", "RNDV_THRESH=0", "ZCOPY_THRESH=0")
+{
+    EXPECT_EQ(4u, get_rma_path_count(UCP_OP_ID_GET, 256 * UCS_KBYTE));
+    EXPECT_EQ(4u, get_rma_device_count(UCP_OP_ID_GET, 256 * UCS_KBYTE));
+    EXPECT_EQ(8u, get_rma_path_count(UCP_OP_ID_GET, UCS_MBYTE));
+    EXPECT_EQ(4u, get_rma_device_count(UCP_OP_ID_GET, UCS_MBYTE));
+    EXPECT_EQ(8u, get_rndv_path_count(UCS_MBYTE));
+    EXPECT_EQ(4u, get_rndv_device_count(UCS_MBYTE));
+}
+
 UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_fixed_ib_num_paths,
-           "NET_DEVICES=^mock_0:1,mock_2:1", "MAX_RMA_RAILS=auto",
+           "NET_DEVICES=mock_1:1,mock_7:1", "MAX_RMA_RAILS=auto",
            "MAX_RNDV_RAILS=auto",
            "RNDV_SCHEME=get_zcopy", "RNDV_THRESH=0", "ZCOPY_THRESH=0")
 {
     EXPECT_EQ(2u, get_rma_path_count(UCP_OP_ID_GET, 64 * UCS_KBYTE));
+    EXPECT_EQ(1u, get_rma_device_count(UCP_OP_ID_GET, 64 * UCS_KBYTE));
     EXPECT_EQ(2u, get_rndv_path_count(64 * UCS_KBYTE));
 }
 
@@ -1089,6 +1171,26 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_single_path_fallback,
 {
     EXPECT_EQ(1u, get_rma_path_count(UCP_OP_ID_GET, UCS_MBYTE));
     EXPECT_EQ(1u, get_rndv_path_count(UCS_MBYTE));
+}
+
+UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths,
+           get_multi_device_single_path_fallback,
+           "NET_DEVICES=mock_2:1,mock_6:1", "MAX_RMA_RAILS=auto",
+           "MAX_RNDV_RAILS=auto", "ZCOPY_THRESH=0")
+{
+    EXPECT_EQ(1u, get_rma_path_count(UCP_OP_ID_GET, UCS_MBYTE));
+    EXPECT_EQ(1u, get_rma_device_count(UCP_OP_ID_GET, UCS_MBYTE));
+}
+
+UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_auto_single_path_device_caps,
+           "NET_DEVICES=mock_8:1,mock_9:1", "MAX_RMA_RAILS=auto",
+           "MAX_RNDV_RAILS=auto", "RNDV_SCHEME=get_zcopy",
+           "RNDV_THRESH=0", "ZCOPY_THRESH=0")
+{
+    EXPECT_EQ(1u, get_rma_path_count(UCP_OP_ID_GET, UCS_MBYTE));
+    EXPECT_EQ(1u, get_rma_device_count(UCP_OP_ID_GET, UCS_MBYTE));
+    EXPECT_EQ(2u, get_rndv_path_count(UCS_MBYTE));
+    EXPECT_EQ(2u, get_rndv_device_count(UCS_MBYTE));
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx_op_paths, rcx, "rc_x")

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -1013,6 +1013,11 @@ public:
                     iface_attr_func(iface_attr);
                     iface_attr.dev_num_paths = 1;
                 };
+        iface_attr_func_t low_bandwidth_iface_attr_func =
+                [iface_attr_func](uct_iface_attr_t &iface_attr) {
+                    iface_attr_func(iface_attr);
+                    iface_attr.bandwidth.shared = 20e9;
+                };
         perf_attr_func_t fixed_paths_perf_attr_func =
                 [](uct_perf_attr_t &perf_attr) {
                     if (perf_attr.field_mask & UCT_PERF_ATTR_FIELD_NUM_PATHS) {
@@ -1034,6 +1039,14 @@ public:
                         perf_attr.num_paths = 1;
                     }
                 };
+        perf_attr_func_t low_single_get_path_perf_attr_func =
+                [single_get_path_perf_attr_func](uct_perf_attr_t &perf_attr) {
+                    single_get_path_perf_attr_func(perf_attr);
+                    if (perf_attr.field_mask &
+                        UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH) {
+                        perf_attr.path_bandwidth.shared = 20e9;
+                    }
+                };
         add_mock_iface("mock_0:1", iface_attr_func, perf_attr_func);
         add_mock_iface("mock_1:1", fixed_paths_iface_attr_func,
                        fixed_paths_perf_attr_func);
@@ -1046,8 +1059,8 @@ public:
                        fixed_paths_perf_attr_func);
         add_mock_iface("mock_8:1", iface_attr_func,
                        single_get_path_perf_attr_func);
-        add_mock_iface("mock_9:1", iface_attr_func,
-                       single_get_path_perf_attr_func);
+        add_mock_iface("mock_9:1", low_bandwidth_iface_attr_func,
+                       low_single_get_path_perf_attr_func);
         test_ucp_proto_mock::init();
     }
 
@@ -1152,7 +1165,8 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_fixed_ib_num_paths,
 {
     EXPECT_EQ(2u, get_rma_path_count(UCP_OP_ID_GET, 64 * UCS_KBYTE));
     EXPECT_EQ(1u, get_rma_device_count(UCP_OP_ID_GET, 64 * UCS_KBYTE));
-    EXPECT_EQ(2u, get_rndv_path_count(64 * UCS_KBYTE));
+    EXPECT_EQ(4u, get_rndv_path_count(64 * UCS_KBYTE));
+    EXPECT_EQ(2u, get_rndv_device_count(64 * UCS_KBYTE));
 }
 
 UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_explicit_ucp_path_caps,

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -519,46 +519,7 @@ protected:
             return 0;
         }
 
-        return attr.lane_map;
-    }
-
-    static unsigned
-    get_selected_path_count(const entity &e,
-                            const ucp_proto_select_elem_t *select_elem,
-                            size_t msg_length)
-    {
-        return ucs_popcount(
-                get_selected_lane_map(e, select_elem, msg_length));
-    }
-
-    static unsigned
-    get_lane_map_device_count(const entity &e, ucp_lane_map_t lane_map)
-    {
-        uint8_t dev_count[UCP_MAX_RESOURCES] = {};
-        ucp_ep_config_t *config              = ucp_worker_ep_config(
-                e.worker(), ep_config_index(e));
-        unsigned count                       = 0;
-        ucp_rsc_index_t dev_index, rsc_index;
-        ucp_lane_index_t lane;
-
-        ucs_for_each_bit(lane, lane_map) {
-            rsc_index = config->key.lanes[lane].rsc_index;
-            dev_index = e.worker()->context->tl_rscs[rsc_index].dev_index;
-            if (dev_count[dev_index]++ == 0) {
-                ++count;
-            }
-        }
-
-        return count;
-    }
-
-    static unsigned
-    get_selected_device_count(const entity &e,
-                              const ucp_proto_select_elem_t *select_elem,
-                              size_t msg_length)
-    {
-        return get_lane_map_device_count(
-                e, get_selected_lane_map(e, select_elem, msg_length));
+        return ucs_popcount(attr.lane_map);
     }
 
     static void dump_select_info(const entity &e,
@@ -1013,11 +974,6 @@ public:
                     iface_attr_func(iface_attr);
                     iface_attr.dev_num_paths = 1;
                 };
-        iface_attr_func_t low_bandwidth_iface_attr_func =
-                [iface_attr_func](uct_iface_attr_t &iface_attr) {
-                    iface_attr_func(iface_attr);
-                    iface_attr.bandwidth.shared = 20e9;
-                };
         perf_attr_func_t fixed_paths_perf_attr_func =
                 [](uct_perf_attr_t &perf_attr) {
                     if (perf_attr.field_mask & UCT_PERF_ATTR_FIELD_NUM_PATHS) {
@@ -1031,41 +987,15 @@ public:
                                 UCT_PERF_ATTR_FLAGS_NUM_PATHS_FIXED;
                     }
                 };
-        perf_attr_func_t single_get_path_perf_attr_func =
-                [perf_attr_func](uct_perf_attr_t &perf_attr) {
-                    perf_attr_func(perf_attr);
-                    if (perf_attr.field_mask &
-                        UCT_PERF_ATTR_FIELD_NUM_PATHS) {
-                        perf_attr.num_paths = 1;
-                    }
-                };
-        perf_attr_func_t low_single_get_path_perf_attr_func =
-                [single_get_path_perf_attr_func](uct_perf_attr_t &perf_attr) {
-                    single_get_path_perf_attr_func(perf_attr);
-                    if (perf_attr.field_mask &
-                        UCT_PERF_ATTR_FIELD_PATH_BANDWIDTH) {
-                        perf_attr.path_bandwidth.shared = 20e9;
-                    }
-                };
         add_mock_iface("mock_0:1", iface_attr_func, perf_attr_func);
         add_mock_iface("mock_1:1", fixed_paths_iface_attr_func,
                        fixed_paths_perf_attr_func);
         add_mock_iface("mock_2:1", single_path_iface_attr_func);
-        add_mock_iface("mock_3:1", iface_attr_func, perf_attr_func);
-        add_mock_iface("mock_4:1", iface_attr_func, perf_attr_func);
-        add_mock_iface("mock_5:1", iface_attr_func, perf_attr_func);
-        add_mock_iface("mock_6:1", single_path_iface_attr_func);
-        add_mock_iface("mock_7:1", fixed_paths_iface_attr_func,
-                       fixed_paths_perf_attr_func);
-        add_mock_iface("mock_8:1", iface_attr_func,
-                       single_get_path_perf_attr_func);
-        add_mock_iface("mock_9:1", low_bandwidth_iface_attr_func,
-                       low_single_get_path_perf_attr_func);
         test_ucp_proto_mock::init();
     }
 
 protected:
-    ucp_lane_map_t get_rndv_lane_map(size_t msg_length)
+    unsigned get_rndv_path_count(size_t msg_length)
     {
         const ucp_proto_threshold_elem_t *thresh;
         const ucp_proto_rndv_ctrl_priv_t *rpriv;
@@ -1102,18 +1032,7 @@ protected:
 
         ucp_proto_config_query(sender().worker(), &rpriv->remote_proto_config,
                                msg_length, &attr);
-        return attr.lane_map;
-    }
-
-    unsigned get_rndv_path_count(size_t msg_length)
-    {
-        return ucs_popcount(get_rndv_lane_map(msg_length));
-    }
-
-    unsigned get_rndv_device_count(size_t msg_length)
-    {
-        return get_lane_map_device_count(sender(),
-                                         get_rndv_lane_map(msg_length));
+        return ucs_popcount(attr.lane_map);
     }
 
     unsigned get_rma_path_count(ucp_operation_id_t op_id, size_t msg_length)
@@ -1145,66 +1064,13 @@ UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_auto_path_selection,
     EXPECT_EQ(1u, get_rma_path_count(UCP_OP_ID_PUT, UCS_MBYTE));
 }
 
-UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_auto_multi_device_selection,
-           "NET_DEVICES=mock_0:1,mock_3:1,mock_4:1,mock_5:1",
-           "MAX_RMA_RAILS=auto", "MAX_RNDV_RAILS=auto",
-           "RNDV_SCHEME=get_zcopy", "RNDV_THRESH=0", "ZCOPY_THRESH=0")
-{
-    EXPECT_EQ(4u, get_rma_path_count(UCP_OP_ID_GET, 256 * UCS_KBYTE));
-    EXPECT_EQ(4u, get_rma_device_count(UCP_OP_ID_GET, 256 * UCS_KBYTE));
-    EXPECT_EQ(8u, get_rma_path_count(UCP_OP_ID_GET, UCS_MBYTE));
-    EXPECT_EQ(4u, get_rma_device_count(UCP_OP_ID_GET, UCS_MBYTE));
-    EXPECT_EQ(8u, get_rndv_path_count(UCS_MBYTE));
-    EXPECT_EQ(4u, get_rndv_device_count(UCS_MBYTE));
-}
-
 UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_fixed_ib_num_paths,
-           "NET_DEVICES=mock_1:1,mock_7:1", "MAX_RMA_RAILS=auto",
+           "NET_DEVICES=^mock_0:1,mock_2:1", "MAX_RMA_RAILS=auto",
            "MAX_RNDV_RAILS=auto",
            "RNDV_SCHEME=get_zcopy", "RNDV_THRESH=0", "ZCOPY_THRESH=0")
 {
     EXPECT_EQ(2u, get_rma_path_count(UCP_OP_ID_GET, 64 * UCS_KBYTE));
-    EXPECT_EQ(1u, get_rma_device_count(UCP_OP_ID_GET, 64 * UCS_KBYTE));
-    EXPECT_EQ(4u, get_rndv_path_count(64 * UCS_KBYTE));
-    EXPECT_EQ(2u, get_rndv_device_count(64 * UCS_KBYTE));
-}
-
-UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_explicit_ucp_path_caps,
-           "NET_DEVICES=^mock_1:1,mock_2:1", "MAX_RMA_RAILS=2",
-           "MAX_RNDV_LANES=2",
-           "RNDV_SCHEME=get_zcopy", "RNDV_THRESH=0", "ZCOPY_THRESH=0")
-{
-    EXPECT_EQ(2u, get_rma_path_count(UCP_OP_ID_GET, UCS_MBYTE));
-    EXPECT_EQ(2u, get_rndv_path_count(UCS_MBYTE));
-}
-
-UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_single_path_fallback,
-           "NET_DEVICES=^mock_0:1,mock_1:1", "MAX_RMA_RAILS=auto",
-           "MAX_RNDV_RAILS=auto", "RNDV_SCHEME=get_zcopy",
-           "RNDV_THRESH=0", "ZCOPY_THRESH=0")
-{
-    EXPECT_EQ(1u, get_rma_path_count(UCP_OP_ID_GET, UCS_MBYTE));
-    EXPECT_EQ(1u, get_rndv_path_count(UCS_MBYTE));
-}
-
-UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths,
-           get_multi_device_single_path_fallback,
-           "NET_DEVICES=mock_2:1,mock_6:1", "MAX_RMA_RAILS=auto",
-           "MAX_RNDV_RAILS=auto", "ZCOPY_THRESH=0")
-{
-    EXPECT_EQ(1u, get_rma_path_count(UCP_OP_ID_GET, UCS_MBYTE));
-    EXPECT_EQ(1u, get_rma_device_count(UCP_OP_ID_GET, UCS_MBYTE));
-}
-
-UCS_TEST_P(test_ucp_proto_mock_rcx_op_paths, get_auto_single_path_device_caps,
-           "NET_DEVICES=mock_8:1,mock_9:1", "MAX_RMA_RAILS=auto",
-           "MAX_RNDV_RAILS=auto", "RNDV_SCHEME=get_zcopy",
-           "RNDV_THRESH=0", "ZCOPY_THRESH=0")
-{
-    EXPECT_EQ(1u, get_rma_path_count(UCP_OP_ID_GET, UCS_MBYTE));
-    EXPECT_EQ(1u, get_rma_device_count(UCP_OP_ID_GET, UCS_MBYTE));
-    EXPECT_EQ(2u, get_rndv_path_count(UCS_MBYTE));
-    EXPECT_EQ(2u, get_rndv_device_count(UCS_MBYTE));
+    EXPECT_EQ(2u, get_rndv_path_count(64 * UCS_KBYTE));
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx_op_paths, rcx, "rc_x")


### PR DESCRIPTION
## What?

Add a generic UCT recommendation for the number of paths to use for a
specific operation, and teach UCP proto-v2 GET protocols to consume it.

Automatic GET path selection can add candidates gradually on the selected
devices. Explicit UCP rail or lane settings remain hard total limits, while a
fixed transport path setting remains a per-device requirement.

## Why?

The required number of paths can be a transport or device property and can
differ by operation. Deriving it from CPU configuration applies the policy too
broadly and cannot represent a NIC-specific RDMA READ requirement.

## How?

UCT performance attributes report an operation-specific path count and whether
that count is fixed. UCP carries this information into protocol selection,
enforces per-device limits, and uses the same path model for candidate ranking
and final protocol estimation.
