### PR TITLE
UCP/WORKER: Add device filter for worker address query

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -456,8 +456,10 @@ enum ucp_worker_attr_field {
     UCP_WORKER_ATTR_FIELD_MAX_AM_HEADER   = UCS_BIT(3), /**< Maximum header size
                                                              used by UCP AM API */
     UCP_WORKER_ATTR_FIELD_NAME            = UCS_BIT(4), /**< UCP worker name */
-    UCP_WORKER_ATTR_FIELD_MAX_INFO_STRING = UCS_BIT(5)  /**< Maximum size of
+    UCP_WORKER_ATTR_FIELD_MAX_INFO_STRING = UCS_BIT(5), /**< Maximum size of
                                                              info string */
+    UCP_WORKER_ATTR_FIELD_ADDRESS_DEVICE_NAME =
+            UCS_BIT(6)  /**< UCP address device name */
 };
 
 
@@ -1400,6 +1402,14 @@ typedef struct ucp_worker_attr {
      * Maximum debug string size that can be filled with @ref ucp_request_query.
      */
     size_t                max_debug_string;
+
+    /**
+     * Device name whose resources should be included in the worker address.
+     * If @ref UCP_WORKER_ATTR_FIELD_ADDRESS_DEVICE_NAME bit is set in
+     * @ref field_mask, this value should point to a valid device name from the
+     * worker's context. @note This is an input attribute.
+     */
+    const char            *address_device_name;
 } ucp_worker_attr_t;
 
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3142,7 +3142,7 @@ static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
             }
         }
 
