### PR TITLE
UCT/IB: load verbs libraries with dlopen

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -229,6 +229,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_STATS], [false])
      AM_CONDITIONAL([HAVE_TUNING], [false])
      AM_CONDITIONAL([HAVE_IB], [false])
+     AM_CONDITIONAL([HAVE_IB_SHIM], [false])
      AM_CONDITIONAL([HAVE_EFA], [false])
      AM_CONDITIONAL([HAVE_MLX5_HW_UD], [false])
      AM_CONDITIONAL([HAVE_MLX5_DV], [false])

--- a/src/uct/ib/Makefile.am
+++ b/src/uct/ib/Makefile.am
@@ -63,6 +63,12 @@ libuct_ib_la_SOURCES += \
 
 endif # HAVE_TL_UD
 
+if HAVE_IB_SHIM
+noinst_HEADERS += \
+	base/ib_dlopen.h
+libuct_ib_la_SOURCES += base/ib_verbs_dlopen.c
+endif
+
 PKG_CONFIG_NAME=ib
 
 include $(top_srcdir)/config/module.am

--- a/src/uct/ib/base/ib_dlopen.h
+++ b/src/uct/ib/base/ib_dlopen.h
@@ -72,6 +72,16 @@ uct_ib_dlopen_module_check(const uct_ib_dlopen_module_t *module,
         } \
     } while (0)
 
+#define UCT_IB_DLOPEN_RESOLVE_OPTIONAL(_module, _ops, _field) \
+    do { \
+        dlerror(); \
+        (_ops)._field = \
+                (__typeof__((_ops)._field))dlsym((_module).library, #_field); \
+        if (dlerror() != NULL) { \
+            (_ops)._field = NULL; \
+        } \
+    } while (0)
+
 static inline int uct_ib_dlopen_errno(uct_ib_dlopen_status_t status)
 {
     switch (status) {
@@ -97,9 +107,16 @@ static inline int uct_ib_dlopen_errno(uct_ib_dlopen_status_t status)
     UCT_IB_DLOPEN_RESOLVE(_module, _ops, _name);
 #define UCT_IB_DLOPEN_RESOLVE_VOID_OP(_module, _ops, _name, _args, _call) \
     UCT_IB_DLOPEN_RESOLVE(_module, _ops, _name);
+#define UCT_IB_DLOPEN_RESOLVE_OPTIONAL_OP(_module, _ops, _ret, _fail, _name, \
+                                          _args, _call) \
+    UCT_IB_DLOPEN_RESOLVE_OPTIONAL(_module, _ops, _name);
+#define UCT_IB_DLOPEN_RESOLVE_OPTIONAL_VOID_OP(_module, _ops, _name, _args, \
+                                               _call) \
+    UCT_IB_DLOPEN_RESOLVE_OPTIONAL(_module, _ops, _name);
 
 #define UCT_IB_DLOPEN_DEFINE_MODULE(_module, _library_name, _ops_type, \
-                                    _ops_list, _check_func) \
+                                    _required_ops_list, _optional_ops_list, \
+                                    _check_func) \
     static uct_ib_dlopen_module_t _module##_module = \
             UCT_IB_DLOPEN_MODULE_INITIALIZER(_library_name); \
     static _ops_type _module##_ops; \
@@ -109,8 +126,12 @@ static inline int uct_ib_dlopen_errno(uct_ib_dlopen_status_t status)
         if (_module##_module.status != UCT_IB_DLOPEN_STATUS_OK) { \
             return; \
         } \
-        _ops_list(UCT_IB_DLOPEN_RESOLVE_OP, UCT_IB_DLOPEN_RESOLVE_VOID_OP, \
-                  _module##_module, _module##_ops); \
+        _required_ops_list(UCT_IB_DLOPEN_RESOLVE_OP, \
+                           UCT_IB_DLOPEN_RESOLVE_VOID_OP, _module##_module, \
+                           _module##_ops); \
+        _optional_ops_list(UCT_IB_DLOPEN_RESOLVE_OPTIONAL_OP, \
+                           UCT_IB_DLOPEN_RESOLVE_OPTIONAL_VOID_OP, \
+                           _module##_module, _module##_ops); \
     } \
     uct_ib_dlopen_status_t \
     _check_func(const char **library_name, const char **symbol_name, \
@@ -148,6 +169,38 @@ static inline int uct_ib_dlopen_errno(uct_ib_dlopen_status_t status)
             ucs_assert((_ops)._name != NULL); \
             (_ops)._name _call; \
         } \
+    }
+
+#define UCT_IB_DLOPEN_FWD_OPTIONAL_OP(_module, _ops, _ret, _fail, _name, \
+                                      _proto, _call) \
+    _ret _name _proto \
+    { \
+        if (_module##_init() != 0) { \
+            return (_fail); \
+        } \
+        \
+        if ((_ops)._name == NULL) { \
+            errno = ENOSYS; \
+            return (_fail); \
+        } \
+        \
+        return (_ops)._name _call; \
+    }
+
+#define UCT_IB_DLOPEN_FWD_OPTIONAL_VOID_OP(_module, _ops, _name, _proto, \
+                                           _call) \
+    void _name _proto \
+    { \
+        if (_module##_init() != 0) { \
+            return; \
+        } \
+        \
+        if ((_ops)._name == NULL) { \
+            errno = ENOSYS; \
+            return; \
+        } \
+        \
+        (_ops)._name _call; \
     }
 
 #endif

