### PR TITLE
TEST ONLY - NOT TO MERGE - UCP/RNDV: Skip memory invalidation without registration cache

### DIFF
--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -420,7 +420,8 @@ int ucp_request_memh_invalidate(ucp_request_t *req, ucs_status_t status)
         memh_p = &req->send.state.dt.dt.contig.memh;
     }
 
-    if ((*memh_p == NULL) || ucp_memh_is_user_memh(*memh_p)) {
+    if ((context->rcache == NULL) || (*memh_p == NULL) ||
+        ucp_memh_is_user_memh(*memh_p)) {
         return 0;
     }
 

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -951,6 +951,14 @@ UCS_TEST_P(test_ucp_peer_failure_rndv_abort, get_zcopy_memory_invalidation,
     rndv_progress_failure_test(rndv_mode::rndv_get, false);
 }
 
+UCS_TEST_P(test_ucp_peer_failure_rndv_abort, get_zcopy_no_rcache,
+           "RNDV_SCHEME=get_zcopy", "RCACHE_ENABLE=n")
+{
+    ASSERT_EQ(nullptr, sender().ucph()->rcache);
+    ASSERT_EQ(nullptr, receiver().ucph()->rcache);
+    rndv_progress_failure_test(rndv_mode::rndv_get, false);
+}
+
 UCS_TEST_P(test_ucp_peer_failure_rndv_abort, put_zcopy_memory_invalidation,
            "RNDV_SCHEME=put_zcopy")
 {


### PR DESCRIPTION
## What?
Add a registration-cache availability check to the UCP rendezvous abort path so memory invalidation is skipped when `context->rcache` is NULL, and add a gtest covering the no-rcache case.

## Why?
UCX can crash with SIGSEGV in `ucs_rcache_region_invalidate()` when the UCP registration cache is unavailable and a rendezvous request is aborted during peer error handling. `ucp_request_memh_invalidate()` only filtered out NULL and user memh and assumed `context->rcache != NULL`, but `ucp_init()` can continue with `context->rcache == NULL` when rcache initialization fails under `RCACHE_ENABLE=try`.

## How?
In `src/ucp/core/ucp_request.c`, `ucp_request_memh_invalidate()` now returns early when `context->rcache == NULL`, in addition to the existing NULL and user memh checks. A new gtest `test_ucp_peer_failure_rndv_abort.get_zcopy_no_rcache` in `test/gtest/ucp/test_ucp_peer_failure.cc` runs with `RNDV_SCHEME=get_zcopy` and `RCACHE_ENABLE=n`, asserts both peers have a NULL rcache, and exercises the RNDV get failure path.
