### PR TITLE
UCP/UCT/UCS: Add a mem_flag for fabric-exportable cuda memory

### DIFF
--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -15,6 +15,24 @@
 #include <ucp/proto/proto_common.inl>
 #include <uct/api/v2/uct_v2.h>
 
+static int
+ucp_proto_rndv_ctrl_skip_inter_node_cuda_rkey_ptr_md(
+        const ucp_proto_rndv_ctrl_init_params_t *params,
+        const uct_md_attr_v2_t *md_attr)
+{
+    const ucp_ep_config_key_t *ep_config_key =
+            params->super.super.ep_config_key;
+
+    /*
+     * A CUDA IPC lane may be reachable at endpoint level on MNNVL-capable
+     * systems, but an individual CUDA allocation may not be usable inter-node.
+     */
+    return (params->super.reg_mem_info.type == UCS_MEMORY_TYPE_CUDA) &&
+           !ucs_test_all_flags(params->super.reg_mem_info.flags,
+                               UCS_MEM_FLAG_FABRIC) &&
+           ucp_ep_config_is_inter_node(ep_config_key) &&
+           (md_attr->flags & UCT_MD_FLAG_RKEY_PTR);
+}
 
 static void
 ucp_proto_rndv_ctrl_get_md_map(const ucp_proto_rndv_ctrl_init_params_t *params,
@@ -85,6 +103,11 @@ ucp_proto_rndv_ctrl_get_md_map(const ucp_proto_rndv_ctrl_init_params_t *params,
                           lane, context->tl_mds[md_index].rsc.md_name,
                           md_attr->required_mem_flags,
                           params->super.reg_mem_info.flags);
+            continue;
+        }
+
+        if (ucp_proto_rndv_ctrl_skip_inter_node_cuda_rkey_ptr_md(params,
+                                                                 md_attr)) {
             continue;
         }
 
