### PR TITLE
UCP/DT: skip rma lanes with incompatible mem_flags

### DIFF
--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -60,6 +60,52 @@ ucs_status_t ucp_dt_mem_info_verify(const char *dt_name, size_t index,
 }
 
 
+static ucp_lane_index_t
+ucp_mem_type_select_lane(ucp_worker_h worker, ucp_ep_h ep, const void *buffer,
+                         size_t length, ucs_memory_type_t mem_type)
+{
+    const ucp_ep_config_t *ep_config = ucp_ep_config(ep);
+    ucp_memory_info_t mem_info;
+    ucp_lane_index_t lane;
+    ucp_md_index_t md_index;
+    uint8_t required_mem_flags;
+    unsigned lane_index;
+
+    lane = ep_config->key.rma_lanes[0];
+    ucs_assert(lane != UCP_NULL_LANE);
+    md_index = ucp_ep_md_index(ep, lane);
+    required_mem_flags =
+            worker->context->tl_mds[md_index].attr.required_mem_flags;
+    if (required_mem_flags == 0) {
+        return lane;
+    }
+
+    ucp_memory_detect(worker->context, buffer, length, &mem_info);
+    for (lane_index = 0; lane_index < UCP_MAX_LANES; ++lane_index) {
+        lane = ep_config->key.rma_lanes[lane_index];
+        if (lane == UCP_NULL_LANE) {
+            break;
+        }
+
+        md_index = ucp_ep_md_index(ep, lane);
+        required_mem_flags =
+                worker->context->tl_mds[md_index].attr.required_mem_flags;
+        if (ucs_test_all_flags(mem_info.flags, required_mem_flags)) {
+            return lane;
+        }
+
+        ucs_trace("mem type %s lane[%d] md[%d]=%s skipped: mem_flags=0x%x "
+                  "do not include required_mem_flags=0x%x",
+                  ucs_memory_type_names[mem_type], lane, md_index,
+                  worker->context->tl_mds[md_index].rsc.md_name, mem_info.flags,
+                  required_mem_flags);
+    }
+
+    ucs_fatal("no compatible RMA lane for %s memory",
+              ucs_memory_type_names[mem_type]);
+}
+
+
 UCS_PROFILE_FUNC_VOID(ucp_mem_type_unpack,
                       (worker, buffer, recv_data, recv_length, mem_type),
                       ucp_worker_h worker, void *buffer, const void *recv_data,
@@ -75,7 +121,8 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_unpack,
         return;
     }
 
-    lane     = ucp_ep_config(ep)->key.rma_lanes[0];
+    lane     = ucp_mem_type_select_lane(worker, ep, buffer, recv_length,
+                                        mem_type);
     md_index = ucp_ep_md_index(ep, lane);
 
     status = ucp_mem_type_reg_buffers(worker, buffer, recv_length, mem_type,
@@ -110,7 +157,7 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_pack,
         return;
     }
 
