### PR TITLE
UCT/IB/MLX5: Add external plugin load marker - DO NOT MERGE

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5_ext.c
+++ b/src/uct/ib/mlx5/ib_mlx5_ext.c
@@ -211,6 +211,7 @@ ucs_status_t uct_ib_mlx5_ext_register(const uct_ib_mlx5_ext_ops_t *ops)
     ucs_list_add_tail(&uct_ib_mlx5_ext_plugins, &plugin->list);
     num_plugins = ucs_list_length(&uct_ib_mlx5_ext_plugins);
 
+    ucs_warn("ucx-ext-pr-smoke: registered plugin %s", plugin->ops.name);
     ucs_debug("ib mlx5 ext: registered plugin name=%s iface_query=%s "
               "ep_query=%s put_sgl_zcopy=%s outstanding_purge=%s "
               "(total=%u)",


### PR DESCRIPTION
## What?

Emit a temporary warning when an external mlx5 extension plugin registers.

## Why?

This draft PR is a stacked-development smoke marker for confirming that an
external plugin pipeline can select and build a public UCX pull request, then
observe the UCX registration path at runtime.

This change is intentionally not for merge.

## How?

`uct_ib_mlx5_ext_register()` emits the distinctive `ucx-ext-pr-smoke` marker
after registration succeeds.