--- a/src/uct/ib/base/ib_dlopen.h
+++ b/src/uct/ib/base/ib_dlopen.h
@@ -1,0 +1,153 @@
+#ifndef UCT_IB_DLOPEN_H
+#define UCT_IB_DLOPEN_H
+
+#include "ib_verbs.h"
+
+#include <ucs/debug/assert.h>
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+
+typedef struct uct_ib_dlopen_module {
+    pthread_once_t once;
+    void *library;
+    uct_ib_dlopen_status_t status;
+    const char *library_name;
+    const char *missing_symbol;
+    char error_msg[256];
+} uct_ib_dlopen_module_t;
+
+#define UCT_IB_DLOPEN_MODULE_INITIALIZER(_library_name) \
+    {PTHREAD_ONCE_INIT, NULL, UCT_IB_DLOPEN_STATUS_OK, (_library_name), \
+     NULL, {0}}
+
+static inline void uct_ib_dlopen_module_open(uct_ib_dlopen_module_t *module)
+{
+    const char *dlopen_error_msg;
+
+    module->library = dlopen(module->library_name, RTLD_NOW | RTLD_LOCAL);
+    if (module->library == NULL) {
+        dlopen_error_msg = dlerror();
+        module->status   = UCT_IB_DLOPEN_STATUS_NO_LIB;
+        snprintf(module->error_msg, sizeof(module->error_msg), "%s",
+                 (dlopen_error_msg != NULL) ? dlopen_error_msg :
+                 "dlopen failed");
+    }
+}
+
+static inline uct_ib_dlopen_status_t
+uct_ib_dlopen_module_check(const uct_ib_dlopen_module_t *module,
+                           const char **library_name,
+                           const char **symbol_name, const char **error_msg)
+{
+    if (library_name != NULL) {
+        *library_name = module->library_name;
+    }
+    if (symbol_name != NULL) {
+        *symbol_name = module->missing_symbol;
+    }
+    if (error_msg != NULL) {
+        *error_msg = module->error_msg;
+    }
+
+    return module->status;
+}
+
+#define UCT_IB_DLOPEN_RESOLVE(_module, _ops, _field) \
+    do { \
+        const char *dlerror_msg; \
+        dlerror(); \
+        (_ops)._field = \
+                (__typeof__((_ops)._field))dlsym((_module).library, #_field); \
+        dlerror_msg   = dlerror(); \
+        if (((_ops)._field == NULL) || (dlerror_msg != NULL)) { \
+            (_module).status         = UCT_IB_DLOPEN_STATUS_MISSING_SYM; \
+            (_module).missing_symbol = #_field; \
+            snprintf((_module).error_msg, sizeof((_module).error_msg), "%s", \
+                     (dlerror_msg != NULL) ? dlerror_msg : \
+                     "symbol resolved to NULL"); \
+            return; \
+        } \
+    } while (0)
+
+static inline int uct_ib_dlopen_errno(uct_ib_dlopen_status_t status)
+{
+    switch (status) {
+    case UCT_IB_DLOPEN_STATUS_OK:
+        return 0;
+    case UCT_IB_DLOPEN_STATUS_NO_LIB:
+        return ENOENT;
+    case UCT_IB_DLOPEN_STATUS_MISSING_SYM:
+        return ENOSYS;
+    }
+
+    return ENOSYS;
+}
+
+#define UCT_IB_DLOPEN_OP_FIELD(_module, _ops, _ret, _fail, _name, _args, \
+                               _call) \
+    _ret (*_name) _args;
+#define UCT_IB_DLOPEN_VOID_OP_FIELD(_module, _ops, _name, _args, _call) \
+    void (*_name) _args;
+
+#define UCT_IB_DLOPEN_RESOLVE_OP(_module, _ops, _ret, _fail, _name, _args, \
+                                 _call) \
+    UCT_IB_DLOPEN_RESOLVE(_module, _ops, _name);
+#define UCT_IB_DLOPEN_RESOLVE_VOID_OP(_module, _ops, _name, _args, _call) \
+    UCT_IB_DLOPEN_RESOLVE(_module, _ops, _name);
+
+#define UCT_IB_DLOPEN_DEFINE_MODULE(_module, _library_name, _ops_type, \
+                                    _ops_list, _check_func) \
+    static uct_ib_dlopen_module_t _module##_module = \
+            UCT_IB_DLOPEN_MODULE_INITIALIZER(_library_name); \
+    static _ops_type _module##_ops; \
+    static void _module##_init_once(void) \
+    { \
+        uct_ib_dlopen_module_open(&_module##_module); \
+        if (_module##_module.status != UCT_IB_DLOPEN_STATUS_OK) { \
+            return; \
+        } \
+        _ops_list(UCT_IB_DLOPEN_RESOLVE_OP, UCT_IB_DLOPEN_RESOLVE_VOID_OP, \
+                  _module##_module, _module##_ops); \
+    } \
+    uct_ib_dlopen_status_t \
+    _check_func(const char **library_name, const char **symbol_name, \
+                const char **error_msg) \
+    { \
+        pthread_once(&_module##_module.once, _module##_init_once); \
+        return uct_ib_dlopen_module_check(&_module##_module, library_name, \
+                                          symbol_name, error_msg); \
+    } \
+    static int _module##_init(void) \
+    { \
+        uct_ib_dlopen_status_t status; \
+        status = _check_func(NULL, NULL, NULL); \
+        if (status != UCT_IB_DLOPEN_STATUS_OK) { \
+            errno = uct_ib_dlopen_errno(status); \
+            return -1; \
+        } \
+        return 0; \
+    }
+
+#define UCT_IB_DLOPEN_FWD_OP(_module, _ops, _ret, _fail, _name, _proto, _call) \
+    _ret _name _proto \
+    { \
+        if (_module##_init() != 0) { \
+            return (_fail); \
+        } \
+        ucs_assert((_ops)._name != NULL); \
+        return (_ops)._name _call; \
+    }
+
+#define UCT_IB_DLOPEN_FWD_VOID_OP(_module, _ops, _name, _proto, _call) \
+    void _name _proto \
+    { \
+        if (_module##_init() == 0) { \
+            ucs_assert((_ops)._name != NULL); \
+            (_ops)._name _call; \
+        } \
+    }
+
+#endif

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1693,6 +1693,10 @@ static uct_ib_md_ops_t uct_ib_verbs_md_ops = {
 
 static UCT_IB_MD_DEFINE_ENTRY(verbs, uct_ib_verbs_md_ops);
 
+#if defined(HAVE_IB_SHIM)
+static int uct_ib_component_initialized;
+#endif
+
 uct_component_t uct_ib_component = {
     .query_md_resources = uct_ib_query_md_resources,
     .md_open            = uct_ib_md_open,
@@ -1717,10 +1721,32 @@ uct_component_t uct_ib_component = {
 void UCS_F_CTOR uct_ib_init()
 {
     UCS_MODULE_FRAMEWORK_DECLARE(uct_ib);
+#if defined(HAVE_IB_SHIM)
+    uct_ib_dlopen_status_t dlopen_status;
+    const char *library_name, *symbol_name, *error_msg;
+#endif
     ssize_t i;
+
+#if defined(HAVE_IB_SHIM)
+    dlopen_status = uct_ib_verbs_dlopen_check(&library_name, &symbol_name,
+                                              &error_msg);
+    if (dlopen_status != UCT_IB_DLOPEN_STATUS_OK) {
+        if (dlopen_status == UCT_IB_DLOPEN_STATUS_MISSING_SYM) {
+            ucs_diag("ib component is disabled: %s is missing symbol %s: %s",
+                     library_name, symbol_name, error_msg);
+        } else {
+            ucs_diag("ib component is disabled: %s: %s: %s", library_name,
+                     uct_ib_dlopen_status_string(dlopen_status), error_msg);
+        }
+        return;
+    }
+#endif
 
     ucs_list_add_head(&uct_ib_ops, &UCT_IB_MD_OPS_NAME(verbs).list);
     uct_component_register(&uct_ib_component);
+#if defined(HAVE_IB_SHIM)
+    uct_ib_component_initialized = 1;
+#endif
 
     for (i = 0; i < ucs_static_array_size(uct_ib_tls); i++) {
         uct_tl_register(&uct_ib_component, uct_ib_tls[i]);
@@ -1732,6 +1758,12 @@ void UCS_F_CTOR uct_ib_init()
 void UCS_F_DTOR uct_ib_cleanup()
 {
     ssize_t i;
+
+#if defined(HAVE_IB_SHIM)
+    if (!uct_ib_component_initialized) {
+        return;
+    }
+#endif
 
     for (i = ucs_static_array_size(uct_ib_tls) - 1; i >= 0; i--) {
         uct_tl_unregister(uct_ib_tls[i]);

--- a/src/uct/ib/base/ib_verbs.h
+++ b/src/uct/ib/base/ib_verbs.h
@@ -22,6 +22,26 @@
 #include <ucs/type/status.h>
 #include <ucs/debug/log.h>
 
+#if defined(HAVE_IB_SHIM)
+typedef enum {
+    UCT_IB_DLOPEN_STATUS_OK,
+    UCT_IB_DLOPEN_STATUS_NO_LIB,
+    UCT_IB_DLOPEN_STATUS_MISSING_SYM
+} uct_ib_dlopen_status_t;
+
+const char *uct_ib_dlopen_status_string(uct_ib_dlopen_status_t status);
+
+uct_ib_dlopen_status_t
+uct_ib_verbs_dlopen_check(const char **library_name, const char **symbol_name,
+                          const char **error_msg);
+
+#if defined(HAVE_MLX5_DV)
+uct_ib_dlopen_status_t
+uct_ib_mlx5_dlopen_check(const char **library_name, const char **symbol_name,
+                         const char **error_msg);
+#endif
+#endif
+
 /* Read device properties */
 #if HAVE_DECL_IBV_QUERY_DEVICE_EX
 

--- a/src/uct/ib/base/ib_verbs_dlopen.c
+++ b/src/uct/ib/base/ib_verbs_dlopen.c
@@ -1,0 +1,207 @@
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "ib_dlopen.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define UCT_IB_VERBS_LIB_NAME  "libibverbs.so.1"
+
+#ifdef HAVE_NETLINK_RDMA
+#define UCT_IB_VERBS_NETLINK_OPS(_op, _module, _ops) \
+    _op(_module, _ops, int, -1, ibv_get_device_index, \
+        (struct ibv_device *device), (device))
+#else
+#define UCT_IB_VERBS_NETLINK_OPS(_op, _module, _ops)
+#endif
+
+#if HAVE_DECL_IBV_REG_DMABUF_MR
+#define UCT_IB_VERBS_DMABUF_OPS(_op, _module, _ops) \
+    _op(_module, _ops, struct ibv_mr *, NULL, ibv_reg_dmabuf_mr, \
+        (struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, \
+         int fd, int access), (pd, offset, length, iova, fd, access))
+#else
+#define UCT_IB_VERBS_DMABUF_OPS(_op, _module, _ops)
+#endif
+
+#if HAVE_DECL_IBV_SET_ECE
+#define UCT_IB_VERBS_ECE_OPS(_op, _module, _ops) \
+    _op(_module, _ops, int, -1, ibv_query_ece, \
+        (struct ibv_qp *qp, struct ibv_ece *ece), (qp, ece)) \
+    _op(_module, _ops, int, -1, ibv_set_ece, \
+        (struct ibv_qp *qp, struct ibv_ece *ece), (qp, ece))
+#else
+#define UCT_IB_VERBS_ECE_OPS(_op, _module, _ops)
+#endif
+
+#if HAVE_DECL_IBV_IS_FORK_INITIALIZED && HAVE_DECL_IBV_FORK_UNNEEDED
+#define UCT_IB_VERBS_FORK_STATUS_OPS(_op, _module, _ops) \
+    _op(_module, _ops, enum ibv_fork_status, IBV_FORK_DISABLED, \
+        ibv_is_fork_initialized, (void), ())
+#else
+#define UCT_IB_VERBS_FORK_STATUS_OPS(_op, _module, _ops)
+#endif
+
+#if HAVE_DECL_IBV_QUERY_PORT_SPEED
+#define UCT_IB_VERBS_PORT_SPEED_OPS(_op, _module, _ops) \
+    _op(_module, _ops, int, -1, ibv_query_port_speed, \
+        (struct ibv_context *context, uint32_t port_num, \
+         uint64_t *port_speed), (context, port_num, port_speed))
+#else
+#define UCT_IB_VERBS_PORT_SPEED_OPS(_op, _module, _ops)
+#endif
+
+#define UCT_IB_VERBS_DEVICE_LIST_OP(_op, _module, _ops) \
+    _op(_module, _ops, struct ibv_device **, NULL, ibv_get_device_list, \
+        (int *num_devices), (num_devices))
+
+#define UCT_IB_VERBS_VOID_OPS(_op, _module, _ops) \
+    _op(_module, _ops, ibv_free_device_list, (struct ibv_device **list), \
+        (list)) \
+    _op(_module, _ops, ibv_ack_async_event, \
+        (struct ibv_async_event *event), (event)) \
+    _op(_module, _ops, ibv_ack_cq_events, \
+        (struct ibv_cq *cq, unsigned int nevents), (cq, nevents))
+
+#define UCT_IB_VERBS_FWD_OPS(_op, _module, _ops) \
+    _op(_module, _ops, const char *, NULL, ibv_get_device_name, \
+        (struct ibv_device *device), (device)) \
+    _op(_module, _ops, __be64, 0, ibv_get_device_guid, \
+        (struct ibv_device *device), \
+        (device)) \
+    _op(_module, _ops, struct ibv_context *, NULL, ibv_open_device, \
+        (struct ibv_device *device), (device)) \
+    _op(_module, _ops, int, -1, ibv_close_device, \
+        (struct ibv_context *context), \
+        (context)) \
+    _op(_module, _ops, int, -1, ibv_fork_init, (void), ()) \
+    _op(_module, _ops, int, -1, ibv_get_async_event, \
+        (struct ibv_context *context, struct ibv_async_event *event), \
+        (context, event)) \
+    _op(_module, _ops, struct ibv_comp_channel *, NULL, \
+        ibv_create_comp_channel, \
+        (struct ibv_context *context), (context)) \
+    _op(_module, _ops, int, -1, ibv_destroy_comp_channel, \
+        (struct ibv_comp_channel *channel), (channel)) \
+    _op(_module, _ops, struct ibv_pd *, NULL, ibv_alloc_pd, \
+        (struct ibv_context *context), (context)) \
+    _op(_module, _ops, int, -1, ibv_dealloc_pd, (struct ibv_pd *pd), (pd)) \
+    _op(_module, _ops, struct ibv_mr *, NULL, ibv_reg_mr, \
+        (struct ibv_pd *pd, void *addr, size_t length, int access), \
+        (pd, addr, length, access)) \
+    _op(_module, _ops, struct ibv_mr *, NULL, ibv_reg_mr_iova2, \
+        (struct ibv_pd *pd, void *addr, size_t length, uint64_t iova, \
+         unsigned int access), (pd, addr, length, iova, access)) \
+    _op(_module, _ops, int, -1, ibv_dereg_mr, (struct ibv_mr *mr), (mr)) \
+    _op(_module, _ops, struct ibv_cq *, NULL, ibv_create_cq, \
+        (struct ibv_context *context, int cqe, void *cq_context, \
+         struct ibv_comp_channel *channel, int comp_vector), \
+        (context, cqe, cq_context, channel, comp_vector)) \
+    _op(_module, _ops, int, -1, ibv_destroy_cq, (struct ibv_cq *cq), (cq)) \
+    _op(_module, _ops, int, -1, ibv_get_cq_event, \
+        (struct ibv_comp_channel *channel, struct ibv_cq **cq, \
+         void **cq_context), (channel, cq, cq_context)) \
+    _op(_module, _ops, struct ibv_ah *, NULL, ibv_create_ah, \
+        (struct ibv_pd *pd, struct ibv_ah_attr *attr), (pd, attr)) \
+    _op(_module, _ops, int, -1, ibv_destroy_ah, (struct ibv_ah *ah), (ah)) \
+    _op(_module, _ops, struct ibv_qp *, NULL, ibv_create_qp, \
+        (struct ibv_pd *pd, struct ibv_qp_init_attr *qp_init_attr), \
+        (pd, qp_init_attr)) \
+    _op(_module, _ops, int, -1, ibv_destroy_qp, (struct ibv_qp *qp), (qp)) \
+    _op(_module, _ops, int, -1, ibv_modify_qp, \
+        (struct ibv_qp *qp, struct ibv_qp_attr *attr, int attr_mask), \
+        (qp, attr, attr_mask)) \
+    _op(_module, _ops, int, -1, ibv_query_qp, \
+        (struct ibv_qp *qp, struct ibv_qp_attr *attr, int attr_mask, \
+         struct ibv_qp_init_attr *init_attr), \
+        (qp, attr, attr_mask, init_attr)) \
+    _op(_module, _ops, struct ibv_srq *, NULL, ibv_create_srq, \
+        (struct ibv_pd *pd, struct ibv_srq_init_attr *srq_init_attr), \
+        (pd, srq_init_attr)) \
+    _op(_module, _ops, int, -1, ibv_destroy_srq, \
+        (struct ibv_srq *srq), (srq)) \
+    _op(_module, _ops, int, -1, ibv_query_device, \
+        (struct ibv_context *context, struct ibv_device_attr *device_attr), \
+        (context, device_attr)) \
+    _op(_module, _ops, int, -1, ibv_query_port, \
+        (struct ibv_context *context, uint8_t port_num, \
+         struct _compat_ibv_port_attr *port_attr), \
+        (context, port_num, port_attr)) \
+    _op(_module, _ops, int, -1, ibv_query_gid, \
+        (struct ibv_context *context, uint8_t port_num, int index, \
+         union ibv_gid *gid), (context, port_num, index, gid)) \
+    _op(_module, _ops, int, -1, ibv_query_pkey, \
+        (struct ibv_context *context, uint8_t port_num, int index, \
+         __be16 *pkey), (context, port_num, index, pkey)) \
+    _op(_module, _ops, const char *, NULL, ibv_wc_status_str, \
+        (enum ibv_wc_status status), (status)) \
+    _op(_module, _ops, const char *, NULL, ibv_event_type_str, \
+        (enum ibv_event_type event), (event)) \
+    _op(_module, _ops, const char *, NULL, ibv_node_type_str, \
+        (enum ibv_node_type node_type), (node_type))
+
+#define UCT_IB_VERBS_FEATURE_OPS(_op, _void_op, _module, _ops) \
+    UCT_IB_VERBS_NETLINK_OPS(_op, _module, _ops) \
+    UCT_IB_VERBS_DMABUF_OPS(_op, _module, _ops) \
+    UCT_IB_VERBS_ECE_OPS(_op, _module, _ops) \
+    UCT_IB_VERBS_FORK_STATUS_OPS(_op, _module, _ops) \
+    UCT_IB_VERBS_PORT_SPEED_OPS(_op, _module, _ops)
+
+#define UCT_IB_VERBS_OPS(_op, _void_op, _module, _ops) \
+    UCT_IB_VERBS_DEVICE_LIST_OP(_op, _module, _ops) \
+    UCT_IB_VERBS_VOID_OPS(_void_op, _module, _ops) \
+    UCT_IB_VERBS_FWD_OPS(_op, _module, _ops) \
+    UCT_IB_VERBS_FEATURE_OPS(_op, _void_op, _module, _ops)
+
+typedef struct uct_ib_verbs_ops {
+    UCT_IB_VERBS_OPS(UCT_IB_DLOPEN_OP_FIELD,
+                     UCT_IB_DLOPEN_VOID_OP_FIELD, uct_ib_verbs,
+                     uct_ib_verbs_ops)
+} uct_ib_verbs_ops_t;
+
+const char *uct_ib_dlopen_status_string(uct_ib_dlopen_status_t status)
+{
+    switch (status) {
+    case UCT_IB_DLOPEN_STATUS_OK:
+        return "ok";
+    case UCT_IB_DLOPEN_STATUS_NO_LIB:
+        return "library not found";
+    case UCT_IB_DLOPEN_STATUS_MISSING_SYM:
+        return "symbol not found";
+    }
+
+    return "unknown";
+}
+
+UCT_IB_DLOPEN_DEFINE_MODULE(uct_ib_verbs, UCT_IB_VERBS_LIB_NAME,
+                            uct_ib_verbs_ops_t, UCT_IB_VERBS_OPS,
+                            uct_ib_verbs_dlopen_check)
+
+struct ibv_device **ibv_get_device_list(int *num_devices)
+{
+    if (uct_ib_verbs_init() != 0) {
+        if (num_devices != NULL) {
+            *num_devices = 0;
+        }
+        return NULL;
+    }
+
+    return uct_ib_verbs_ops.ibv_get_device_list(num_devices);
+}
+
+/* ibv_reg_mr and ibv_query_port are macros in modern verbs.h. */
+#undef ibv_reg_mr
+#undef ibv_query_port
+
+UCT_IB_VERBS_VOID_OPS(UCT_IB_DLOPEN_FWD_VOID_OP, uct_ib_verbs,
+                      uct_ib_verbs_ops)
+UCT_IB_VERBS_FWD_OPS(UCT_IB_DLOPEN_FWD_OP, uct_ib_verbs, uct_ib_verbs_ops)
+UCT_IB_VERBS_FEATURE_OPS(UCT_IB_DLOPEN_FWD_OP, UCT_IB_DLOPEN_FWD_VOID_OP,
+                         uct_ib_verbs, uct_ib_verbs_ops)

--- a/src/uct/ib/base/ib_verbs_dlopen.c
+++ b/src/uct/ib/base/ib_verbs_dlopen.c
@@ -147,23 +147,26 @@
     _op(_module, _ops, const char *, NULL, ibv_node_type_str, \
         (enum ibv_node_type node_type), (node_type))
 
-#define UCT_IB_VERBS_FEATURE_OPS(_op, _void_op, _module, _ops) \
+/* Symbols not available in the minimum supported rdma-core v28. */
+#define UCT_IB_VERBS_OPTIONAL_OPS(_op, _void_op, _module, _ops) \
     UCT_IB_VERBS_NETLINK_OPS(_op, _module, _ops) \
     UCT_IB_VERBS_DMABUF_OPS(_op, _module, _ops) \
     UCT_IB_VERBS_ECE_OPS(_op, _module, _ops) \
     UCT_IB_VERBS_FORK_STATUS_OPS(_op, _module, _ops) \
     UCT_IB_VERBS_PORT_SPEED_OPS(_op, _module, _ops)
 
-#define UCT_IB_VERBS_OPS(_op, _void_op, _module, _ops) \
+#define UCT_IB_VERBS_REQUIRED_OPS(_op, _void_op, _module, _ops) \
     UCT_IB_VERBS_DEVICE_LIST_OP(_op, _module, _ops) \
     UCT_IB_VERBS_VOID_OPS(_void_op, _module, _ops) \
-    UCT_IB_VERBS_FWD_OPS(_op, _module, _ops) \
-    UCT_IB_VERBS_FEATURE_OPS(_op, _void_op, _module, _ops)
+    UCT_IB_VERBS_FWD_OPS(_op, _module, _ops)
 
 typedef struct uct_ib_verbs_ops {
-    UCT_IB_VERBS_OPS(UCT_IB_DLOPEN_OP_FIELD,
-                     UCT_IB_DLOPEN_VOID_OP_FIELD, uct_ib_verbs,
-                     uct_ib_verbs_ops)
+    UCT_IB_VERBS_REQUIRED_OPS(UCT_IB_DLOPEN_OP_FIELD,
+                              UCT_IB_DLOPEN_VOID_OP_FIELD, uct_ib_verbs,
+                              uct_ib_verbs_ops)
+    UCT_IB_VERBS_OPTIONAL_OPS(UCT_IB_DLOPEN_OP_FIELD,
+                              UCT_IB_DLOPEN_VOID_OP_FIELD, uct_ib_verbs,
+                              uct_ib_verbs_ops)
 } uct_ib_verbs_ops_t;
 
 const char *uct_ib_dlopen_status_string(uct_ib_dlopen_status_t status)
@@ -181,7 +184,8 @@ const char *uct_ib_dlopen_status_string(uct_ib_dlopen_status_t status)
 }
 
 UCT_IB_DLOPEN_DEFINE_MODULE(uct_ib_verbs, UCT_IB_VERBS_LIB_NAME,
-                            uct_ib_verbs_ops_t, UCT_IB_VERBS_OPS,
+                            uct_ib_verbs_ops_t, UCT_IB_VERBS_REQUIRED_OPS,
+                            UCT_IB_VERBS_OPTIONAL_OPS,
                             uct_ib_verbs_dlopen_check)
 
 struct ibv_device **ibv_get_device_list(int *num_devices)
@@ -203,5 +207,6 @@ struct ibv_device **ibv_get_device_list(int *num_devices)
 UCT_IB_VERBS_VOID_OPS(UCT_IB_DLOPEN_FWD_VOID_OP, uct_ib_verbs,
                       uct_ib_verbs_ops)
 UCT_IB_VERBS_FWD_OPS(UCT_IB_DLOPEN_FWD_OP, uct_ib_verbs, uct_ib_verbs_ops)
-UCT_IB_VERBS_FEATURE_OPS(UCT_IB_DLOPEN_FWD_OP, UCT_IB_DLOPEN_FWD_VOID_OP,
-                         uct_ib_verbs, uct_ib_verbs_ops)
+UCT_IB_VERBS_OPTIONAL_OPS(UCT_IB_DLOPEN_FWD_OPTIONAL_OP,
+                          UCT_IB_DLOPEN_FWD_OPTIONAL_VOID_OP, uct_ib_verbs,
+                          uct_ib_verbs_ops)

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -24,12 +24,6 @@ AS_IF([test "x$with_verbs" = "xyes"], [with_verbs=/usr])
 AS_IF([test -d "$with_verbs"], [with_ib=yes; str="with verbs support from $with_verbs"], [with_ib=no; str="without verbs support"])
 AS_IF([test -d "$with_verbs/lib64"],[libsuff="64"],[libsuff=""])
 
-AS_IF([test "x$enable_ib_shim" = xyes -a \
-            "x$with_ib" = xyes -a \
-            "x$enable_shared" = xno -a \
-            "x$enable_static" = xyes],
-      [LDFLAGS="$LDFLAGS -Wl,-u,ucs_init"])
-
 AC_MSG_NOTICE([Compiling $str])
 
 

--- a/src/uct/ib/configure.m4
+++ b/src/uct/ib/configure.m4
@@ -13,9 +13,22 @@ AC_ARG_WITH([verbs],
         [],
         [with_verbs=/usr])
 
+AC_ARG_ENABLE([ib-shim],
+              [AS_HELP_STRING([--enable-ib-shim],
+                              [Load libibverbs and libmlx5 at runtime
+                               instead of linking them directly])],
+              [],
+              [enable_ib_shim=no])
+
 AS_IF([test "x$with_verbs" = "xyes"], [with_verbs=/usr])
 AS_IF([test -d "$with_verbs"], [with_ib=yes; str="with verbs support from $with_verbs"], [with_ib=no; str="without verbs support"])
 AS_IF([test -d "$with_verbs/lib64"],[libsuff="64"],[libsuff=""])
+
+AS_IF([test "x$enable_ib_shim" = xyes -a \
+            "x$with_ib" = xyes -a \
+            "x$enable_shared" = xno -a \
+            "x$enable_static" = xyes],
+      [LDFLAGS="$LDFLAGS -Wl,-u,ucs_init"])
 
 AC_MSG_NOTICE([Compiling $str])
 
@@ -109,14 +122,27 @@ AS_IF([test "x$with_ib" = "xyes"],
         CPPFLAGS="$verbs_incl $CPPFLAGS"
         AC_CHECK_HEADER([infiniband/verbs.h], [],
                         [AC_MSG_WARN([ibverbs header files not found]); with_ib=no])
-        AC_CHECK_LIB([ibverbs], [ibv_get_device_list],
-            [
-            AC_SUBST(IBVERBS_LDFLAGS,  ["$verbs_libs -libverbs"])
-            AC_SUBST(IBVERBS_DIR,      ["$with_verbs"])
-            AC_SUBST(IBVERBS_CPPFLAGS, ["$verbs_incl"])
-            AC_SUBST(IBVERBS_CFLAGS,   ["$verbs_incl"])
-            ],
-            [AC_MSG_WARN([libibverbs not found]); with_ib=no])
+        AS_IF([test "x$enable_ib_shim" = "xyes"],
+              [AS_IF([test "x$with_ib" = "xyes"],
+                     [
+                     AC_DEFINE([HAVE_IB_SHIM], 1, [IB shim support])
+                     AC_SUBST(IBVERBS_LDFLAGS,  ["-ldl"])
+                     AC_SUBST(IBVERBS_DIR,      ["$with_verbs"])
+                     AC_SUBST(IBVERBS_CPPFLAGS, ["$verbs_incl"])
+                     AC_SUBST(IBVERBS_CFLAGS,   ["$verbs_incl"])
+                     AC_SUBST(IBVERBS_REQUIRES, [""])
+                     AC_SUBST(MLX5_REQUIRES,    [""])
+                     ])],
+              [AC_CHECK_LIB([ibverbs], [ibv_get_device_list],
+                   [
+                   AC_SUBST(IBVERBS_LDFLAGS,  ["$verbs_libs -libverbs"])
+                   AC_SUBST(IBVERBS_DIR,      ["$with_verbs"])
+                   AC_SUBST(IBVERBS_CPPFLAGS, ["$verbs_incl"])
+                   AC_SUBST(IBVERBS_CFLAGS,   ["$verbs_incl"])
+                   AC_SUBST(IBVERBS_REQUIRES, ["libibverbs"])
+                   AC_SUBST(MLX5_REQUIRES,    ["libmlx5"])
+                   ],
+                   [AC_MSG_WARN([libibverbs not found]); with_ib=no])])
 
         have_ib_funcs=yes
         LDFLAGS="$LDFLAGS $IBVERBS_LDFLAGS"
@@ -155,11 +181,14 @@ AS_IF([test "x$with_ib" = "xyes"],
 
               AC_MSG_NOTICE([Checking for DV bare-metal support])
 
-              AC_CHECK_LIB([mlx5-rdmav2], [mlx5dv_query_device],
-                                    [AC_SUBST(LIB_MLX5, [-lmlx5-rdmav2])],[
-              AC_CHECK_LIB([mlx5], [mlx5dv_query_device],
-                                    [AC_SUBST(LIB_MLX5, [-lmlx5])],
-                                    [have_mlx5=no], [-libverbs])], [-libverbs])
+              AS_IF([test "x$enable_ib_shim" = "xyes"],
+                    [AC_SUBST(LIB_MLX5, [])],
+                    [AC_CHECK_LIB([mlx5-rdmav2], [mlx5dv_query_device],
+                                       [AC_SUBST(LIB_MLX5, [-lmlx5-rdmav2])],[
+                     AC_CHECK_LIB([mlx5], [mlx5dv_query_device],
+                                       [AC_SUBST(LIB_MLX5, [-lmlx5])],
+                                       [have_mlx5=no],
+                                       [-libverbs])], [-libverbs])])
 
               AS_IF([test "x$have_mlx5" = xyes], [
                        AC_CHECK_HEADERS([infiniband/mlx5dv.h],
@@ -369,6 +398,8 @@ AS_IF([test "x$with_ib" = "xyes"],
 # For automake
 #
 AM_CONDITIONAL([HAVE_IB],      [test "x$with_ib" != xno])
+AM_CONDITIONAL([HAVE_IB_SHIM],
+               [test "x$enable_ib_shim" = xyes -a "x$with_ib" != xno])
 AM_CONDITIONAL([HAVE_MLX5_DV], [test "x$have_mlx5" = xyes])
 AM_CONDITIONAL([HAVE_TL_RC],   [test "x$with_rc" != xno])
 AM_CONDITIONAL([HAVE_TL_DC],   [test "x$with_dc" != xno])

--- a/src/uct/ib/mlx5/Makefile.am
+++ b/src/uct/ib/mlx5/Makefile.am
@@ -24,6 +24,11 @@ libuct_ib_mlx5_la_SOURCES = \
 	dv/ib_mlx5_dv.c \
 	dv/ib_mlx5dv_md.c
 
+if HAVE_IB_SHIM
+libuct_ib_mlx5_la_SOURCES += \
+	ib_mlx5_dlopen.c
+endif
+
 noinst_HEADERS = \
 	ib_mlx5_log.h \
 	ib_mlx5.h \

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -1251,8 +1251,31 @@ extern uct_tl_t UCT_TL_NAME(ud_mlx5);
 extern uct_ib_md_ops_entry_t UCT_IB_MD_OPS_NAME(devx);
 extern uct_ib_md_ops_entry_t UCT_IB_MD_OPS_NAME(dv);
 
+#if defined(HAVE_IB_SHIM)
+static int uct_mlx5_initialized;
+#endif
+
 void UCS_F_CTOR uct_mlx5_init(void)
 {
+#if defined(HAVE_IB_SHIM) && defined(HAVE_MLX5_DV)
+    uct_ib_dlopen_status_t dlopen_status;
+    const char *library_name, *symbol_name, *error_msg;
+
+    dlopen_status = uct_ib_mlx5_dlopen_check(&library_name, &symbol_name,
+                                             &error_msg);
+    if (dlopen_status != UCT_IB_DLOPEN_STATUS_OK) {
+        if (dlopen_status == UCT_IB_DLOPEN_STATUS_MISSING_SYM) {
+            ucs_diag("mlx5 transports are disabled: %s is missing symbol %s: "
+                     "%s", library_name, symbol_name, error_msg);
+        } else {
+            ucs_diag("mlx5 transports are disabled: %s: %s: %s",
+                     library_name,
+                     uct_ib_dlopen_status_string(dlopen_status), error_msg);
+        }
+        return;
+    }
+#endif
+
 #if defined (HAVE_MLX5_DV)
     ucs_list_add_head(&uct_ib_ops, &UCT_IB_MD_OPS_NAME(dv).list);
 #endif
@@ -1269,10 +1292,19 @@ void UCS_F_CTOR uct_mlx5_init(void)
 #if defined (HAVE_TL_UD) && defined (HAVE_MLX5_HW_UD)
     uct_tl_register(&uct_ib_component, &UCT_TL_NAME(ud_mlx5));
 #endif
+#if defined(HAVE_IB_SHIM)
+    uct_mlx5_initialized = 1;
+#endif
 }
 
 void UCS_F_DTOR uct_mlx5_cleanup(void)
 {
+#if defined(HAVE_IB_SHIM)
+    if (!uct_mlx5_initialized) {
+        return;
+    }
+#endif
+
 #if defined (HAVE_TL_UD) && defined (HAVE_MLX5_HW_UD)
     uct_tl_unregister(&UCT_TL_NAME(ud_mlx5));
 #endif

--- a/src/uct/ib/mlx5/ib_mlx5_dlopen.c
+++ b/src/uct/ib/mlx5/ib_mlx5_dlopen.c
@@ -1,0 +1,152 @@
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <uct/ib/base/ib_dlopen.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <infiniband/mlx5dv.h>
+
+#define UCT_IB_MLX5_LIB_NAME "libmlx5.so.1"
+
+#if HAVE_DECL_MLX5DV_REG_DMABUF_MR
+#define UCT_IB_MLX5_DMABUF_OPS(_op, _module, _ops) \
+    _op(_module, _ops, struct ibv_mr *, NULL, mlx5dv_reg_dmabuf_mr, \
+        (struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, \
+         int fd, int access, int mlx5_access), \
+        (pd, offset, length, iova, fd, access, mlx5_access))
+#else
+#define UCT_IB_MLX5_DMABUF_OPS(_op, _module, _ops)
+#endif
+
+#if HAVE_DECL_MLX5DV_GET_DATA_DIRECT_SYSFS_PATH
+#define UCT_IB_MLX5_DATA_DIRECT_OPS(_op, _module, _ops) \
+    _op(_module, _ops, int, -1, mlx5dv_get_data_direct_sysfs_path, \
+        (struct ibv_context *context, char *buf, size_t buf_len), \
+        (context, buf, buf_len))
+#else
+#define UCT_IB_MLX5_DATA_DIRECT_OPS(_op, _module, _ops)
+#endif
+
+#define UCT_IB_MLX5_BASE_OPS(_op, _module, _ops) \
+    _op(_module, _ops, bool, false, mlx5dv_is_supported, \
+        (struct ibv_device *device), (device)) \
+    _op(_module, _ops, int, -1, mlx5dv_query_device, \
+        (struct ibv_context *ctx_in, struct mlx5dv_context *attrs_out), \
+        (ctx_in, attrs_out)) \
+    _op(_module, _ops, struct ibv_qp *, NULL, mlx5dv_create_qp, \
+        (struct ibv_context *context, struct ibv_qp_init_attr_ex *qp_attr, \
+         struct mlx5dv_qp_init_attr *mlx5_qp_attr), \
+        (context, qp_attr, mlx5_qp_attr)) \
+    _op(_module, _ops, struct ibv_cq_ex *, NULL, mlx5dv_create_cq, \
+        (struct ibv_context *context, struct ibv_cq_init_attr_ex *cq_attr, \
+         struct mlx5dv_cq_init_attr *mlx5_cq_attr), \
+        (context, cq_attr, mlx5_cq_attr)) \
+    _op(_module, _ops, int, -1, mlx5dv_init_obj, \
+        (struct mlx5dv_obj *obj, uint64_t obj_type), (obj, obj_type))
+
+#if HAVE_DEVX
+#define UCT_IB_MLX5_DEVX_VOID_OPS(_op, _module, _ops) \
+    _op(_module, _ops, mlx5dv_devx_free_uar, \
+        (struct mlx5dv_devx_uar *devx_uar), (devx_uar)) \
+    _op(_module, _ops, mlx5dv_devx_destroy_event_channel, \
+        (struct mlx5dv_devx_event_channel *event_channel), (event_channel))
+
+#define UCT_IB_MLX5_DEVX_OPS(_op, _module, _ops) \
+    _op(_module, _ops, struct ibv_context *, NULL, mlx5dv_open_device, \
+        (struct ibv_device *device, struct mlx5dv_context_attr *attr), \
+        (device, attr)) \
+    _op(_module, _ops, struct mlx5dv_mkey *, NULL, mlx5dv_create_mkey, \
+        (struct mlx5dv_mkey_init_attr *mkey_init_attr), (mkey_init_attr)) \
+    _op(_module, _ops, int, -1, mlx5dv_destroy_mkey, \
+        (struct mlx5dv_mkey *mkey), (mkey)) \
+    _op(_module, _ops, struct mlx5dv_devx_obj *, NULL, \
+        mlx5dv_devx_obj_create, \
+        (struct ibv_context *context, const void *in, size_t inlen, \
+         void *out, size_t outlen), (context, in, inlen, out, outlen)) \
+    _op(_module, _ops, int, -1, mlx5dv_devx_obj_destroy, \
+        (struct mlx5dv_devx_obj *obj), (obj)) \
+    _op(_module, _ops, int, -1, mlx5dv_devx_obj_modify, \
+        (struct mlx5dv_devx_obj *obj, const void *in, size_t inlen, \
+         void *out, size_t outlen), (obj, in, inlen, out, outlen)) \
+    _op(_module, _ops, int, -1, mlx5dv_devx_obj_query, \
+        (struct mlx5dv_devx_obj *obj, const void *in, size_t inlen, \
+         void *out, size_t outlen), (obj, in, inlen, out, outlen)) \
+    _op(_module, _ops, int, -1, mlx5dv_devx_general_cmd, \
+        (struct ibv_context *context, const void *in, size_t inlen, \
+         void *out, size_t outlen), (context, in, inlen, out, outlen)) \
+    _op(_module, _ops, int, -1, mlx5dv_devx_qp_modify, \
+        (struct ibv_qp *qp, const void *in, size_t inlen, void *out, \
+         size_t outlen), (qp, in, inlen, out, outlen)) \
+    _op(_module, _ops, int, -1, mlx5dv_devx_qp_query, \
+        (struct ibv_qp *qp, const void *in, size_t inlen, void *out, \
+         size_t outlen), (qp, in, inlen, out, outlen)) \
+    _op(_module, _ops, struct mlx5dv_devx_umem *, NULL, \
+        mlx5dv_devx_umem_reg, \
+        (struct ibv_context *ctx, void *addr, size_t size, \
+         uint32_t access), (ctx, addr, size, access)) \
+    _op(_module, _ops, int, -1, mlx5dv_devx_umem_dereg, \
+        (struct mlx5dv_devx_umem *umem), (umem)) \
+    _op(_module, _ops, struct mlx5dv_devx_uar *, NULL, \
+        mlx5dv_devx_alloc_uar, \
+        (struct ibv_context *context, uint32_t flags), (context, flags)) \
+    _op(_module, _ops, int, -1, mlx5dv_devx_query_eqn, \
+        (struct ibv_context *context, uint32_t vector, uint32_t *eqn), \
+        (context, vector, eqn)) \
+    _op(_module, _ops, struct mlx5dv_devx_event_channel *, NULL, \
+        mlx5dv_devx_create_event_channel, \
+        (struct ibv_context *context, \
+         enum mlx5dv_devx_create_event_channel_flags flags), \
+        (context, flags)) \
+    _op(_module, _ops, int, -1, mlx5dv_devx_subscribe_devx_event, \
+        (struct mlx5dv_devx_event_channel *event_channel, \
+         struct mlx5dv_devx_obj *obj, uint16_t events_sz, \
+         uint16_t events_num[], uint64_t cookie), \
+        (event_channel, obj, events_sz, events_num, cookie)) \
+    _op(_module, _ops, ssize_t, -1, mlx5dv_devx_get_event, \
+        (struct mlx5dv_devx_event_channel *event_channel, \
+         struct mlx5dv_devx_async_event_hdr *event_data, \
+         size_t event_resp_len), (event_channel, event_data, event_resp_len))
+#else
+#define UCT_IB_MLX5_DEVX_VOID_OPS(_op, _module, _ops)
+#define UCT_IB_MLX5_DEVX_OPS(_op, _module, _ops)
+#endif
+
+#if HAVE_DEVX && HAVE_DECL_MLX5DV_UMEM_MASK_DMABUF
+#define UCT_IB_MLX5_DEVX_UMEM_EX_OPS(_op, _module, _ops) \
+    _op(_module, _ops, struct mlx5dv_devx_umem *, NULL, \
+        mlx5dv_devx_umem_reg_ex, \
+        (struct ibv_context *ctx, struct mlx5dv_devx_umem_in *umem_in), \
+        (ctx, umem_in))
+#else
+#define UCT_IB_MLX5_DEVX_UMEM_EX_OPS(_op, _module, _ops)
+#endif
+
+#define UCT_IB_MLX5_OPS(_op, _void_op, _module, _ops) \
+    UCT_IB_MLX5_BASE_OPS(_op, _module, _ops) \
+    UCT_IB_MLX5_DEVX_OPS(_op, _module, _ops) \
+    UCT_IB_MLX5_DEVX_VOID_OPS(_void_op, _module, _ops) \
+    UCT_IB_MLX5_DEVX_UMEM_EX_OPS(_op, _module, _ops) \
+    UCT_IB_MLX5_DMABUF_OPS(_op, _module, _ops) \
+    UCT_IB_MLX5_DATA_DIRECT_OPS(_op, _module, _ops)
+
+typedef struct uct_ib_mlx5_ops {
+    UCT_IB_MLX5_OPS(UCT_IB_DLOPEN_OP_FIELD, UCT_IB_DLOPEN_VOID_OP_FIELD,
+                    uct_ib_mlx5, uct_ib_mlx5_ops)
+} uct_ib_mlx5_ops_t;
+
+UCT_IB_DLOPEN_DEFINE_MODULE(uct_ib_mlx5, UCT_IB_MLX5_LIB_NAME,
+                            uct_ib_mlx5_ops_t, UCT_IB_MLX5_OPS,
+                            uct_ib_mlx5_dlopen_check)
+
+UCT_IB_MLX5_OPS(UCT_IB_DLOPEN_FWD_OP, UCT_IB_DLOPEN_FWD_VOID_OP,
+                uct_ib_mlx5, uct_ib_mlx5_ops)

--- a/src/uct/ib/mlx5/ib_mlx5_dlopen.c
+++ b/src/uct/ib/mlx5/ib_mlx5_dlopen.c
@@ -131,22 +131,33 @@
 #define UCT_IB_MLX5_DEVX_UMEM_EX_OPS(_op, _module, _ops)
 #endif
 
-#define UCT_IB_MLX5_OPS(_op, _void_op, _module, _ops) \
+#define UCT_IB_MLX5_REQUIRED_OPS(_op, _void_op, _module, _ops) \
     UCT_IB_MLX5_BASE_OPS(_op, _module, _ops) \
     UCT_IB_MLX5_DEVX_OPS(_op, _module, _ops) \
-    UCT_IB_MLX5_DEVX_VOID_OPS(_void_op, _module, _ops) \
+    UCT_IB_MLX5_DEVX_VOID_OPS(_void_op, _module, _ops)
+
+/* Symbols not available in the minimum supported rdma-core v28. */
+#define UCT_IB_MLX5_OPTIONAL_OPS(_op, _void_op, _module, _ops) \
     UCT_IB_MLX5_DEVX_UMEM_EX_OPS(_op, _module, _ops) \
     UCT_IB_MLX5_DMABUF_OPS(_op, _module, _ops) \
     UCT_IB_MLX5_DATA_DIRECT_OPS(_op, _module, _ops)
 
 typedef struct uct_ib_mlx5_ops {
-    UCT_IB_MLX5_OPS(UCT_IB_DLOPEN_OP_FIELD, UCT_IB_DLOPEN_VOID_OP_FIELD,
-                    uct_ib_mlx5, uct_ib_mlx5_ops)
+    UCT_IB_MLX5_REQUIRED_OPS(UCT_IB_DLOPEN_OP_FIELD,
+                             UCT_IB_DLOPEN_VOID_OP_FIELD, uct_ib_mlx5,
+                             uct_ib_mlx5_ops)
+    UCT_IB_MLX5_OPTIONAL_OPS(UCT_IB_DLOPEN_OP_FIELD,
+                             UCT_IB_DLOPEN_VOID_OP_FIELD, uct_ib_mlx5,
+                             uct_ib_mlx5_ops)
 } uct_ib_mlx5_ops_t;
 
 UCT_IB_DLOPEN_DEFINE_MODULE(uct_ib_mlx5, UCT_IB_MLX5_LIB_NAME,
-                            uct_ib_mlx5_ops_t, UCT_IB_MLX5_OPS,
+                            uct_ib_mlx5_ops_t, UCT_IB_MLX5_REQUIRED_OPS,
+                            UCT_IB_MLX5_OPTIONAL_OPS,
                             uct_ib_mlx5_dlopen_check)
 
-UCT_IB_MLX5_OPS(UCT_IB_DLOPEN_FWD_OP, UCT_IB_DLOPEN_FWD_VOID_OP,
-                uct_ib_mlx5, uct_ib_mlx5_ops)
+UCT_IB_MLX5_REQUIRED_OPS(UCT_IB_DLOPEN_FWD_OP, UCT_IB_DLOPEN_FWD_VOID_OP,
+                         uct_ib_mlx5, uct_ib_mlx5_ops)
+UCT_IB_MLX5_OPTIONAL_OPS(UCT_IB_DLOPEN_FWD_OPTIONAL_OP,
+                         UCT_IB_DLOPEN_FWD_OPTIONAL_VOID_OP, uct_ib_mlx5,
+                         uct_ib_mlx5_ops)

--- a/src/uct/ib/mlx5/ucx-ib-mlx5.pc.in
+++ b/src/uct/ib/mlx5/ucx-ib-mlx5.pc.in
@@ -13,4 +13,4 @@ Description: Unified Communication X Library IB MLX5 module
 Version: @VERSION@
 Libs:
 Libs.private: -L${libdir} -luct_ib_mlx5 -Wl,--undefined=uct_mlx5_init @IBVERBS_LDFLAGS@
-Requires.private: libmlx5 libibverbs
+Requires.private: @MLX5_REQUIRES@ @IBVERBS_REQUIRES@

--- a/src/uct/ib/ucx-ib.pc.in
+++ b/src/uct/ib/ucx-ib.pc.in
@@ -13,4 +13,4 @@ Description: Unified Communication X Library IB module
 Version: @VERSION@
 Libs:
 Libs.private: -L${libdir} -luct_ib -Wl,--undefined=uct_ib_init @IBVERBS_LDFLAGS@
-Requires.private: libibverbs
+Requires.private: @IBVERBS_REQUIRES@


### PR DESCRIPTION
## What?

Add an IB verbs/MLX5 dlopen shim so static UCX binaries can include the IB
transports without carrying a direct libibverbs or libmlx5 dynamic dependency.

This supersedes #11726 and targets the master branch.

## Why?

Static UCX builds that include IB support should not force every binary to
depend on rdma-core at load time. Delaying libibverbs and libmlx5 loading until
UCX initializes the IB components keeps those binaries usable on systems where
the verbs stack is absent, while preserving normal IB behavior when the
libraries are installed.

## How?

- Add shared dlopen helper code and libibverbs/libmlx5 forwarding tables.
- Build wrappers only for features enabled by the matching configure guards,
  including DEVX, DMABUF, ECE, netlink, Direct NIC, fork status, port speed,
  and extended umem support.
- Treat every wrapper included in the build as a required runtime symbol.
- Remove direct libibverbs/libmlx5 link dependencies when the shim is enabled.
- Retain constructor-only UCX/IB objects in static binaries.
- Skip IB or MLX5 component registration when its runtime library or a required
  symbol is unavailable.
