### PR TITLE
NEWS: Document JUCX package rename

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -118,6 +118,9 @@
  * Replaced ofed_info usage with native package-manager queries
  * Fixed CI build result reporting on exceptions
  * Excluded .ci/ changes from PR pipeline triggers
+### Known issues:
+ * JUCX package for this release was renamed to
+   `1.22.0-1`, please avoid using `1.22.0`.
 
 ## 1.21.0 (June 24, 2026)
 ### Features:


### PR DESCRIPTION
## What
Adds a v1.22.0 known issue note that the JUCX package for this release was renamed to `1.22.0-1`, and asks users to avoid `1.22.0`.

## Why
The original JUCX package for v1.22.0 was published from the RC1 tag, so the release notes should direct Java users to the replacement package.