### PR TITLE
UCP/AMO/SW: Add non-fetching SWAP to software atomic post handler

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Alex Mikheev <alexm@mellanox.com>
 Alexey Rivkin <arivkin@nvidia.com>
 Alina Sklarevich <alinas@mellanox.com>
 Alma Mastbaum <amastbaum@nvidia.com>
+Amit Kumar <a.k@amd.com>
 Anatoly Vildemanov <anatolyv@nvidia.com>
 Andrey Maslennikov <andreyma@mellanox.com>
 Arnaud Celermajer <acelermajer@nvidia.com>

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -177,6 +177,9 @@ static ucs_status_t ucp_progress_atomic_reply(uct_pending_req_t *self)
         case UCT_ATOMIC_OP_XOR: \
             ucs_atomic_xor##_bits(ptr, args[0]); \
             break; \
+        case UCT_ATOMIC_OP_SWAP: \
+            (void)ucs_atomic_swap##_bits(ptr, args[0]); \
+            break; \
         default: \
             ucs_fatal("invalid opcode: %d", atomicreqh->opcode); \
         } \


### PR DESCRIPTION
  ## What?

  Add `UCT_ATOMIC_OP_SWAP` to the software AMO non-fetching handler (`ucp_amo_sw_do_op` in `amo_sw.c`). The handler implements ADD, AND, OR, and XOR but is missing SWAP, causing a `ucs_fatal("invalid opcode: 4")`  on the receiver when a non-fetching SWAP request arrives.

  ## Why?

  OpenMPI v6.0.x `shmem_atomic_set` maps to a non-fetching `UCP_ATOMIC_OP_SWAP` (opcode 4). Since `ucp_amo_sw_do_op` has no SWAP case, any peer using the software AMO path (e.g. UD verbs) aborts with:

      amo_sw.c:216 Fatal: invalid opcode: 4

  A non-fetching SWAP is well-defined: write the new value atomically and discard the old value. `ucs_atomic_swap` (`lock xchg`) already exists and is used by the fetching handler (`ucp_amo_sw_do_fop`). The non-fetching handler simply discards the return value, consistent with  how other non-fetching ops (ADD, AND, OR, XOR) work.

  Reproducer: OpenMPI v6.0.x + UCX, run `osu_oshm_atomics` with `UCX_TLS=rc_verbs,ud_verbs` — `shmem_int_set` / `shmem_longlong_set` crash. With this fix, the benchmark completes cleanly.
