### PR TITLE
UCT/CMA: Avoid stack address in reachability probe

### DIFF
--- a/src/uct/sm/scopy/cma/cma_iface.c
+++ b/src/uct/sm/scopy/cma/cma_iface.c
@@ -62,7 +62,7 @@ uct_cma_iface_is_reachable_v2(const uct_iface_h tl_iface,
                               const uct_iface_is_reachable_params_t *params)
 {
     struct iovec iov = {
-        .iov_base = &iov,
+        .iov_base = NULL,
         .iov_len  = sizeof(iov),
     };
     ucs_cma_iface_ext_device_addr_t *iface_addr;


### PR DESCRIPTION
## What
Change the CMA reachability probe to use a NULL probe address instead of a stack-local iovec address.

## Why
The existing probe passes the local stack address as the remote address to process_vm_readv(). When that address lands just below the peer stack VMA, the kernel can emit a `GUP no longer grows the stack` warning while handling the failed probe.

Using NULL still exercises the CMA permission path without presenting a stack-adjacent remote address to the kernel.

Fixes #11654