-        UCS_STATIC_BITMAP_AND_INPLACE(&tl_bitmap, &net_tl_bitmap);
+        UCS_STATIC_BITMAP_AND_INPLACE(&tl_bitmap, net_tl_bitmap);
     }
 
     if ((address_device_name != NULL) && UCS_STATIC_BITMAP_IS_ZERO(tl_bitmap)) {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3111,12 +3111,13 @@ void ucp_worker_destroy(ucp_worker_h worker)
 
 static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
                                             uint32_t address_flags,
+                                            const char *address_device_name,
                                             size_t *address_length_p,
                                             void **address_p)
 {
     ucp_context_h context = worker->context;
     unsigned flags        = ucp_worker_default_address_pack_flags(worker);
-    ucp_tl_bitmap_t tl_bitmap;
+    ucp_tl_bitmap_t tl_bitmap, net_tl_bitmap;
     ucp_rsc_index_t tl_id;
     const uct_iface_attr_t *iface_attr;
 
@@ -3126,16 +3127,28 @@ static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
      */
     ucs_assert(flags & UCP_ADDRESS_PACK_FLAG_WORKER_UUID);
 
-    if (address_flags & UCP_WORKER_ADDRESS_FLAG_NET_ONLY) {
-        UCS_STATIC_BITMAP_RESET_ALL(&tl_bitmap);
-        UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &worker->context->tl_bitmap) {
-            iface_attr = ucp_worker_iface_get_attr(worker, tl_id);
-            if (iface_attr->cap.flags & UCT_IFACE_FLAG_INTER_NODE) {
-                UCS_STATIC_BITMAP_SET(&tl_bitmap, tl_id);
-            }
-        }
+    if (address_device_name != NULL) {
+        ucp_context_dev_tl_bitmap(context, address_device_name, &tl_bitmap);
     } else {
         UCS_STATIC_BITMAP_SET_ALL(&tl_bitmap);
+    }
+
+    if (address_flags & UCP_WORKER_ADDRESS_FLAG_NET_ONLY) {
+        UCS_STATIC_BITMAP_RESET_ALL(&net_tl_bitmap);
+        UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &context->tl_bitmap) {
+            iface_attr = ucp_worker_iface_get_attr(worker, tl_id);
+            if (iface_attr->cap.flags & UCT_IFACE_FLAG_INTER_NODE) {
+                UCS_STATIC_BITMAP_SET(&net_tl_bitmap, tl_id);
+            }
+        }
+
+        UCS_STATIC_BITMAP_AND_INPLACE(&tl_bitmap, &net_tl_bitmap);
+    }
+
+    if ((address_device_name != NULL) && UCS_STATIC_BITMAP_IS_ZERO(tl_bitmap)) {
+        ucs_debug("worker %p: device %s has no addressable resources", worker,
+                  address_device_name);
+        return UCS_ERR_NO_DEVICE;
     }
 
     return ucp_address_pack(worker, NULL, &tl_bitmap, flags,
@@ -3146,6 +3159,7 @@ static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
 ucs_status_t ucp_worker_query(ucp_worker_h worker,
                               ucp_worker_attr_t *attr)
 {
+    const char *address_device_name;
     ucs_status_t status = UCS_OK;
     uint32_t address_flags;
 
@@ -3156,7 +3170,10 @@ ucs_status_t ucp_worker_query(ucp_worker_h worker,
     if (attr->field_mask & UCP_WORKER_ATTR_FIELD_ADDRESS) {
         address_flags = UCP_ATTR_VALUE(WORKER, attr, address_flags,
                                        ADDRESS_FLAGS, 0);
+        address_device_name = UCP_ATTR_VALUE(WORKER, attr, address_device_name,
+                                             ADDRESS_DEVICE_NAME, NULL);
         status        = ucp_worker_address_pack(worker, address_flags,
+                                                address_device_name,
                                                 &attr->address_length,
                                                 (void**)&attr->address);
     }
@@ -3432,7 +3449,7 @@ ucs_status_t ucp_worker_get_address(ucp_worker_h worker,
 
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
-    status = ucp_worker_address_pack(worker, 0, address_length_p,
+    status = ucp_worker_address_pack(worker, 0, NULL, address_length_p,
                                      (void**)address_p);
 
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3111,11 +3111,10 @@ void ucp_worker_destroy(ucp_worker_h worker)
     ucs_free(worker);
 }
 
-static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
-                                            uint32_t address_flags,
-                                            const char *address_device_name,
-                                            size_t *address_length_p,
-                                            void **address_p)
+static ucs_status_t
+ucp_worker_address_pack(ucp_worker_h worker, uint32_t address_flags,
+                        const char *address_device_name,
+                        size_t *address_length_p, void **address_p)
 {
     ucp_context_h context = worker->context;
     unsigned flags        = ucp_worker_default_address_pack_flags(worker);
@@ -3146,9 +3145,11 @@ static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
 
     if ((address_device_name != NULL) && UCS_STATIC_BITMAP_IS_ZERO(tl_bitmap)) {
         ucs_error("worker %p: no addressable resources for device %s with "
-                  "network-only flag %c", worker, address_device_name,
+                  "network-only flag %c",
+                  worker, address_device_name,
                   ((address_flags & UCP_WORKER_ADDRESS_FLAG_NET_ONLY) != 0) ?
-                          'y' : 'n');
+                          'y' :
+                          'n');
         return UCS_ERR_NO_DEVICE;
     }
 
@@ -3160,8 +3161,8 @@ static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
 ucs_status_t ucp_worker_query(ucp_worker_h worker,
                               ucp_worker_attr_t *attr)
 {
-    const char *address_device_name;
     ucs_status_t status = UCS_OK;
+    const char *address_device_name;
     uint32_t address_flags;
 
     if (attr->field_mask & UCP_WORKER_ATTR_FIELD_THREAD_MODE) {
@@ -3173,10 +3174,10 @@ ucs_status_t ucp_worker_query(ucp_worker_h worker,
                                        ADDRESS_FLAGS, 0);
         address_device_name = UCP_ATTR_VALUE(WORKER, attr, address_device_name,
                                              ADDRESS_DEVICE_NAME, NULL);
-        status        = ucp_worker_address_pack(worker, address_flags,
-                                                address_device_name,
-                                                &attr->address_length,
-                                                (void**)&attr->address);
+        status              = ucp_worker_address_pack(worker, address_flags,
+                                                      address_device_name,
+                                                      &attr->address_length,
+                                                      (void**)&attr->address);
     }
 
     if (attr->field_mask & UCP_WORKER_ATTR_FIELD_MAX_AM_HEADER) {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3119,7 +3119,7 @@ static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
 {
     ucp_context_h context = worker->context;
     unsigned flags        = ucp_worker_default_address_pack_flags(worker);
-    ucp_tl_bitmap_t tl_bitmap, net_tl_bitmap;
+    ucp_tl_bitmap_t tl_bitmap;
     ucp_rsc_index_t tl_id;
     const uct_iface_attr_t *iface_attr;
 
@@ -3132,24 +3132,23 @@ static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
     if (address_device_name != NULL) {
         ucp_context_dev_tl_bitmap(context, address_device_name, &tl_bitmap);
     } else {
-        UCS_STATIC_BITMAP_SET_ALL(&tl_bitmap);
+        tl_bitmap = context->tl_bitmap;
     }
 
     if (address_flags & UCP_WORKER_ADDRESS_FLAG_NET_ONLY) {
-        UCS_STATIC_BITMAP_RESET_ALL(&net_tl_bitmap);
-        UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &context->tl_bitmap) {
+        UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &tl_bitmap) {
             iface_attr = ucp_worker_iface_get_attr(worker, tl_id);
-            if (iface_attr->cap.flags & UCT_IFACE_FLAG_INTER_NODE) {
-                UCS_STATIC_BITMAP_SET(&net_tl_bitmap, tl_id);
+            if ((iface_attr->cap.flags & UCT_IFACE_FLAG_INTER_NODE) == 0) {
+                UCS_STATIC_BITMAP_RESET(&tl_bitmap, tl_id);
             }
         }
-
-        UCS_STATIC_BITMAP_AND_INPLACE(&tl_bitmap, net_tl_bitmap);
     }
 
     if ((address_device_name != NULL) && UCS_STATIC_BITMAP_IS_ZERO(tl_bitmap)) {
-        ucs_debug("worker %p: device %s has no addressable resources", worker,
-                  address_device_name);
+        ucs_error("worker %p: no addressable resources for device %s with "
+                  "network-only flag %c", worker, address_device_name,
+                  ((address_flags & UCP_WORKER_ADDRESS_FLAG_NET_ONLY) != 0) ?
+                          'y' : 'n');
         return UCS_ERR_NO_DEVICE;
     }
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3138,7 +3138,7 @@ static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
     if (address_flags & UCP_WORKER_ADDRESS_FLAG_NET_ONLY) {
         UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &tl_bitmap) {
             iface_attr = ucp_worker_iface_get_attr(worker, tl_id);
-            if ((iface_attr->cap.flags & UCT_IFACE_FLAG_INTER_NODE) == 0) {
+            if (!(iface_attr->cap.flags & UCT_IFACE_FLAG_INTER_NODE)) {
                 UCS_STATIC_BITMAP_RESET(&tl_bitmap, tl_id);
             }
         }

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -3113,12 +3113,13 @@ void ucp_worker_destroy(ucp_worker_h worker)
 
 static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
                                             uint32_t address_flags,
+                                            const char *address_device_name,
                                             size_t *address_length_p,
                                             void **address_p)
 {
     ucp_context_h context = worker->context;
     unsigned flags        = ucp_worker_default_address_pack_flags(worker);
-    ucp_tl_bitmap_t tl_bitmap;
+    ucp_tl_bitmap_t tl_bitmap, net_tl_bitmap;
     ucp_rsc_index_t tl_id;
     const uct_iface_attr_t *iface_attr;
 
@@ -3128,16 +3129,28 @@ static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
      */
     ucs_assert(flags & UCP_ADDRESS_PACK_FLAG_WORKER_UUID);
 
-    if (address_flags & UCP_WORKER_ADDRESS_FLAG_NET_ONLY) {
-        UCS_STATIC_BITMAP_RESET_ALL(&tl_bitmap);
-        UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &worker->context->tl_bitmap) {
-            iface_attr = ucp_worker_iface_get_attr(worker, tl_id);
-            if (iface_attr->cap.flags & UCT_IFACE_FLAG_INTER_NODE) {
-                UCS_STATIC_BITMAP_SET(&tl_bitmap, tl_id);
-            }
-        }
+    if (address_device_name != NULL) {
+        ucp_context_dev_tl_bitmap(context, address_device_name, &tl_bitmap);
     } else {
         UCS_STATIC_BITMAP_SET_ALL(&tl_bitmap);
+    }
+
+    if (address_flags & UCP_WORKER_ADDRESS_FLAG_NET_ONLY) {
+        UCS_STATIC_BITMAP_RESET_ALL(&net_tl_bitmap);
+        UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &context->tl_bitmap) {
+            iface_attr = ucp_worker_iface_get_attr(worker, tl_id);
+            if (iface_attr->cap.flags & UCT_IFACE_FLAG_INTER_NODE) {
+                UCS_STATIC_BITMAP_SET(&net_tl_bitmap, tl_id);
+            }
+        }
+
+        UCS_STATIC_BITMAP_AND_INPLACE(&tl_bitmap, net_tl_bitmap);
+    }
+
+    if ((address_device_name != NULL) && UCS_STATIC_BITMAP_IS_ZERO(tl_bitmap)) {
+        ucs_debug("worker %p: device %s has no addressable resources", worker,
+                  address_device_name);
+        return UCS_ERR_NO_DEVICE;
     }
 
     return ucp_address_pack(worker, NULL, &tl_bitmap, flags,
@@ -3148,6 +3161,7 @@ static ucs_status_t ucp_worker_address_pack(ucp_worker_h worker,
 ucs_status_t ucp_worker_query(ucp_worker_h worker,
                               ucp_worker_attr_t *attr)
 {
+    const char *address_device_name;
     ucs_status_t status = UCS_OK;
     uint32_t address_flags;
 
@@ -3158,7 +3172,10 @@ ucs_status_t ucp_worker_query(ucp_worker_h worker,
     if (attr->field_mask & UCP_WORKER_ATTR_FIELD_ADDRESS) {
         address_flags = UCP_ATTR_VALUE(WORKER, attr, address_flags,
                                        ADDRESS_FLAGS, 0);
+        address_device_name = UCP_ATTR_VALUE(WORKER, attr, address_device_name,
+                                             ADDRESS_DEVICE_NAME, NULL);
         status        = ucp_worker_address_pack(worker, address_flags,
+                                                address_device_name,
                                                 &attr->address_length,
                                                 (void**)&attr->address);
     }
@@ -3434,7 +3451,7 @@ ucs_status_t ucp_worker_get_address(ucp_worker_h worker,
 
     UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(worker);
 
-    status = ucp_worker_address_pack(worker, 0, address_length_p,
+    status = ucp_worker_address_pack(worker, 0, NULL, address_length_p,
                                      (void**)address_p);
 
     UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(worker);

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -834,6 +834,12 @@ public:
         }
     }
 
+    static uint64_t iface_can_connect(const uct_iface_attr_t *attrs)
+    {
+        return attrs->cap.flags &
+               (UCT_IFACE_FLAG_CONNECT_TO_IFACE | UCT_IFACE_FLAG_CONNECT_TO_EP);
+    }
+
     static void get_test_variants(std::vector<ucp_test_variant> &variants)
     {
         add_variant_with_value(variants, UCP_FEATURE_TAG, 0, "");
@@ -869,8 +875,8 @@ UCS_TEST_P(test_ucp_worker_address_query, query_address_by_device)
     ucp_rsc_index_t tl_id;
 
     UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &context->tl_bitmap) {
-        if (ucp_worker_iface_can_connect(
-                    ucp_worker_iface_get_attr(sender().worker(), tl_id))) {
+        if (iface_can_connect(ucp_worker_iface_get_attr(sender().worker(),
+                                                        tl_id))) {
             address_device_name = context->tl_rscs[tl_id].tl_rsc.dev_name;
             break;
         }
@@ -881,8 +887,8 @@ UCS_TEST_P(test_ucp_worker_address_query, query_address_by_device)
     ASSERT_FALSE(UCS_STATIC_BITMAP_IS_ZERO(tl_bitmap));
 
     UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &tl_bitmap) {
-        if (ucp_worker_iface_can_connect(
-                    ucp_worker_iface_get_attr(sender().worker(), tl_id))) {
+        if (iface_can_connect(ucp_worker_iface_get_attr(sender().worker(),
+                                                        tl_id))) {
             ++expected_count;
         }
     }

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -860,6 +860,86 @@ UCS_TEST_P(test_ucp_worker_address_query, query)
     ucp_worker_release_address(sender().worker(), worker_attr.address);
 }
 
+UCS_TEST_P(test_ucp_worker_address_query, query_address_by_device)
+{
+    ucp_context_h context             = sender().worker()->context;
+    const char *address_device_name   = NULL;
+    unsigned expected_count          = 0;
+    ucp_tl_bitmap_t tl_bitmap;
+    ucp_rsc_index_t tl_id;
+
+    UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &context->tl_bitmap) {
+        if (ucp_worker_iface_can_connect(
+                    ucp_worker_iface_get_attr(sender().worker(), tl_id))) {
+            address_device_name = context->tl_rscs[tl_id].tl_rsc.dev_name;
+            break;
+        }
+    }
+
+    ASSERT_TRUE(address_device_name != NULL);
+    ucp_context_dev_tl_bitmap(context, address_device_name, &tl_bitmap);
+    ASSERT_FALSE(UCS_STATIC_BITMAP_IS_ZERO(tl_bitmap));
+
+    UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &tl_bitmap) {
+        if (ucp_worker_iface_can_connect(
+                    ucp_worker_iface_get_attr(sender().worker(), tl_id))) {
+            ++expected_count;
+        }
+    }
+
+    ASSERT_GT(expected_count, 0u);
+
+    ucp_worker_attr_t worker_attr = {};
+    worker_attr.field_mask          = UCP_WORKER_ATTR_FIELD_ADDRESS |
+                                      UCP_WORKER_ATTR_FIELD_ADDRESS_DEVICE_NAME;
+    worker_attr.address_device_name = address_device_name;
+    ucs_status_t status             = ucp_worker_query(sender().worker(),
+                                                       &worker_attr);
+    ASSERT_UCS_OK(status);
+    ASSERT_TRUE(worker_attr.address != NULL);
+
+    ucp_unpacked_address_t unpacked_address;
+    status = ucp_address_unpack(sender().worker(), worker_attr.address,
+                                ucp_worker_default_address_pack_flags(
+                                        sender().worker()),
+                                &unpacked_address);
+    ASSERT_UCS_OK(status);
+    EXPECT_EQ(expected_count, unpacked_address.address_count);
+
+    const ucp_address_entry_t *ae;
+    ucp_unpacked_address_for_each(ae, &unpacked_address) {
+        bool found = false;
+
+        UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &tl_bitmap) {
+            const ucp_tl_resource_desc_t *resource =
+                    &context->tl_rscs[tl_id];
+
+            if ((resource->md_index == ae->md_index) &&
+                (resource->tl_name_csum == ae->tl_name_csum)) {
+                found = true;
+                break;
+            }
+        }
+
+        EXPECT_TRUE(found);
+    }
+
+    ucs_free(unpacked_address.address_list);
+    ucp_worker_release_address(sender().worker(), worker_attr.address);
+}
+
+UCS_TEST_P(test_ucp_worker_address_query, query_address_unknown_device)
+{
+    ucp_worker_attr_t worker_attr = {};
+    worker_attr.field_mask          = UCP_WORKER_ATTR_FIELD_ADDRESS |
+                                      UCP_WORKER_ATTR_FIELD_ADDRESS_DEVICE_NAME;
+    worker_attr.address_device_name = "no-such-ucx-device";
+    ucs_status_t status             = ucp_worker_query(sender().worker(),
+                                                       &worker_attr);
+
+    EXPECT_EQ(UCS_ERR_NO_DEVICE, status);
+}
+
 UCP_INSTANTIATE_TEST_CASE(test_ucp_worker_address_query)
 
 class test_ucp_worker_address_version : public ucp_test {

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -881,11 +881,11 @@ public:
     void check_address_by_device(const std::string &address_device_name,
                                  const uint32_t address_flags)
     {
-        const auto worker  = sender().worker();
-        const auto context = worker->context;
+        const auto worker                        = sender().worker();
+        const auto context                       = worker->context;
+        const ucp_address_entry_t *address_entry = nullptr;
         ucp_worker_attr_t worker_attr{};
         ucp_unpacked_address_t unpacked_address{};
-        const ucp_address_entry_t *address_entry = nullptr;
         ucp_tl_bitmap_t tl_bitmap;
         ucp_rsc_index_t tl_id;
         ucs_status_t status;
@@ -914,7 +914,9 @@ public:
 
         status = ucp_worker_query(worker, &worker_attr);
         ASSERT_UCS_OK(status);
-        ASSERT_NE(nullptr, worker_attr.address);
+        if (worker_attr.address == nullptr) {
+            UCS_TEST_ABORT("ucp_worker_query() returned a null address");
+        }
 
         status = ucp_address_unpack(worker, worker_attr.address,
                                     ucp_worker_default_address_pack_flags(
@@ -992,7 +994,7 @@ UCS_TEST_P(test_ucp_worker_address_query, query_address_by_device_net_only)
                             UCP_WORKER_ADDRESS_FLAG_NET_ONLY);
 }
 
-UCS_TEST_P(test_ucp_worker_address_query, query_address_by_intersection)
+UCS_TEST_P(test_ucp_worker_address_query, empty_intersection)
 {
     const auto address_device_name =
             find_address_device(address_device_type::non_net);

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -8,6 +8,7 @@
 #include <uct/api/uct.h>
 #include <uct/api/tl.h>
 #include <fenv.h>
+#include <string>
 
 extern "C" {
 #include <ucp/core/ucp_worker.h>
@@ -827,11 +828,148 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_worker_thread_mode, all, "all")
 
 class test_ucp_worker_address_query : public ucp_test {
 public:
+    enum class address_device_type {
+        any,
+        net,
+        non_net
+    };
+
     test_ucp_worker_address_query()
     {
         if (get_variant_value(0)) {
             modify_config("UNIFIED_MODE", "y");
         }
+    }
+
+    static bool iface_can_connect(const uct_iface_attr_t &attrs)
+    {
+        return (attrs.cap.flags & (UCT_IFACE_FLAG_CONNECT_TO_IFACE |
+                                   UCT_IFACE_FLAG_CONNECT_TO_EP)) != 0;
+    }
+
+    static bool iface_matches_address_flags(const uct_iface_attr_t &iface_attr,
+                                            const uint32_t address_flags)
+    {
+        return iface_can_connect(iface_attr) &&
+               (((address_flags & UCP_WORKER_ADDRESS_FLAG_NET_ONLY) == 0) ||
+                ((iface_attr.cap.flags & UCT_IFACE_FLAG_INTER_NODE) != 0));
+    }
+
+    std::string find_address_device(const address_device_type device_type)
+    {
+        const auto worker  = sender().worker();
+        const auto context = worker->context;
+        ucp_tl_bitmap_t tl_bitmap;
+        ucp_rsc_index_t tl_id, dev_tl_id;
+
+        UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &context->tl_bitmap) {
+            const auto &iface_attr =
+                    *ucp_worker_iface_get_attr(worker, tl_id);
+            if (!iface_can_connect(iface_attr)) {
+                continue;
+            }
+
+            const auto device_name = std::string{
+                    context->tl_rscs[tl_id].tl_rsc.dev_name};
+            if (device_type == address_device_type::any) {
+                return device_name;
+            }
+
+            auto has_network_resource             = false;
+            auto has_addressable_network_resource = false;
+            ucp_context_dev_tl_bitmap(context, device_name.c_str(),
+                                      &tl_bitmap);
+            UCS_STATIC_BITMAP_FOR_EACH_BIT(dev_tl_id, &tl_bitmap) {
+                const auto &device_iface_attr =
+                        *ucp_worker_iface_get_attr(worker, dev_tl_id);
+
+                if ((device_iface_attr.cap.flags &
+                     UCT_IFACE_FLAG_INTER_NODE) != 0) {
+                    has_network_resource = true;
+                    has_addressable_network_resource =
+                            has_addressable_network_resource ||
+                            iface_can_connect(device_iface_attr);
+                }
+            }
+
+            if (((device_type == address_device_type::net) &&
+                 has_addressable_network_resource) ||
+                ((device_type == address_device_type::non_net) &&
+                 !has_network_resource)) {
+                return device_name;
+            }
+        }
+
+        return {};
+    }
+
+    void check_address_by_device(const std::string &address_device_name,
+                                 const uint32_t address_flags)
+    {
+        const auto worker   = sender().worker();
+        const auto context  = worker->context;
+        auto expected_count = 0u;
+        ucp_tl_bitmap_t tl_bitmap;
+        ucp_rsc_index_t tl_id;
+
+        ucp_context_dev_tl_bitmap(context, address_device_name.c_str(),
+                                  &tl_bitmap);
+        ASSERT_FALSE(UCS_STATIC_BITMAP_IS_ZERO(tl_bitmap));
+
+        UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &tl_bitmap) {
+            const auto &iface_attr =
+                    *ucp_worker_iface_get_attr(worker, tl_id);
+
+            if (iface_matches_address_flags(iface_attr, address_flags)) {
+                ++expected_count;
+            }
+        }
+
+        ASSERT_GT(expected_count, 0u);
+
+        ucp_worker_attr_t worker_attr{};
+        worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_ADDRESS |
+                                 UCP_WORKER_ATTR_FIELD_ADDRESS_DEVICE_NAME;
+        if (address_flags != 0) {
+            worker_attr.field_mask    |= UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS;
+            worker_attr.address_flags  = address_flags;
+        }
+
+        worker_attr.address_device_name = address_device_name.c_str();
+        auto status = ucp_worker_query(worker, &worker_attr);
+        ASSERT_UCS_OK(status);
+        ASSERT_NE(nullptr, worker_attr.address);
+
+        ucp_unpacked_address_t unpacked_address{};
+        status = ucp_address_unpack(worker, worker_attr.address,
+                                    ucp_worker_default_address_pack_flags(
+                                            worker),
+                                    &unpacked_address);
+        ASSERT_UCS_OK(status);
+        EXPECT_EQ(expected_count, unpacked_address.address_count);
+
+        const ucp_address_entry_t *address_entry = nullptr;
+        ucp_unpacked_address_for_each(address_entry, &unpacked_address) {
+            auto found = false;
+
+            UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &tl_bitmap) {
+                const auto &resource   = context->tl_rscs[tl_id];
+                const auto &iface_attr =
+                        *ucp_worker_iface_get_attr(worker, tl_id);
+
+                if (iface_matches_address_flags(iface_attr, address_flags) &&
+                    (resource.md_index == address_entry->md_index) &&
+                    (resource.tl_name_csum == address_entry->tl_name_csum)) {
+                    found = true;
+                    break;
+                }
+            }
+
+            EXPECT_TRUE(found);
+        }
+
+        ucs_free(unpacked_address.address_list);
+        ucp_worker_release_address(worker, worker_attr.address);
     }
 
     static void get_test_variants(std::vector<ucp_test_variant> &variants)
@@ -843,14 +981,14 @@ public:
 
 UCS_TEST_P(test_ucp_worker_address_query, query)
 {
-    ucp_worker_attr_t worker_attr = {};
+    ucp_worker_attr_t worker_attr{};
 
     worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_ADDRESS;
-    ucs_status_t status    = ucp_worker_query(sender().worker(), &worker_attr);
+    auto status = ucp_worker_query(sender().worker(), &worker_attr);
     ASSERT_EQ(UCS_OK, status);
-    ASSERT_TRUE(worker_attr.address != NULL);
+    ASSERT_NE(nullptr, worker_attr.address);
 
-    ucp_worker_address_attr_t address_attr = {};
+    ucp_worker_address_attr_t address_attr{};
     address_attr.field_mask = UCP_WORKER_ADDRESS_ATTR_FIELD_UID;
     status                  = ucp_worker_address_query(worker_attr.address,
                                                        &address_attr);
@@ -858,6 +996,60 @@ UCS_TEST_P(test_ucp_worker_address_query, query)
 
     EXPECT_EQ(sender().worker()->uuid, address_attr.worker_uid);
     ucp_worker_release_address(sender().worker(), worker_attr.address);
+}
+
+UCS_TEST_P(test_ucp_worker_address_query, query_address_by_device)
+{
+    const auto address_device_name =
+            find_address_device(address_device_type::any);
+
+    ASSERT_FALSE(address_device_name.empty());
+    check_address_by_device(address_device_name, 0);
+}
+
+UCS_TEST_P(test_ucp_worker_address_query, query_address_by_device_net_only)
+{
+    const auto address_device_name =
+            find_address_device(address_device_type::net);
+
+    if (address_device_name.empty()) {
+        UCS_TEST_SKIP_R("no network device");
+    }
+
+    check_address_by_device(address_device_name,
+                            UCP_WORKER_ADDRESS_FLAG_NET_ONLY);
+}
+
+UCS_TEST_P(test_ucp_worker_address_query,
+           query_address_by_non_net_device_net_only)
+{
+    const auto address_device_name =
+            find_address_device(address_device_type::non_net);
+
+    if (address_device_name.empty()) {
+        UCS_TEST_SKIP_R("no non-network device");
+    }
+
+    ucp_worker_attr_t worker_attr{};
+    worker_attr.field_mask          = UCP_WORKER_ATTR_FIELD_ADDRESS |
+                                      UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS |
+                                      UCP_WORKER_ATTR_FIELD_ADDRESS_DEVICE_NAME;
+    worker_attr.address_flags       = UCP_WORKER_ADDRESS_FLAG_NET_ONLY;
+    worker_attr.address_device_name = address_device_name.c_str();
+
+    EXPECT_EQ(UCS_ERR_NO_DEVICE,
+              ucp_worker_query(sender().worker(), &worker_attr));
+}
+
+UCS_TEST_P(test_ucp_worker_address_query, query_address_unknown_device)
+{
+    ucp_worker_attr_t worker_attr{};
+    worker_attr.field_mask          = UCP_WORKER_ATTR_FIELD_ADDRESS |
+                                      UCP_WORKER_ATTR_FIELD_ADDRESS_DEVICE_NAME;
+    worker_attr.address_device_name = "no-such-ucx-device";
+    const auto status = ucp_worker_query(sender().worker(), &worker_attr);
+
+    EXPECT_EQ(UCS_ERR_NO_DEVICE, status);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_worker_address_query)

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -828,12 +828,6 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_worker_thread_mode, all, "all")
 
 class test_ucp_worker_address_query : public ucp_test {
 public:
-    enum class address_device_type {
-        any,
-        net,
-        non_net
-    };
-
     test_ucp_worker_address_query()
     {
         if (get_variant_value(0)) {
@@ -841,19 +835,18 @@ public:
         }
     }
 
-    static bool iface_can_connect(const uct_iface_attr_t &attrs)
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
     {
-        return (attrs.cap.flags & (UCT_IFACE_FLAG_CONNECT_TO_IFACE |
-                                   UCT_IFACE_FLAG_CONNECT_TO_EP)) != 0;
+        add_variant_with_value(variants, UCP_FEATURE_TAG, 0, "");
+        add_variant_with_value(variants, UCP_FEATURE_TAG, 1, "unified");
     }
 
-    static bool iface_matches_address_flags(const uct_iface_attr_t &iface_attr,
-                                            const uint32_t address_flags)
-    {
-        return iface_can_connect(iface_attr) &&
-               (((address_flags & UCP_WORKER_ADDRESS_FLAG_NET_ONLY) == 0) ||
-                ((iface_attr.cap.flags & UCT_IFACE_FLAG_INTER_NODE) != 0));
-    }
+protected:
+    enum class address_device_type {
+        any,
+        net,
+        non_net
+    };
 
     std::string find_address_device(const address_device_type device_type)
     {
@@ -863,10 +856,9 @@ public:
 
         UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &context->tl_bitmap) {
             const auto &resource   = context->tl_rscs[tl_id].tl_rsc;
-            const auto &iface_attr =
-                    *ucp_worker_iface_get_attr(worker, tl_id);
-            const auto is_network  =
-                    (iface_attr.cap.flags & UCT_IFACE_FLAG_INTER_NODE) != 0;
+            const auto &iface_attr = *ucp_worker_iface_get_attr(worker, tl_id);
+            const auto is_network  = (iface_attr.cap.flags &
+                                      UCT_IFACE_FLAG_INTER_NODE) != 0;
 
             if (iface_can_connect(iface_attr) &&
                 ((device_type == address_device_type::any) ||
@@ -893,8 +885,7 @@ public:
         ucp_context_dev_tl_bitmap(context, address_device_name.c_str(),
                                   &tl_bitmap);
         UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &tl_bitmap) {
-            const auto &iface_attr =
-                    *ucp_worker_iface_get_attr(worker, tl_id);
+            const auto &iface_attr = *ucp_worker_iface_get_attr(worker, tl_id);
 
             if (!iface_matches_address_flags(iface_attr, address_flags)) {
                 UCS_STATIC_BITMAP_RESET(&tl_bitmap, tl_id);
@@ -906,8 +897,8 @@ public:
         worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_ADDRESS |
                                  UCP_WORKER_ATTR_FIELD_ADDRESS_DEVICE_NAME;
         if (address_flags != 0) {
-            worker_attr.field_mask    |= UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS;
-            worker_attr.address_flags  = address_flags;
+            worker_attr.field_mask   |= UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS;
+            worker_attr.address_flags = address_flags;
         }
 
         worker_attr.address_device_name = address_device_name.c_str();
@@ -946,10 +937,19 @@ public:
         ucp_worker_release_address(worker, worker_attr.address);
     }
 
-    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+private:
+    static bool iface_can_connect(const uct_iface_attr_t &attrs)
     {
-        add_variant_with_value(variants, UCP_FEATURE_TAG, 0, "");
-        add_variant_with_value(variants, UCP_FEATURE_TAG, 1, "unified");
+        return (attrs.cap.flags & (UCT_IFACE_FLAG_CONNECT_TO_IFACE |
+                                   UCT_IFACE_FLAG_CONNECT_TO_EP)) != 0;
+    }
+
+    static bool iface_matches_address_flags(const uct_iface_attr_t &iface_attr,
+                                            const uint32_t address_flags)
+    {
+        return iface_can_connect(iface_attr) &&
+               (((address_flags & UCP_WORKER_ADDRESS_FLAG_NET_ONLY) == 0) ||
+                ((iface_attr.cap.flags & UCT_IFACE_FLAG_INTER_NODE) != 0));
     }
 };
 
@@ -974,8 +974,8 @@ UCS_TEST_P(test_ucp_worker_address_query, query)
 
 UCS_TEST_P(test_ucp_worker_address_query, query_address_by_device)
 {
-    const auto address_device_name =
-            find_address_device(address_device_type::any);
+    const auto address_device_name = find_address_device(
+            address_device_type::any);
 
     ASSERT_FALSE(address_device_name.empty());
     check_address_by_device(address_device_name, 0);
@@ -983,8 +983,8 @@ UCS_TEST_P(test_ucp_worker_address_query, query_address_by_device)
 
 UCS_TEST_P(test_ucp_worker_address_query, query_address_by_device_net_only)
 {
-    const auto address_device_name =
-            find_address_device(address_device_type::net);
+    const auto address_device_name = find_address_device(
+            address_device_type::net);
 
     if (address_device_name.empty()) {
         UCS_TEST_SKIP_R("no network device");
@@ -996,8 +996,8 @@ UCS_TEST_P(test_ucp_worker_address_query, query_address_by_device_net_only)
 
 UCS_TEST_P(test_ucp_worker_address_query, empty_intersection)
 {
-    const auto address_device_name =
-            find_address_device(address_device_type::non_net);
+    const auto address_device_name = find_address_device(
+            address_device_type::non_net);
     scoped_log_handler wrap_err(wrap_errors_logger);
     ucp_worker_attr_t worker_attr;
 

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -859,44 +859,19 @@ public:
     {
         const auto worker  = sender().worker();
         const auto context = worker->context;
-        ucp_tl_bitmap_t tl_bitmap;
-        ucp_rsc_index_t tl_id, dev_tl_id;
+        ucp_rsc_index_t tl_id;
 
         UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &context->tl_bitmap) {
+            const auto &resource   = context->tl_rscs[tl_id].tl_rsc;
             const auto &iface_attr =
                     *ucp_worker_iface_get_attr(worker, tl_id);
-            if (!iface_can_connect(iface_attr)) {
-                continue;
-            }
+            const auto is_network  =
+                    (iface_attr.cap.flags & UCT_IFACE_FLAG_INTER_NODE) != 0;
 
-            const auto device_name = std::string{
-                    context->tl_rscs[tl_id].tl_rsc.dev_name};
-            if (device_type == address_device_type::any) {
-                return device_name;
-            }
-
-            auto has_network_resource             = false;
-            auto has_addressable_network_resource = false;
-            ucp_context_dev_tl_bitmap(context, device_name.c_str(),
-                                      &tl_bitmap);
-            UCS_STATIC_BITMAP_FOR_EACH_BIT(dev_tl_id, &tl_bitmap) {
-                const auto &device_iface_attr =
-                        *ucp_worker_iface_get_attr(worker, dev_tl_id);
-
-                if ((device_iface_attr.cap.flags &
-                     UCT_IFACE_FLAG_INTER_NODE) != 0) {
-                    has_network_resource = true;
-                    has_addressable_network_resource =
-                            has_addressable_network_resource ||
-                            iface_can_connect(device_iface_attr);
-                }
-            }
-
-            if (((device_type == address_device_type::net) &&
-                 has_addressable_network_resource) ||
-                ((device_type == address_device_type::non_net) &&
-                 !has_network_resource)) {
-                return device_name;
+            if (iface_can_connect(iface_attr) &&
+                ((device_type == address_device_type::any) ||
+                 ((device_type == address_device_type::net) == is_network))) {
+                return resource.dev_name;
             }
         }
 
@@ -906,28 +881,28 @@ public:
     void check_address_by_device(const std::string &address_device_name,
                                  const uint32_t address_flags)
     {
-        const auto worker   = sender().worker();
-        const auto context  = worker->context;
-        auto expected_count = 0u;
+        const auto worker  = sender().worker();
+        const auto context = worker->context;
+        ucp_worker_attr_t worker_attr{};
+        ucp_unpacked_address_t unpacked_address{};
+        const ucp_address_entry_t *address_entry = nullptr;
         ucp_tl_bitmap_t tl_bitmap;
         ucp_rsc_index_t tl_id;
+        ucs_status_t status;
 
         ucp_context_dev_tl_bitmap(context, address_device_name.c_str(),
                                   &tl_bitmap);
-        ASSERT_FALSE(UCS_STATIC_BITMAP_IS_ZERO(tl_bitmap));
-
         UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &tl_bitmap) {
             const auto &iface_attr =
                     *ucp_worker_iface_get_attr(worker, tl_id);
 
-            if (iface_matches_address_flags(iface_attr, address_flags)) {
-                ++expected_count;
+            if (!iface_matches_address_flags(iface_attr, address_flags)) {
+                UCS_STATIC_BITMAP_RESET(&tl_bitmap, tl_id);
             }
         }
 
-        ASSERT_GT(expected_count, 0u);
+        ASSERT_FALSE(UCS_STATIC_BITMAP_IS_ZERO(tl_bitmap));
 
-        ucp_worker_attr_t worker_attr{};
         worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_ADDRESS |
                                  UCP_WORKER_ATTR_FIELD_ADDRESS_DEVICE_NAME;
         if (address_flags != 0) {
@@ -936,29 +911,26 @@ public:
         }
 
         worker_attr.address_device_name = address_device_name.c_str();
-        auto status = ucp_worker_query(worker, &worker_attr);
+
+        status = ucp_worker_query(worker, &worker_attr);
         ASSERT_UCS_OK(status);
         ASSERT_NE(nullptr, worker_attr.address);
 
-        ucp_unpacked_address_t unpacked_address{};
         status = ucp_address_unpack(worker, worker_attr.address,
                                     ucp_worker_default_address_pack_flags(
                                             worker),
                                     &unpacked_address);
         ASSERT_UCS_OK(status);
-        EXPECT_EQ(expected_count, unpacked_address.address_count);
+        EXPECT_EQ(UCS_STATIC_BITMAP_POPCOUNT(tl_bitmap),
+                  unpacked_address.address_count);
 
-        const ucp_address_entry_t *address_entry = nullptr;
         ucp_unpacked_address_for_each(address_entry, &unpacked_address) {
             auto found = false;
 
             UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &tl_bitmap) {
-                const auto &resource   = context->tl_rscs[tl_id];
-                const auto &iface_attr =
-                        *ucp_worker_iface_get_attr(worker, tl_id);
+                const auto &resource = context->tl_rscs[tl_id];
 
-                if (iface_matches_address_flags(iface_attr, address_flags) &&
-                    (resource.md_index == address_entry->md_index) &&
+                if ((resource.md_index == address_entry->md_index) &&
                     (resource.tl_name_csum == address_entry->tl_name_csum)) {
                     found = true;
                     break;
@@ -981,14 +953,14 @@ public:
 
 UCS_TEST_P(test_ucp_worker_address_query, query)
 {
-    ucp_worker_attr_t worker_attr{};
+    ucp_worker_attr_t worker_attr = {};
 
     worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_ADDRESS;
-    auto status = ucp_worker_query(sender().worker(), &worker_attr);
+    ucs_status_t status    = ucp_worker_query(sender().worker(), &worker_attr);
     ASSERT_EQ(UCS_OK, status);
-    ASSERT_NE(nullptr, worker_attr.address);
+    ASSERT_TRUE(worker_attr.address != NULL);
 
-    ucp_worker_address_attr_t address_attr{};
+    ucp_worker_address_attr_t address_attr = {};
     address_attr.field_mask = UCP_WORKER_ADDRESS_ATTR_FIELD_UID;
     status                  = ucp_worker_address_query(worker_attr.address,
                                                        &address_attr);
@@ -1020,8 +992,7 @@ UCS_TEST_P(test_ucp_worker_address_query, query_address_by_device_net_only)
                             UCP_WORKER_ADDRESS_FLAG_NET_ONLY);
 }
 
-UCS_TEST_P(test_ucp_worker_address_query,
-           query_address_by_non_net_device_net_only)
+UCS_TEST_P(test_ucp_worker_address_query, query_address_by_intersection)
 {
     const auto address_device_name =
             find_address_device(address_device_type::non_net);

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -857,8 +857,8 @@ public:
 
     std::string find_address_device(const address_device_type device_type)
     {
-        const auto worker  = sender().worker();
-        const auto context = worker->context;
+        ucp_worker_h worker   = sender().worker();
+        ucp_context_h context = worker->context;
         ucp_rsc_index_t tl_id;
 
         UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, &context->tl_bitmap) {
@@ -881,8 +881,8 @@ public:
     void check_address_by_device(const std::string &address_device_name,
                                  const uint32_t address_flags)
     {
-        const auto worker                        = sender().worker();
-        const auto context                       = worker->context;
+        ucp_worker_h worker                      = sender().worker();
+        ucp_context_h context                    = worker->context;
         const ucp_address_entry_t *address_entry = nullptr;
         ucp_worker_attr_t worker_attr{};
         ucp_unpacked_address_t unpacked_address{};
@@ -998,12 +998,13 @@ UCS_TEST_P(test_ucp_worker_address_query, empty_intersection)
 {
     const auto address_device_name =
             find_address_device(address_device_type::non_net);
+    scoped_log_handler wrap_err(wrap_errors_logger);
+    ucp_worker_attr_t worker_attr;
 
     if (address_device_name.empty()) {
         UCS_TEST_SKIP_R("no non-network device");
     }
 
-    ucp_worker_attr_t worker_attr{};
     worker_attr.field_mask          = UCP_WORKER_ATTR_FIELD_ADDRESS |
                                       UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS |
                                       UCP_WORKER_ATTR_FIELD_ADDRESS_DEVICE_NAME;
@@ -1016,7 +1017,9 @@ UCS_TEST_P(test_ucp_worker_address_query, empty_intersection)
 
 UCS_TEST_P(test_ucp_worker_address_query, query_address_unknown_device)
 {
-    ucp_worker_attr_t worker_attr{};
+    scoped_log_handler wrap_err(wrap_errors_logger);
+    ucp_worker_attr_t worker_attr;
+
     worker_attr.field_mask          = UCP_WORKER_ATTR_FIELD_ADDRESS |
                                       UCP_WORKER_ATTR_FIELD_ADDRESS_DEVICE_NAME;
     worker_attr.address_device_name = "no-such-ucx-device";


### PR DESCRIPTION
## What
Add an optional `address_device_name` input field to `ucp_worker_attr_t` and a matching `UCP_WORKER_ATTR_FIELD_ADDRESS_DEVICE_NAME` field mask.

When `ucp_worker_query()` is asked for a worker address with this field set, UCP packs only resources whose context device name matches the requested device. Requests for a device with no addressable worker resources return `UCS_ERR_NO_DEVICE`.

## Why
Some users need to exchange a worker address for a specific network device instead of all resources opened by the worker. This lets applications reduce address payload size and control which device is exposed during out-of-band address exchange.