### PR TITLE
AZP/RELEASE: Do not publish JUCX for release candidate tags

### DIFF
--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -96,7 +96,8 @@ jobs:
               ARGS="--settings $(temp_cfg)" \
               JUCX_VERSION=${MAVEN_VERSION}${SUFFIX}
         displayName: Publish-Maven
-        condition: eq(variables['Build.Reason'], 'IndividualCI')
+        # rc tags carry the final maven version - skip to keep it for GA
+        condition: and(eq(variables['Build.Reason'], 'IndividualCI'), not(contains(variables['Build.SourceBranch'], '-rc')))
         env:
           GPG_PASSPHRASE: $(GPG_PASSPHRASE)
           SONATYPE_PASSWORD: $(SONATYPE_PASSWORD)


### PR DESCRIPTION
## What?
Skip JUCX `Publish-Maven` for release candidate tags.

## Why?
Since #11349 the maven version comes from the Makefile and no longer carries the rc suffix, so an rc tag publishes the final release coordinates. Central versions are immutable, so the GA run then fails - rc1 published `jucx:1.22.0` on Jul 1 and GA build 129922 got `Component ... already exists`.