-    lane     = ucp_ep_config(ep)->key.rma_lanes[0];
+    lane     = ucp_mem_type_select_lane(worker, ep, src, length, mem_type);
     md_index = ucp_ep_md_index(ep, lane);
 
     status = ucp_mem_type_reg_buffers(worker, (void *)src, length, mem_type,

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -71,7 +71,7 @@ ucp_mem_type_select_lane(ucp_worker_h worker, ucp_ep_h ep, const void *buffer,
     uint8_t required_mem_flags;
     unsigned lane_index;
 
-    lane = ep_config->key.rma_lanes[0];
+    lane     = ep_config->key.rma_lanes[0];
     md_index = ucp_ep_md_index(ep, lane);
     required_mem_flags =
             worker->context->tl_mds[md_index].attr.required_mem_flags;

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -72,7 +72,6 @@ ucp_mem_type_select_lane(ucp_worker_h worker, ucp_ep_h ep, const void *buffer,
     unsigned lane_index;
 
     lane = ep_config->key.rma_lanes[0];
-    ucs_assert(lane != UCP_NULL_LANE);
     md_index = ucp_ep_md_index(ep, lane);
     required_mem_flags =
             worker->context->tl_mds[md_index].attr.required_mem_flags;

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -116,11 +116,12 @@ uct_gdr_copy_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
     uct_gdr_copy_md_t *md = ucs_derived_of(uct_md, uct_gdr_copy_md_t);
 
     uct_md_base_md_query(md_attr);
-    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;
-    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->rkey_packed_size = sizeof(uct_gdr_copy_key_t);
-    md_attr->reg_cost         = md->reg_cost;
+    md_attr->flags              = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;
+    md_attr->reg_mem_types      = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->access_mem_types   = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->required_mem_flags = UCS_MEM_FLAG_REGISTRABLE;
+    md_attr->rkey_packed_size   = sizeof(uct_gdr_copy_key_t);
+    md_attr->reg_cost           = md->reg_cost;
 
     /* In absence of own cache require proper alignment from the global cache */
     if (md->rcache == NULL) {
@@ -667,4 +668,3 @@ uct_component_t uct_gdr_copy_component = {
     .md_vfs_init        = (uct_component_md_vfs_init_func_t)ucs_empty_function
 };
 UCT_COMPONENT_REGISTER(&uct_gdr_copy_component);
-

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -529,8 +529,7 @@ UCS_TEST_P(test_ucp_proto_gdr_copy, mem_type_pack_non_reg,
                                            &cache_mem_info));
     ASSERT_EQ(0, cache_mem_info.mem_flags & UCS_MEM_FLAG_REGISTRABLE);
 
-    const ucp_ep_h mem_type_ep =
-            worker()->mem_type_ep[UCS_MEMORY_TYPE_CUDA];
+    const ucp_ep_h mem_type_ep = worker()->mem_type_ep[UCS_MEMORY_TYPE_CUDA];
     ASSERT_NE(nullptr, mem_type_ep);
     const ucp_ep_config_t *ep_config = ucp_ep_config(mem_type_ep);
 

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -496,7 +496,6 @@ public:
 protected:
     void init() override
     {
-        modify_config("PROTO_ENABLE", "y");
         ucp_test::init();
         sender().connect(&sender(), get_ep_params());
     }
@@ -508,12 +507,8 @@ UCS_TEST_P(test_ucp_proto_gdr_copy, mem_type_pack_non_reg,
     constexpr size_t buffer_size = 65536;
     std::vector<uint8_t> expected(buffer_size);
     std::vector<uint8_t> actual(buffer_size);
-    ucp_ep_h mem_type_ep;
-    const ucp_ep_config_t *ep_config;
     ucp_memory_info_t detected_mem_info;
     ucs_memory_info_t cache_mem_info;
-    ucp_lane_index_t lane;
-    ucp_md_index_t md_index;
 
     if (!mem_buffer::is_async_supported(UCS_MEMORY_TYPE_CUDA)) {
         UCS_TEST_SKIP_R("CUDA async allocation is not supported");
@@ -534,13 +529,14 @@ UCS_TEST_P(test_ucp_proto_gdr_copy, mem_type_pack_non_reg,
                                            &cache_mem_info));
     ASSERT_EQ(0, cache_mem_info.mem_flags & UCS_MEM_FLAG_REGISTRABLE);
 
-    mem_type_ep = worker()->mem_type_ep[UCS_MEMORY_TYPE_CUDA];
+    const ucp_ep_h mem_type_ep =
+            worker()->mem_type_ep[UCS_MEMORY_TYPE_CUDA];
     ASSERT_NE(nullptr, mem_type_ep);
-    ep_config = ucp_ep_config(mem_type_ep);
+    const ucp_ep_config_t *ep_config = ucp_ep_config(mem_type_ep);
 
-    lane     = ep_config->key.rma_lanes[0];
+    const ucp_lane_index_t lane = ep_config->key.rma_lanes[0];
     ASSERT_NE(UCP_NULL_LANE, lane);
-    md_index = ucp_ep_md_index(mem_type_ep, lane);
+    const ucp_md_index_t md_index = ucp_ep_md_index(mem_type_ep, lane);
     ASSERT_STREQ("gdr_copy", context()->tl_mds[md_index].rsc.md_name);
     ASSERT_FALSE(ucs_test_all_flags(
             cache_mem_info.mem_flags,

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -8,19 +8,23 @@
 
 #include <common/test.h>
 #include <common/mem_buffer.h>
+#include <algorithm>
 #include <cstring>
 #include <unordered_map>
 #include <memory>
 
 extern "C" {
+#include <ucp/core/ucp_ep.inl>
 #include <ucp/core/ucp_rkey.h>
 #include <ucp/dt/datatype_iter.inl>
+#include <ucp/dt/dt.h>
 #include <ucp/proto/proto.h>
 #include <ucp/proto/proto_debug.h>
 #include <ucp/proto/proto_perf.h>
 #include <ucp/proto/proto_init.h>
 #include <ucp/rndv/proto_rndv.h>
 #include <ucs/datastruct/linear_func.h>
+#include <ucs/memory/memtype_cache.h>
 #include <ucp/proto/proto_select.inl>
 #include <ucp/core/ucp_worker.inl>
 #include <uct/api/v2/uct_v2.h>
@@ -481,6 +485,86 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_cuda_async_non_reg, rcx,
                               "rc_x,cuda_copy")
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_cuda_async_non_reg, rcv,
                               "rc_v,cuda_copy")
+
+class test_ucp_proto_gdr_copy : public test_ucp_proto {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant>& variants)
+    {
+        add_variant(variants, UCP_FEATURE_RMA);
+    }
+
+protected:
+    void init() override
+    {
+        modify_config("PROTO_ENABLE", "y");
+        ucp_test::init();
+        sender().connect(&sender(), get_ep_params());
+    }
+};
+
+UCS_TEST_P(test_ucp_proto_gdr_copy, mem_type_pack_non_reg,
+           "GDR_COPY_BW?=1000GBs")
+{
+    constexpr size_t buffer_size = 65536;
+    std::vector<uint8_t> expected(buffer_size);
+    std::vector<uint8_t> actual(buffer_size);
+    ucp_ep_h mem_type_ep;
+    const ucp_ep_config_t *ep_config;
+    ucp_memory_info_t detected_mem_info;
+    ucs_memory_info_t cache_mem_info;
+    ucp_lane_index_t lane;
+    ucp_md_index_t md_index;
+
+    if (!mem_buffer::is_async_supported(UCS_MEMORY_TYPE_CUDA)) {
+        UCS_TEST_SKIP_R("CUDA async allocation is not supported");
+    }
+
+    scoped_async_cuda_buffer buffer(buffer_size);
+    ucp_memory_detect(context(), buffer.ptr(), buffer_size, &detected_mem_info);
+    if (detected_mem_info.sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) {
+        UCS_TEST_SKIP_R("CUDA system device is unknown");
+    }
+
+    ucs_memtype_cache_update(buffer.ptr(), buffer_size, UCS_MEMORY_TYPE_CUDA,
+                             detected_mem_info.sys_dev, 0);
+    ucs::handle<const void*, size_t> cache_entry(
+            buffer.ptr(), ucs_memtype_cache_remove, buffer_size);
+
+    ASSERT_UCS_OK(ucs_memtype_cache_lookup(buffer.ptr(), buffer_size,
+                                           &cache_mem_info));
+    ASSERT_EQ(0, cache_mem_info.mem_flags & UCS_MEM_FLAG_REGISTRABLE);
+
+    mem_type_ep = worker()->mem_type_ep[UCS_MEMORY_TYPE_CUDA];
+    ASSERT_NE(nullptr, mem_type_ep);
+    ep_config = ucp_ep_config(mem_type_ep);
+
+    lane     = ep_config->key.rma_lanes[0];
+    ASSERT_NE(UCP_NULL_LANE, lane);
+    md_index = ucp_ep_md_index(mem_type_ep, lane);
+    ASSERT_STREQ("gdr_copy", context()->tl_mds[md_index].rsc.md_name);
+    ASSERT_FALSE(ucs_test_all_flags(
+            cache_mem_info.mem_flags,
+            context()->tl_mds[md_index].attr.required_mem_flags));
+
+    for (size_t i = 0; i < buffer_size; ++i) {
+        expected[i] = static_cast<uint8_t>(i);
+    }
+
+    mem_buffer::copy_to(buffer.ptr(), expected.data(), buffer_size,
+                        UCS_MEMORY_TYPE_CUDA);
+    ucp_mem_type_pack(worker(), actual.data(), buffer.ptr(), buffer_size,
+                      UCS_MEMORY_TYPE_CUDA);
+    EXPECT_EQ(0, std::memcmp(expected.data(), actual.data(), buffer_size));
+
+    std::fill(expected.begin(), expected.end(), 0xa5);
+    ucp_mem_type_unpack(worker(), buffer.ptr(), expected.data(), buffer_size,
+                        UCS_MEMORY_TYPE_CUDA);
+    EXPECT_TRUE(mem_buffer::compare(expected.data(), buffer.ptr(), buffer_size,
+                                    UCS_MEMORY_TYPE_CUDA));
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_gdr_copy, gdr_copy,
+                              "self,gdr_copy,cuda_copy")
 
 class test_perf_node : public test_ucp_proto {
 };

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -488,7 +488,7 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_cuda_async_non_reg, rcv,
 
 class test_ucp_proto_gdr_copy : public test_ucp_proto {
 public:
-    static void get_test_variants(std::vector<ucp_test_variant>& variants)
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
     {
         add_variant(variants, UCP_FEATURE_RMA);
     }
@@ -522,8 +522,9 @@ UCS_TEST_P(test_ucp_proto_gdr_copy, mem_type_pack_non_reg,
 
     ucs_memtype_cache_update(buffer.ptr(), buffer_size, UCS_MEMORY_TYPE_CUDA,
                              detected_mem_info.sys_dev, 0);
-    ucs::handle<const void*, size_t> cache_entry(
-            buffer.ptr(), ucs_memtype_cache_remove, buffer_size);
+    ucs::handle<const void*, size_t> cache_entry(buffer.ptr(),
+                                                 ucs_memtype_cache_remove,
+                                                 buffer_size);
 
     ASSERT_UCS_OK(ucs_memtype_cache_lookup(buffer.ptr(), buffer_size,
                                            &cache_mem_info));


### PR DESCRIPTION
## What?
Change ucp_mem_type_pack and ucp_mem_type_unpack to check required_mem_flags.
Make gdrcopy require REGISTERABLE flag.

## Why?
gdrcopy may not work with localized memory.

## How?
if required_memory_flags is not 0 for the candidate lane, call detect the memory flags.