@@ -189,27 +212,34 @@ static ucs_status_t ucp_proto_rndv_ctrl_select_remote_proto(
 {
     ucp_worker_h worker                 = params->super.super.worker;
     ucp_worker_cfg_index_t ep_cfg_index = params->super.super.ep_cfg_index;
+    const ucp_rkey_config_key_t *key    = params->super.super.rkey_config_key;
     const ucp_ep_config_t *ep_config    = &ucs_array_elem(&worker->ep_config,
                                                           ep_cfg_index);
     ucs_sys_dev_distance_t lanes_distance[UCP_MAX_LANES];
     ucp_rkey_config_key_t rkey_config_key;
     ucp_worker_cfg_index_t rkey_cfg_index;
     ucp_rkey_config_t *rkey_config;
+    ucp_md_map_t remote_md_map;
+    ucp_md_map_t unreachable_md_map;
     ucs_status_t status;
     ucp_lane_index_t lane;
+
+    remote_md_map      = ucp_proto_rndv_md_map_to_remote(params, md_map);
+    unreachable_md_map = (key == NULL) ? 0 : key->unreachable_md_map;
+    if (unreachable_md_map != 0) {
+        remote_md_map &= ~unreachable_md_map;
+    }
 
     /* Construct remote key for remote protocol lookup according to the local
      * buffer properties (since remote side is expected to access the local
      * buffer)
      */
-    rkey_config_key.md_map       = ucp_proto_rndv_md_map_to_remote(params,
-                                                                   md_map);
-    rkey_config_key.ep_cfg_index = ep_cfg_index;
-    rkey_config_key.sys_dev      = params->super.reg_mem_info.sys_dev;
-    rkey_config_key.mem_type     = params->super.reg_mem_info.type;
-    rkey_config_key.flags        = 0;
-
-    rkey_config_key.unreachable_md_map = 0;
+    rkey_config_key.md_map             = remote_md_map;
+    rkey_config_key.ep_cfg_index       = ep_cfg_index;
+    rkey_config_key.sys_dev            = params->super.reg_mem_info.sys_dev;
+    rkey_config_key.mem_type           = params->super.reg_mem_info.type;
+    rkey_config_key.flags              = 0;
+    rkey_config_key.unreachable_md_map = unreachable_md_map;
 
     for (lane = 0; lane < ep_config->key.num_lanes; ++lane) {
         ucp_proto_common_get_lane_distance(&params->super.super, lane,

--- a/src/ucs/memory/memory_type.h
+++ b/src/ucs/memory/memory_type.h
@@ -52,7 +52,8 @@ typedef enum ucs_memory_type {
 
 
 typedef enum ucs_mem_flags {
-    UCS_MEM_FLAG_REGISTRABLE = UCS_BIT(0) /**< Memory is registrable by MDs */
+    UCS_MEM_FLAG_REGISTRABLE = UCS_BIT(0), /**< Memory is registrable by MDs */
+    UCS_MEM_FLAG_FABRIC      = UCS_BIT(1)  /**< Memory has a fabric handle */
 } ucs_mem_flags_t;
 
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -851,24 +851,35 @@ uct_cuda_copy_md_detect_mem_flags(uct_cuda_copy_md_t *md,
                                   int is_async_managed, int is_host_located,
                                   const uct_cuda_copy_md_dmabuf_t *dmabuf)
 {
+    uint8_t mem_flags = 0;
     int close_dmabuf = 0;
     uct_cuda_copy_md_dmabuf_t local_dmabuf;
+#if HAVE_CUDA_FABRIC
+    CUpointer_attribute attr_type[2];
+    void *attr_data[2];
+    uint64_t allowed_handle_types;
+    int legacy_capable;
+    ucs_status_t status;
+#endif
 
     if (is_async_managed) {
-        return 0;
+        goto out_fabric;
     }
 
     /* Host-located CUDA VMM is registerable even if dmabuf export fails. */
     if (is_host_located) {
-        return UCS_MEM_FLAG_REGISTRABLE;
+        mem_flags |= UCS_MEM_FLAG_REGISTRABLE;
+        goto out_fabric;
     }
 
     if (mem_info->sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) {
-        return UCS_MEM_FLAG_REGISTRABLE;
+        mem_flags |= UCS_MEM_FLAG_REGISTRABLE;
+        goto out_fabric;
     }
 
     if (!md->config.dmabuf_supported) {
-        return UCS_MEM_FLAG_REGISTRABLE;
+        mem_flags |= UCS_MEM_FLAG_REGISTRABLE;
+        goto out_fabric;
     }
 
     if (dmabuf == NULL) {
@@ -879,15 +890,33 @@ uct_cuda_copy_md_detect_mem_flags(uct_cuda_copy_md_t *md,
         close_dmabuf = 1;
     }
 
-    if (dmabuf->fd == UCT_DMABUF_FD_INVALID) {
-        return 0;
+    if (dmabuf->fd != UCT_DMABUF_FD_INVALID) {
+        mem_flags |= UCS_MEM_FLAG_REGISTRABLE;
     }
 
     if (close_dmabuf) {
         ucs_close_fd(&local_dmabuf.fd);
     }
 
-    return UCS_MEM_FLAG_REGISTRABLE;
+out_fabric:
+#if HAVE_CUDA_FABRIC
+    attr_type[0] = CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE;
+    attr_data[0] = &legacy_capable;
+    attr_type[1] = CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES;
+    attr_data[1] = &allowed_handle_types;
+
+    status = UCT_CUDADRV_FUNC(cuPointerGetAttributes(
+                                      ucs_static_array_size(attr_data),
+                                      attr_type, attr_data,
+                                      (CUdeviceptr)mem_info->base_address),
+                              UCS_LOG_LEVEL_DEBUG);
+    if ((status == UCS_OK) && !legacy_capable &&
+        (allowed_handle_types & CU_MEM_HANDLE_TYPE_FABRIC)) {
+        mem_flags |= UCS_MEM_FLAG_FABRIC;
+    }
+#endif
+
+    return mem_flags;
 }
 
 ucs_status_t uct_cuda_copy_md_mem_query(uct_md_h tl_md, const void *address,

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -13,6 +13,7 @@ extern "C" {
 #include <uct/base/uct_iface.h>
 #include <ucp/proto/proto_debug.h>
 #include <ucp/proto/proto_select.inl>
+#include <ucp/rndv/proto_rndv.h>
 #include <ucs/memory/numa.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/topo/base/topo.h>
@@ -1332,6 +1333,95 @@ public:
 
         check_rkey_config(sender(), data_vec, key, rkey_cfg_index);
     }
+
+protected:
+    struct cuda_ipc_lane_info {
+        ucp_lane_index_t lane;
+        ucp_md_index_t md_index;
+        ucp_rsc_index_t cmpt_index;
+    };
+
+    template <typename value_t>
+    class scoped_value {
+    public:
+        scoped_value(value_t &value, value_t new_value) :
+            m_value(value), m_orig_value(value)
+        {
+            m_value = new_value;
+        }
+
+        ~scoped_value()
+        {
+            m_value = m_orig_value;
+        }
+
+    private:
+        value_t &m_value;
+        value_t m_orig_value;
+    };
+
+    bool find_cuda_ipc_lane(const entity &e, ucp_ep_config_t *config,
+                            cuda_ipc_lane_info *lane_info)
+    {
+        ucp_context_h context = e.ucph();
+        ucp_lane_index_t lane;
+
+        for (lane = 0; lane < config->key.num_lanes; ++lane) {
+            ucp_rsc_index_t rsc_index = config->key.lanes[lane].rsc_index;
+            ucp_md_index_t md_index;
+
+            if ((rsc_index == UCP_NULL_RESOURCE) ||
+                (std::string(context->tl_rscs[rsc_index].tl_rsc.tl_name) !=
+                 "cuda_ipc")) {
+                continue;
+            }
+
+            md_index = context->tl_rscs[rsc_index].md_index;
+            lane_info->lane       = lane;
+            lane_info->md_index   = md_index;
+            lane_info->cmpt_index = context->tl_mds[md_index].cmpt_index;
+            return true;
+        }
+
+        return false;
+    }
+
+    const ucp_proto_config_t *
+    select_cuda_proto(const entity &e, ucp_operation_id_t op_id,
+                      ucp_md_map_t md_map, ucp_md_map_t unreachable_md_map,
+                      uint8_t mem_flags)
+    {
+        ucp_rkey_config_key_t rkey_config_key = {
+            md_map, ep_config_index(e), UCS_SYS_DEVICE_ID_UNKNOWN, 0,
+            UCS_MEMORY_TYPE_CUDA, unreachable_md_map
+        };
+        ucp_worker_cfg_index_t rkey_cfg_index;
+        ucp_rkey_config_t *rkey_config;
+        ucp_proto_select_param_t select_param;
+        ucp_proto_select_elem_t *select_elem;
+        ucp_memory_info_t mem_info;
+
+        mem_info.type    = UCS_MEMORY_TYPE_CUDA;
+        mem_info.sys_dev = e.ucph()->alloc_md[UCS_MEMORY_TYPE_CUDA].sys_dev;
+        mem_info.flags   = mem_flags;
+
+        ASSERT_UCS_OK(ucp_worker_rkey_config_get(e.worker(), &rkey_config_key,
+                                                 nullptr, &rkey_cfg_index));
+        rkey_config = &ucs_array_elem(&e.worker()->rkey_config,
+                                      rkey_cfg_index);
+
+        ucp_proto_select_param_init(&select_param, op_id, 0, 0,
+                                    UCP_DATATYPE_CONTIG, &mem_info, 1);
+        select_elem = ucp_proto_select_lookup_slow(
+                e.worker(), &rkey_config->proto_select, 0, ep_config_index(e),
+                rkey_cfg_index, &select_param);
+        if (select_elem == nullptr) {
+            UCS_TEST_ABORT("failed to select CUDA protocol");
+        }
+
+        return &ucp_proto_thresholds_search_slow(
+                select_elem->thresholds, 64 * UCS_MBYTE)->proto_config;
+    }
 };
 
 UCS_TEST_P(test_ucp_proto_mock_cuda_ipc, put, "IB_NUM_PATHS?=1")
@@ -1348,6 +1438,96 @@ UCS_TEST_P(test_ucp_proto_mock_cuda_ipc, get, "IB_NUM_PATHS?=1")
         {0, 0,   "copy-out",  "rc_mlx5/mock"},
         {1, INF, "zero-copy", "cuda_ipc/cuda"},
     });
+}
+
+UCS_TEST_P(test_ucp_proto_mock_cuda_ipc, put_unreachable_cuda_ipc,
+           "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1",
+           "RMA_PPLN_ENABLE=y", "RNDV_THRESH=0",
+           "RNDV_FRAG_MEM_TYPES=cuda")
+{
+    ucp_ep_config_t *config        = ucp_worker_ep_config(
+            sender().worker(), ep_config_index(sender()));
+    ucp_md_index_t remote_cuda_md_index;
+    cuda_ipc_lane_info cuda_lane;
+    const ucp_proto_rndv_ctrl_priv_t *rpriv;
+    ucp_md_map_t new_reachable_md_map;
+    std::vector<ucp_rsc_index_t> dst_md_cmpts;
+
+    if (!find_cuda_ipc_lane(sender(), config, &cuda_lane)) {
+        UCS_TEST_SKIP_R("cuda_ipc lane is not available");
+    }
+
+    remote_cuda_md_index = ucs_ffs64_safe(
+            ~(config->key.reachable_md_map | UCS_BIT(cuda_lane.md_index)) &
+            UCS_MASK(UCP_MAX_MDS));
+    if (remote_cuda_md_index >= UCP_MAX_MDS) {
+        UCS_TEST_SKIP_R("no unused remote MD index is available");
+    }
+
+    new_reachable_md_map = config->key.reachable_md_map |
+                           UCS_BIT(remote_cuda_md_index);
+    dst_md_cmpts.assign(config->key.dst_md_cmpts,
+                        config->key.dst_md_cmpts +
+                        ucs_popcount(config->key.reachable_md_map));
+    dst_md_cmpts.insert(
+            dst_md_cmpts.begin() +
+            ucs_bitmap2idx(new_reachable_md_map, remote_cuda_md_index),
+            cuda_lane.cmpt_index);
+    scoped_value<ucp_md_map_t> reachable_md_map(config->key.reachable_md_map,
+                                                new_reachable_md_map);
+    scoped_value<ucp_rsc_index_t*> remote_md_cmpts(config->key.dst_md_cmpts,
+                                                   dst_md_cmpts.data());
+    scoped_value<ucp_md_index_t> dst_md_index(
+            config->key.lanes[cuda_lane.lane].dst_md_index,
+            remote_cuda_md_index);
+
+    auto proto_config = select_cuda_proto(
+            sender(), UCP_OP_ID_PUT,
+            config->key.reachable_md_map & ~UCS_BIT(remote_cuda_md_index),
+            UCS_BIT(remote_cuda_md_index), 0);
+
+    ASSERT_STREQ("put/rndv", proto_config->proto->name);
+    rpriv = static_cast<const ucp_proto_rndv_ctrl_priv_t*>(proto_config->priv);
+    EXPECT_STREQ("rndv/rtr/mtype", rpriv->remote_proto_config.proto->name);
+}
+
+UCS_TEST_P(test_ucp_proto_mock_cuda_ipc, rndv_recv_legacy_cuda,
+           "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1",
+           "RMA_PPLN_ENABLE=y", "RNDV_THRESH=0",
+           "RNDV_FRAG_MEM_TYPES=cuda")
+{
+    ucp_ep_config_t *config        = ucp_worker_ep_config(
+            receiver().worker(), ep_config_index(receiver()));
+    cuda_ipc_lane_info cuda_lane;
+    ucp_context_alloc_md_index_t *alloc_md;
+    ucp_md_index_t alloc_md_index;
+    ucp_memory_info_t mem_info;
+
+    if (!find_cuda_ipc_lane(receiver(), config, &cuda_lane)) {
+        UCS_TEST_SKIP_R("cuda_ipc lane is not available");
+    }
+
+    if (ucp_mm_get_alloc_md_index(receiver().ucph(), UCS_MEMORY_TYPE_CUDA,
+                                  UCS_SYS_DEVICE_ID_UNKNOWN, &alloc_md_index,
+                                  &mem_info) != UCS_OK) {
+        UCS_TEST_SKIP_R("CUDA allocation MD is not available");
+    }
+
+    alloc_md = &receiver().ucph()->alloc_md[UCS_MEMORY_TYPE_CUDA];
+    scoped_value<unsigned> ep_flags(
+            config->key.flags,
+            config->key.flags & ~(UCP_EP_CONFIG_KEY_FLAG_SELF |
+                                  UCP_EP_CONFIG_KEY_FLAG_INTRA_NODE));
+
+    scoped_value<uint8_t> alloc_md_flags(
+            alloc_md->mem_flags, alloc_md->mem_flags | UCS_MEM_FLAG_FABRIC);
+
+    auto proto_config = select_cuda_proto(receiver(), UCP_OP_ID_RNDV_RECV,
+                                          0, 0, UCS_MEM_FLAG_FABRIC);
+    EXPECT_STREQ("rndv/rtr", proto_config->proto->name);
+
+    proto_config = select_cuda_proto(receiver(), UCP_OP_ID_RNDV_RECV, 0, 0, 0);
+    EXPECT_STREQ("rndv/rtr/mtype", proto_config->proto->name);
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_proto_mock_cuda_ipc,


### PR DESCRIPTION
## What?
Add a mem_flag for fabric-exportable cuda memory
And filter rndv proto selection to not use cuda_ipc for inter-node cases if memory is not fabric exportabl

## Why?
cuda_ipc can be chosen for inter-node rndv even if memory is legacy cuda memory. This causes rndv to fail even though it could have succeeded with the pipeline rndv.

## How?
Add a mem_flag for cuda memory that can be exported as a fabric handle, filter according it, inter-node, memory type and if the md is cuda_ipc.
