### PR TITLE
UCT/CUDA/CUDA_IPC: Unmap memory handle at ucp_device_mem_list_release.

### DIFF
--- a/src/ucp/core/ucp_device.c
+++ b/src/ucp/core/ucp_device.c
@@ -23,10 +23,18 @@
 #include "ucp_ep.inl"
 #include "ucp_mm.inl"
 
+typedef struct {
+    uct_md_h md;
+    void     *release_handle;
+} ucp_device_mem_elem_release_handle_t;
+
+UCS_ARRAY_DECLARE_TYPE(ucp_device_mem_elem_release_handles_t, unsigned,
+                       ucp_device_mem_elem_release_handle_t);
 
 typedef struct {
-    uct_allocated_memory_t mem;
-    uint32_t               mem_list_length;
+    uct_allocated_memory_t                mem;
+    uint32_t                              mem_list_length;
+    ucp_device_mem_elem_release_handles_t release_handles;
 } ucp_device_handle_info_t;
 
 #define ucp_device_handle_hash_key(_handle) \
@@ -61,9 +69,40 @@ void ucp_device_cleanup(void)
     ucs_spinlock_destroy(&ucp_device_handle_hash_lock);
 }
 
-static ucs_status_t
-ucp_device_mem_handle_hash_insert(const uct_allocated_memory_t *mem_handle,
-                                  uint32_t mem_list_length)
+static ucs_status_t ucp_device_mem_elem_release_handles_append(
+        ucp_device_mem_elem_release_handles_t *release_handles, uct_md_h md,
+        void *release_handle)
+{
+    ucp_device_mem_elem_release_handle_t *it;
+
+    it     = ucs_array_append(release_handles, return UCS_ERR_NO_MEMORY);
+    it->md = md;
+    it->release_handle = release_handle;
+    return UCS_OK;
+}
+
+static void ucp_device_mem_elem_release_handles_cleanup(
+        ucp_device_mem_elem_release_handles_t *release_handles)
+{
+    ucp_device_mem_elem_release_handle_t *it;
+
+    /* Check buffer explicitly: Coverity issues FORWARD_NULL error;
+       ucs_array_is_empty is not enough as Coverity does not correlate
+       non-zero length with a non-NULL buffer after create_handle paths. */
+    if (ucs_array_begin(release_handles) == NULL) {
+        return;
+    }
+
+    ucs_array_for_each(it, release_handles) {
+        uct_md_mem_elem_release(it->md, it->release_handle);
+    }
+
+    ucs_array_cleanup_dynamic(release_handles);
+}
+
+static ucs_status_t ucp_device_mem_handle_hash_insert(
+        const uct_allocated_memory_t *mem_handle, uint32_t mem_list_length,
+        ucp_device_mem_elem_release_handles_t *release_handles)
 {
     ucs_status_t status;
     khiter_t iter;
@@ -72,6 +111,7 @@ ucp_device_mem_handle_hash_insert(const uct_allocated_memory_t *mem_handle,
 
     info.mem             = *mem_handle;
     info.mem_list_length = mem_list_length;
+    info.release_handles = *release_handles;
 
     ucs_spin_lock(&ucp_device_handle_hash_lock);
     iter = kh_put(ucp_device_handle_allocs, &ucp_device_handle_hash,
@@ -85,25 +125,27 @@ ucp_device_mem_handle_hash_insert(const uct_allocated_memory_t *mem_handle,
     } else {
         kh_value(&ucp_device_handle_hash, iter) = info;
         status                                  = UCS_OK;
+        /* Ownership of the array moved to the hash */
+        ucs_array_init_dynamic(release_handles);
     }
 
     ucs_spin_unlock(&ucp_device_handle_hash_lock);
     return status;
 }
 
-static uct_allocated_memory_t ucp_device_mem_handle_hash_remove(void *handle)
+static ucp_device_handle_info_t ucp_device_mem_handle_hash_remove(void *handle)
 {
     khiter_t iter;
-    uct_allocated_memory_t mem;
+    ucp_device_handle_info_t info;
 
     ucs_spin_lock(&ucp_device_handle_hash_lock);
     iter = kh_get(ucp_device_handle_allocs, &ucp_device_handle_hash, handle);
     ucs_assertv_always((iter != kh_end(&ucp_device_handle_hash)), "handle=%p",
                        handle);
-    mem = kh_value(&ucp_device_handle_hash, iter).mem;
+    info = kh_value(&ucp_device_handle_hash, iter);
     kh_del(ucp_device_handle_allocs, &ucp_device_handle_hash, iter);
     ucs_spin_unlock(&ucp_device_handle_hash_lock);
-    return mem;
+    return info;
 }
 
 static ucs_status_t
@@ -182,13 +224,15 @@ ucp_device_get_tl_bitmap(const ucp_worker_h worker,
 static ucs_status_t ucp_device_local_mem_list_element_pack(
         const ucp_worker_h worker, const ucp_worker_iface_t *wiface,
         const ucp_device_mem_list_elem_t *element,
-        const ucs_memory_type_t mem_type, uct_device_mem_elem_t *mem_element)
+        const ucs_memory_type_t mem_type, uct_device_mem_elem_t *mem_element,
+        ucp_device_mem_elem_release_handles_t *release_handles)
 {
     ucp_tl_resource_desc_t *resource;
     ucp_md_index_t md_index;
     ucp_mem_h memh;
     uct_mem_h uct_memh;
     ucp_tl_md_t *ucp_md;
+    void *release_handle;
     ucs_status_t status;
 
     if (wiface == NULL) {
@@ -207,11 +251,18 @@ static ucs_status_t ucp_device_local_mem_list_element_pack(
     }
 
     status = uct_md_mem_elem_pack(ucp_md->md, uct_memh, UCT_INVALID_RKEY,
-                                  mem_element);
+                                  mem_element, &release_handle);
     if (status != UCS_OK) {
         ucs_error("failed to pack local mem element for memh=%p", memh);
+        return status;
     }
 
+    status = ucp_device_mem_elem_release_handles_append(release_handles,
+                                                        ucp_md->md,
+                                                        release_handle);
+    if (status != UCS_OK) {
+        uct_md_mem_elem_release(ucp_md->md, release_handle);
+    }
     return status;
 }
 
@@ -240,7 +291,8 @@ static ucs_status_t ucp_device_mem_list_export_handle(
 
 static ucs_status_t ucp_device_local_mem_list_create_handle(
         const ucp_device_mem_list_params_t *params, ucs_memory_type_t mem_type,
-        uct_allocated_memory_t *mem, ucs_sys_device_t local_sys_dev)
+        ucs_sys_device_t local_sys_dev, uct_allocated_memory_t *mem,
+        ucp_device_mem_elem_release_handles_t *release_handles)
 {
     const ucp_worker_h worker   = UCS_PARAM_VALUE(
             UCP_DEVICE_MEM_LIST_PARAMS_FIELD, params, worker, WORKER, NULL);
@@ -283,7 +335,8 @@ static ucs_status_t ucp_device_local_mem_list_create_handle(
             status = ucp_device_local_mem_list_element_pack(worker, wiface,
                                                             ucp_element,
                                                             mem_type,
-                                                            tl_element);
+                                                            tl_element,
+                                                            release_handles);
             if (status != UCS_OK) {
                 ucs_error("failed to pack local mem list element for "
                           "element=%zu",
@@ -377,6 +430,8 @@ ucs_status_t
 ucp_device_local_mem_list_create(const ucp_device_mem_list_params_t *params,
                                  ucp_device_local_mem_list_h *mem_list_h)
 {
+    ucp_device_mem_elem_release_handles_t release_handles =
+            UCS_ARRAY_DYNAMIC_INITIALIZER;
     const ucp_worker_h worker = UCS_PARAM_VALUE(UCP_DEVICE_MEM_LIST_PARAMS_FIELD,
                                                params, worker, WORKER, NULL);
     ucs_memory_type_t export_mem_type;
@@ -405,21 +460,27 @@ ucp_device_local_mem_list_create(const ucp_device_mem_list_params_t *params,
     }
 
     status = ucp_device_local_mem_list_create_handle(params, export_mem_type,
-                                                     &mem, local_sys_dev);
+                                                     local_sys_dev, &mem,
+                                                     &release_handles);
     if (status != UCS_OK) {
         ucs_error("failed to create local mem list handle: %s",
                   ucs_status_string(status));
-        return status;
+        goto err;
     }
 
     /* Track memory allocator for later release */
-    status = ucp_device_mem_handle_hash_insert(&mem, params->num_elements);
+    status = ucp_device_mem_handle_hash_insert(&mem, params->num_elements,
+                                               &release_handles);
     if (status != UCS_OK) {
         uct_mem_free(&mem);
-    } else {
-        *mem_list_h = mem.address;
+        goto err;
     }
 
+    *mem_list_h = mem.address;
+    return UCS_OK;
+
+err:
+    ucp_device_mem_elem_release_handles_cleanup(&release_handles);
     return status;
 }
 
@@ -458,15 +519,18 @@ ucp_device_ep_check_lanes(const ucp_ep_h ep, ucp_tl_bitmap_t *tl_bitmap)
 
 static ucs_status_t ucp_device_remote_mem_list_element_pack(
         const ucp_device_mem_list_elem_t *element, ucp_rsc_index_t tl_id,
-        uct_device_remote_tl_elem_t *mem_element)
+        uct_device_remote_tl_elem_t *mem_element,
+        ucp_device_mem_elem_release_handles_t *release_handles)
 {
     const ucp_ep_h ep     = element->ep;
     const ucp_rkey_h rkey = element->rkey;
     ucp_ep_config_t *ep_config = ucp_ep_config(ep);
+    uct_md_h md;
     uint8_t rkey_index;
     uct_rkey_t uct_rkey;
     uct_ep_h uct_ep;
     uct_device_ep_h device_ep;
+    void *release_handle;
     ucs_status_t status;
     ucp_lane_index_t lane;
 
@@ -488,11 +552,19 @@ static ucs_status_t ucp_device_remote_mem_list_element_pack(
     uct_rkey   = ucp_rkey_get_tl_rkey(rkey, rkey_index);
     ucs_assert(uct_rkey != UCT_INVALID_RKEY);
 
+    md              = ucp_ep_md(ep, lane);
     mem_element->ep = device_ep;
-    status          = uct_md_mem_elem_pack(ucp_ep_md(ep, lane), NULL, uct_rkey,
-                                           &mem_element->uct);
+    status = uct_md_mem_elem_pack(md, NULL, uct_rkey, &mem_element->uct,
+                                  &release_handle);
     if (status != UCS_OK) {
         ucs_error("failed to pack uct memory element for lane=%u", lane);
+        return status;
+    }
+
+    status = ucp_device_mem_elem_release_handles_append(release_handles, md,
+                                                        release_handle);
+    if (status != UCS_OK) {
+        uct_md_mem_elem_release(md, release_handle);
     }
 
     return status;
@@ -532,10 +604,11 @@ static ucp_ep_h ucp_device_remote_mem_list_get_first_ep(
     return NULL;
 }
 
-static ucs_status_t
-ucp_device_remote_mem_list_fill(const ucp_device_mem_list_elem_t *ucp_element,
-                                ucp_tl_bitmap_t *tl_bitmap, size_t num_lanes,
-                                uct_device_remote_mem_elem_t *uct_element)
+static ucs_status_t ucp_device_remote_mem_list_fill(
+        const ucp_device_mem_list_elem_t *ucp_element,
+        const ucp_tl_bitmap_t *tl_bitmap, size_t num_lanes,
+        uct_device_remote_mem_elem_t *uct_element,
+        ucp_device_mem_elem_release_handles_t *release_handles)
 {
     uct_device_remote_tl_elem_t *tl_element;
     ucp_rsc_index_t tl_id;
@@ -547,7 +620,8 @@ ucp_device_remote_mem_list_fill(const ucp_device_mem_list_elem_t *ucp_element,
     for (i = 0; i < num_lanes;) {
         UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, tl_bitmap) {
             status = ucp_device_remote_mem_list_element_pack(ucp_element, tl_id,
-                                                             tl_element);
+                                                             tl_element,
+                                                             release_handles);
             if (status != UCS_OK) {
                 return status;
             }
@@ -561,9 +635,10 @@ ucp_device_remote_mem_list_fill(const ucp_device_mem_list_elem_t *ucp_element,
 }
 
 static ucs_status_t ucp_device_remote_mem_list_create_handle(
-        const ucp_device_mem_list_params_t *params, const ucp_ep_h ep,
-        const ucs_memory_type_t mem_type, uct_allocated_memory_t *mem,
-        const ucs_sys_device_t local_sys_dev)
+        const ucp_device_mem_list_params_t *params, ucp_ep_h ep,
+        ucs_memory_type_t mem_type, ucs_sys_device_t local_sys_dev,
+        uct_allocated_memory_t *mem,
+        ucp_device_mem_elem_release_handles_t *release_handles)
 {
     size_t uct_elem_size;
     size_t handle_size         = 0;
@@ -622,7 +697,8 @@ static ucs_status_t ucp_device_remote_mem_list_create_handle(
 
             status = ucp_device_remote_mem_list_fill(ucp_element,
                                                      &tl_bitmap[tl_type],
-                                                     num_lanes, uct_element);
+                                                     num_lanes, uct_element,
+                                                     release_handles);
             if (status != UCS_OK) {
                 goto out;
             }
@@ -698,7 +774,9 @@ ucs_status_t
 ucp_device_remote_mem_list_create(const ucp_device_mem_list_params_t *params,
                                   ucp_device_remote_mem_list_h *mem_list_h)
 {
-    const ucp_ep_h ep = ucp_device_remote_mem_list_get_first_ep(params);
+    ucp_ep_h ep = ucp_device_remote_mem_list_get_first_ep(params);
+    ucp_device_mem_elem_release_handles_t release_handles =
+            UCS_ARRAY_DYNAMIC_INITIALIZER;
     ucs_memory_type_t export_mem_type;
     ucs_sys_device_t sys_dev;
     uct_allocated_memory_t mem;
@@ -721,8 +799,8 @@ ucp_device_remote_mem_list_create(const ucp_device_mem_list_params_t *params,
     }
 
     status = ucp_device_remote_mem_list_create_handle(params, ep,
-                                                      export_mem_type,
-                                                      &mem, sys_dev);
+                                                      export_mem_type, sys_dev,
+                                                      &mem, &release_handles);
     if (status != UCS_OK) {
         /*
          * Do not log error for UCS_ERR_NOT_CONNECTED because it is expected
@@ -732,17 +810,22 @@ ucp_device_remote_mem_list_create(const ucp_device_mem_list_params_t *params,
         if (status != UCS_ERR_NOT_CONNECTED) {
             ucs_error("failed to create handle: %s", ucs_status_string(status));
         }
-        return status;
+        goto err;
     }
 
     /* Track memory allocator for later release */
-    status = ucp_device_mem_handle_hash_insert(&mem, params->num_elements);
+    status = ucp_device_mem_handle_hash_insert(&mem, params->num_elements,
+                                               &release_handles);
     if (status != UCS_OK) {
         uct_mem_free(&mem);
-    } else {
-        *mem_list_h = mem.address;
+        goto err;
     }
 
+    *mem_list_h = mem.address;
+    return UCS_OK;
+
+err:
+    ucp_device_mem_elem_release_handles_cleanup(&release_handles);
     return status;
 }
 
@@ -766,10 +849,11 @@ uint32_t ucp_device_get_mem_list_length(const void *mem_list_h)
 
 void ucp_device_mem_list_release(void *mem_list_h)
 {
-    uct_allocated_memory_t mem;
+    ucp_device_handle_info_t info;
 
-    mem = ucp_device_mem_handle_hash_remove(mem_list_h);
-    uct_mem_free(&mem);
+    info = ucp_device_mem_handle_hash_remove(mem_list_h);
+    ucp_device_mem_elem_release_handles_cleanup(&info.release_handles);
+    uct_mem_free(&info.mem);
 }
 
 static ucs_memory_type_t

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1535,15 +1535,28 @@ ucs_status_t uct_rkey_unpack_v2(uct_component_h component,
  * @ingroup UCT_MD
  * @brief Pack a memh and rkey into a device memory element structure.
  *
- * @param [in]  md           Memory domain.
- * @param [in]  memh         Memory handle to pack (can be NULL).
- * @param [in]  rkey         Remote key to pack (can be UCT_INVALID_RKEY).
- * @param [out] mem_elem     Filled with the packed memh and rkey.
+ * @param [in]  md                Memory domain.
+ * @param [in]  memh              Memory handle to pack (can be NULL).
+ * @param [in]  rkey              Remote key to pack (can be UCT_INVALID_RKEY).
+ * @param [out] mem_elem          Filled with the packed memh and rkey.
+ * @param [out] release_handle_p  Handle for releasing resources allocated
+ *                                during packing.
  *
  * @return UCS_OK on success or error code in case of failure.
  */
 ucs_status_t uct_md_mem_elem_pack(uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
-                                  uct_device_mem_elem_t *mem_elem);
+                                  uct_device_mem_elem_t *mem_elem,
+                                  void **release_handle_p);
+
+
+/**
+ * @ingroup UCT_MD
+ * @brief Release resources allocated by @ref uct_md_mem_elem_pack.
+ *
+ * @param [in] md              Memory domain.
+ * @param [in] release_handle  Handle for releasing resources.
+ */
+void uct_md_mem_elem_release(uct_md_h md, void *release_handle);
 
 
 /**

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -752,7 +752,13 @@ ucs_status_t uct_md_dummy_mem_dereg(uct_md_h uct_md,
 }
 
 ucs_status_t uct_md_mem_elem_pack(uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
-                                  uct_device_mem_elem_t *mem_elem)
+                                  uct_device_mem_elem_t *mem_elem,
+                                  void **release_handle_p)
 {
-    return md->ops->mem_elem_pack(md, memh, rkey, mem_elem);
+    return md->ops->mem_elem_pack(md, memh, rkey, mem_elem, release_handle_p);
+}
+
+void uct_md_mem_elem_release(uct_md_h md, void *release_handle)
+{
+    md->ops->mem_elem_release(md, release_handle);
 }

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -128,7 +128,10 @@ typedef ucs_status_t (*uct_md_detect_memory_type_func_t)(uct_md_h md,
 
 typedef ucs_status_t (*uct_md_mem_elem_pack_func_t)(
         uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
-        uct_device_mem_elem_t *mem_elem_p);
+        uct_device_mem_elem_t *mem_elem, void **release_handle_p);
+
+typedef void (*uct_md_mem_elem_release_func_t)(uct_md_h md,
+                                               void *release_handle);
 
 /**
  * Memory domain operations
@@ -146,6 +149,7 @@ struct uct_md_ops {
     uct_md_mem_attach_func_t             mem_attach;
     uct_md_detect_memory_type_func_t     detect_memory_type;
     uct_md_mem_elem_pack_func_t          mem_elem_pack;
+    uct_md_mem_elem_release_func_t       mem_elem_release;
 };
 
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -1052,6 +1052,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack          = (uct_md_mkey_pack_func_t)ucs_empty_function_return_success,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function,
     .detect_memory_type = uct_cuda_copy_md_detect_memory_type
 };
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -41,6 +41,14 @@ typedef struct {
     CUdevice   cu_dev;
 } uct_cuda_ipc_rkey_handle_t;
 
+typedef struct {
+    pid_t        pid;
+    ucs_sys_ns_t pid_ns;
+    uintptr_t    d_bptr;
+    void         *mapped_addr;
+    CUdevice     cu_dev;
+} uct_cuda_ipc_mem_elem_release_handle_t;
+
 static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
     {"", "", NULL,
      ucs_offsetof(uct_cuda_ipc_md_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
@@ -759,11 +767,13 @@ static void uct_cuda_ipc_md_close(uct_md_h md)
 
 static ucs_status_t
 uct_cuda_ipc_md_mem_elem_pack(uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
-                              uct_device_mem_elem_t *mem_elem_p)
+                              uct_device_mem_elem_t *mem_elem,
+                              void **release_handle_p)
 {
     uct_cuda_ipc_unpacked_rkey_t *key = (uct_cuda_ipc_unpacked_rkey_t*)rkey;
     uct_cuda_ipc_md_device_mem_element_t *cuda_ipc_md_mem_element =
-            (uct_cuda_ipc_md_device_mem_element_t*)mem_elem_p;
+            (uct_cuda_ipc_md_device_mem_element_t*)mem_elem;
+    uct_cuda_ipc_mem_elem_release_handle_t *release_handle;
     ucs_status_t status;
     CUdevice cuda_device;
     void *mapped_addr;
@@ -772,16 +782,40 @@ uct_cuda_ipc_md_mem_elem_pack(uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
         return UCS_ERR_UNREACHABLE;
     }
 
+    release_handle = ucs_malloc(sizeof(*release_handle),
+                                "uct_cuda_ipc_mem_elem_release_handle");
+    if (release_handle == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
     status = uct_cuda_ipc_map_memhandle(&key->super, cuda_device, &mapped_addr,
                                         UCS_LOG_LEVEL_ERROR);
     if (ucs_unlikely(status != UCS_OK)) {
+        ucs_free(release_handle);
         return status;
     }
 
     cuda_ipc_md_mem_element->mapped_offset =
             UCS_PTR_BYTE_DIFF(key->super.super.d_bptr, mapped_addr);
 
+    release_handle->pid         = key->super.super.pid;
+    release_handle->pid_ns      = key->super.pid_ns;
+    release_handle->d_bptr      = key->super.super.d_bptr;
+    release_handle->mapped_addr = mapped_addr;
+    release_handle->cu_dev      = cuda_device;
+    *release_handle_p           = release_handle;
+
     return UCS_OK;
+}
+
+static void uct_cuda_ipc_md_mem_elem_release(uct_md_h md, void *release_handle)
+{
+    uct_cuda_ipc_mem_elem_release_handle_t *handle = release_handle;
+
+    uct_cuda_ipc_unmap_memhandle(handle->pid, handle->pid_ns, handle->d_bptr,
+                                 handle->mapped_addr, handle->cu_dev,
+                                 uct_cuda_ipc_component.enable_remote_cache);
+    ucs_free(handle);
 }
 
 static ucs_status_t
@@ -799,6 +833,7 @@ uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
         .mem_query          = (uct_md_mem_query_func_t)ucs_empty_function_return_unsupported,
         .mkey_pack          = uct_cuda_ipc_mkey_pack,
         .mem_elem_pack      = uct_cuda_ipc_md_mem_elem_pack,
+        .mem_elem_release   = uct_cuda_ipc_md_mem_elem_release,
         .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
     };

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -399,6 +399,7 @@ static uct_md_ops_t uct_gdr_copy_md_ops = {
     .mkey_pack          = uct_gdr_copy_mkey_pack,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function,
     .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
 };
 
@@ -467,7 +468,8 @@ static uct_md_ops_t uct_gdr_copy_md_rcache_ops = {
     .mkey_pack          = uct_gdr_copy_mkey_pack,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
 };
 
 static ucs_status_t

--- a/src/uct/gaudi/gaudi_gdr/gaudi_gdr_md.c
+++ b/src/uct/gaudi/gaudi_gdr/gaudi_gdr_md.c
@@ -145,7 +145,9 @@ static uct_md_ops_t md_ops = {
     .mkey_pack = (uct_md_mkey_pack_func_t)ucs_empty_function_return_unsupported,
     .mem_attach         = (uct_md_mem_attach_func_t)
             ucs_empty_function_return_unsupported,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)
+            ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function,
     .detect_memory_type = uct_gaudi_md_detect_memory_type,
 };
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1686,7 +1686,8 @@ static uct_ib_md_ops_t uct_ib_verbs_md_ops = {
         .mkey_pack          = uct_ib_verbs_mkey_pack,
         .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+        .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
     },
     .open = uct_ib_verbs_md_open,
 };

--- a/src/uct/ib/efa/base/ib_efa_md.c
+++ b/src/uct/ib/efa/base/ib_efa_md.c
@@ -109,7 +109,8 @@ static uct_ib_md_ops_t uct_ib_efa_md_ops = {
         .mkey_pack          = uct_ib_verbs_mkey_pack,
         .mem_attach         =(uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+        .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
     },
     .open = uct_ib_efa_md_open,
 };

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -3200,7 +3200,8 @@ uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
 static ucs_status_t
 uct_ib_md_mlx5_devx_md_mem_elem_pack(uct_md_h md, uct_mem_h memh,
                                      uct_rkey_t rkey,
-                                     uct_device_mem_elem_t *mem_elem_p)
+                                     uct_device_mem_elem_t *mem_elem_p,
+                                     void **pack_resources_p)
 {
     uct_ib_md_device_mem_element_t *mem_elem = (uct_ib_md_device_mem_element_t*)
             mem_elem_p;
@@ -3233,7 +3234,8 @@ static uct_ib_md_ops_t uct_ib_mlx5_devx_md_ops = {
         .mkey_pack          = uct_ib_mlx5_devx_mkey_pack,
         .mem_attach         = uct_ib_mlx5_devx_mem_attach,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-        .mem_elem_pack      = uct_ib_md_mlx5_devx_md_mem_elem_pack
+        .mem_elem_pack      = uct_ib_md_mlx5_devx_md_mem_elem_pack,
+        .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
     },
     .open = uct_ib_mlx5_devx_md_open,
 };
@@ -3464,7 +3466,8 @@ static uct_ib_md_ops_t uct_ib_mlx5_md_ops = {
         .mkey_pack          = uct_ib_verbs_mkey_pack,
         .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+        .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
     },
     .open = uct_ib_mlx5dv_md_open,
 };

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -895,7 +895,8 @@ static uct_md_ops_t uct_mlx5_gga_md_ops = {
     .mkey_pack          = uct_ib_mlx5_gga_mkey_pack,
     .mem_attach         = uct_ib_mlx5_gga_mem_attach,
     .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
 };
 
 static ucs_status_t

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -294,7 +294,8 @@ static uct_md_ops_t md_ops = {
     .mkey_pack          = uct_rocm_copy_mkey_pack,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .detect_memory_type = uct_rocm_base_detect_memory_type,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
 };
 
 static inline uct_rocm_copy_rcache_region_t*
@@ -354,7 +355,8 @@ static uct_md_ops_t md_rcache_ops = {
     .mkey_pack          = uct_rocm_copy_mkey_pack,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .detect_memory_type = uct_rocm_base_detect_memory_type,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
 };
 
 static ucs_status_t

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -122,7 +122,8 @@ uct_rocm_ipc_mem_dereg(uct_md_h md,
 
 static ucs_status_t
 uct_rocm_ipc_md_mem_elem_pack(uct_md_h md_h, uct_mem_h memh, uct_rkey_t rkey,
-                              uct_device_mem_elem_t *mem_elem_p)
+                              uct_device_mem_elem_t *mem_elem_p,
+                              void **release_handle_p)
 {
     uct_md_t *md = (uct_md_t*)md_h;
     uct_rocm_ipc_component_t *rocm_comp =
@@ -180,7 +181,8 @@ uct_rocm_ipc_md_open(uct_component_h component, const char *md_name,
         .mem_attach         = (uct_md_mem_attach_func_t)
                 ucs_empty_function_return_unsupported,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)
-                ucs_empty_function_return_unsupported
+                ucs_empty_function_return_unsupported,
+        .mem_elem_release = (uct_md_mem_elem_release_func_t)ucs_empty_function
     };
     static uct_md_t md         = {
         .ops       = &md_ops,

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -173,7 +173,8 @@ uct_cma_md_open(uct_component_t *component, const char *md_name,
         .mkey_pack          = (uct_md_mkey_pack_func_t)ucs_empty_function_return_unsupported,
         .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+        .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
     };
     uct_cma_md_t *cma_md;
 

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -257,7 +257,8 @@ static uct_md_ops_t md_ops = {
     .mkey_pack          = uct_knem_mkey_pack,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
 };
 
 static ucs_status_t

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -452,7 +452,8 @@ static ucs_status_t uct_self_md_open(uct_component_t *component, const char *md_
         .mkey_pack          = (uct_md_mkey_pack_func_t)ucs_empty_function_return_success,
         .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+        .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
     };
 
     static uct_self_md_t md;

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -52,7 +52,8 @@ static uct_md_ops_t uct_tcp_md_ops = {
     .mkey_pack          = (uct_md_mkey_pack_func_t)ucs_empty_function_return_unsupported,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
 };
 
 static ucs_status_t

--- a/src/uct/ze/copy/ze_copy_md.c
+++ b/src/uct/ze/copy/ze_copy_md.c
@@ -280,7 +280,8 @@ static uct_md_ops_t md_ops = {
     .mkey_pack          = (uct_md_mkey_pack_func_t)ucs_empty_function_return_success,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .detect_memory_type = uct_ze_copy_md_detect_memory_type,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
 };
 
 static ucs_status_t

--- a/test/gtest/uct/cuda/test_cuda_ipc_device.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_device.cc
@@ -191,8 +191,11 @@ UCS_TEST_P(test_cuda_ipc_rma, get_mem_elem_pack)
     mapped_buffer recvbuf(length, SEED2, *m_receiver, 0, UCS_MEMORY_TYPE_CUDA);
 
     uct_device_mem_elem_t mem_elem_host;
+    void *release_handle;
     EXPECT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
-                                       recvbuf.rkey(), &mem_elem_host));
+                                       recvbuf.rkey(), &mem_elem_host,
+                                       &release_handle));
+    uct_md_mem_elem_release(m_sender->md(), release_handle);
 }
 
 UCS_TEST_P(test_cuda_ipc_rma, get_device_ep)
@@ -223,8 +226,10 @@ UCS_TEST_P(test_cuda_ipc_rma_device, put_device)
     mapped_buffer recvbuf(length, SEED2, *m_receiver, 0, UCS_MEMORY_TYPE_CUDA);
 
     uct_device_mem_elem_t src_elem_host;
+    void *release_handle;
     ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
-                                       recvbuf.rkey(), &src_elem_host));
+                                       recvbuf.rkey(), &src_elem_host,
+                                       &release_handle));
 
 
     uct_device_mem_elem_t *src_elem;
@@ -249,6 +254,7 @@ UCS_TEST_P(test_cuda_ipc_rma_device, put_device)
     recvbuf.pattern_check(SEED1);
     cuMemFree((CUdeviceptr)src_elem);
     cuMemFree((CUdeviceptr)mem_elem);
+    uct_md_mem_elem_release(m_sender->md(), release_handle);
 }
 
 UCS_TEST_P(test_cuda_ipc_rma_device, atomic_add_device)
@@ -273,9 +279,10 @@ UCS_TEST_P(test_cuda_ipc_rma_device, atomic_add_device)
     ASSERT_UCS_OK(uct_ep_get_device_ep(m_sender->ep(0), &device_ep));
 
     uct_device_mem_elem_t mem_elem_host;
+    void *release_handle;
     ASSERT_EQ(CUDA_SUCCESS, cuMemAlloc((CUdeviceptr*)&mem_elem, mem_elem_size));
     ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), nullptr, signal.rkey(),
-                                       &mem_elem_host));
+                                       &mem_elem_host, &release_handle));
     ASSERT_EQ(CUDA_SUCCESS, cuMemcpyHtoD((CUdeviceptr)mem_elem, &mem_elem_host,
                                          mem_elem_size));
 
@@ -287,6 +294,7 @@ UCS_TEST_P(test_cuda_ipc_rma_device, atomic_add_device)
                                   UCS_MEMORY_TYPE_CUDA),
               1);
     cuMemFree((CUdeviceptr)mem_elem);
+    uct_md_mem_elem_release(m_sender->md(), release_handle);
 }
 
 _UCT_INSTANTIATE_TEST_CASE(test_cuda_ipc_rma_device, cuda_ipc)

--- a/test/gtest/uct/rocm/test_rocm_ipc_device.hip
+++ b/test/gtest/uct/rocm/test_rocm_ipc_device.hip
@@ -182,8 +182,11 @@ UCS_TEST_P(test_rocm_ipc_rma, get_mem_elem_pack)
 
     mem_elem = static_cast<uct_device_mem_elem_t*>(malloc(mem_elem_size));
     ASSERT_NE(nullptr, mem_elem);
+    void *release_handle;
     EXPECT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
-                                       recvbuf.rkey(), mem_elem));
+                                       recvbuf.rkey(), mem_elem,
+                                       &release_handle));
+    uct_md_mem_elem_release(m_sender->md(), release_handle);
     free(mem_elem);
 }
 
@@ -218,9 +221,10 @@ UCS_TEST_P(test_rocm_ipc_rma_device, device_put)
                                  sizeof(uct_device_mem_elem_t);
     struct { uct_device_local_mem_elem_t hdr; uct_device_mem_elem_t tl; }
             src_elem_host = {};
+    void *release_handle;
     ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
                                        recvbuf.rkey(),
-                                       &src_elem_host.tl));
+                                       &src_elem_host.tl, &release_handle));
 
     uct_device_local_mem_elem_t *src_elem;
     ASSERT_EQ(hipSuccess, hipMalloc((void**)&src_elem, src_elem_size));
@@ -245,6 +249,7 @@ UCS_TEST_P(test_rocm_ipc_rma_device, device_put)
     recvbuf.pattern_check(SEED1);
     hipFree(src_elem);
     hipFree(mem_elem);
+    uct_md_mem_elem_release(m_sender->md(), release_handle);
 }
 
 _UCT_INSTANTIATE_TEST_CASE(test_rocm_ipc_rma_device, rocm_ipc)

--- a/test/gtest/uct/test_device.cc
+++ b/test/gtest/uct/test_device.cc
@@ -155,8 +155,10 @@ UCS_TEST_P(test_device, put)
     mapped_buffer recvbuf(length, SEED2, *m_receiver, 0, UCS_MEMORY_TYPE_CUDA);
 
     uct_device_mem_elem_t src_elem_host;
+    void *release_handle;
     ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
-                                       recvbuf.rkey(), &src_elem_host));
+                                       recvbuf.rkey(), &src_elem_host,
+                                       &release_handle));
 
     mapped_buffer src_elembuf(sizeof(src_elem_host), 0, *m_sender, 0,
                               UCS_MEMORY_TYPE_CUDA);
@@ -179,6 +181,7 @@ UCS_TEST_P(test_device, put)
 
     recvbuf.pattern_check(SEED1);
     recvbuf.pattern_fill(SEED2);
+    uct_md_mem_elem_release(m_sender->md(), release_handle);
 }
 
 UCS_TEST_P(test_device, atomic)
@@ -199,8 +202,9 @@ UCS_TEST_P(test_device, atomic)
     uct_device_mem_elem_t *mem_elem_host = (uct_device_mem_elem_t*)
                                                    elembuf_host.ptr();
     uct_device_mem_elem_t *mem_elem = (uct_device_mem_elem_t*)elembuf.ptr();
+    void *release_handle;
     ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), nullptr, signal.rkey(),
-                                       mem_elem_host));
+                                       mem_elem_host, &release_handle));
     ASSERT_EQ(CUDA_SUCCESS, cuMemcpyHtoD((CUdeviceptr)mem_elem, mem_elem_host,
                                          sizeof(uct_device_mem_elem_t)));
 
@@ -215,6 +219,7 @@ UCS_TEST_P(test_device, atomic)
                                     sizeof(signal_val), UCS_MEMORY_TYPE_CUDA))
             ;
     }
+    uct_md_mem_elem_release(m_sender->md(), release_handle);
 }
 
 _UCT_INSTANTIATE_TEST_CASE(test_device, rc_gda)


### PR DESCRIPTION
## What?
Added UCT API `uct_md_mem_elem_release` to be able to release resources allocated during `uct_md_mem_elem_pack`.

## Why?
`cuda_ipc` implementation of `uct_md_mem_elem_pack` maps remote address, opening interprocess handle. It's not possible to release the memory without closing all opened interprocess handles.  

