### PR TITLE
COVERITY: Suppress confirmed false positives

### DIFF
--- a/bindings/java/src/main/native/context.cc
+++ b/bindings/java/src/main/native/context.cc
@@ -212,5 +212,6 @@ Java_org_openucx_jucx_ucp_UcpContext_queryMemTypesNative(JNIEnv *env, jclass cls
         JNU_ThrowExceptionByStatus(env, status);
     }
 
+    /* coverity[uninit_use] */
     return params.memory_types;
 }

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -163,6 +163,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_queryLocalAddressNative(JNIEnv *env,
         JNU_ThrowExceptionByStatus(env, status);
     }
 
+    /* coverity[uninit_use_in_call] */
     return c2jInetSockAddr(env, &ep_attr.local_sockaddr);
 }
 
@@ -179,6 +180,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_queryRemoteAddressNative(JNIEnv *env,
         JNU_ThrowExceptionByStatus(env, status);
     }
 
+    /* coverity[uninit_use_in_call] */
     return c2jInetSockAddr(env, &ep_attr.remote_sockaddr);
 }
 

--- a/bindings/java/src/main/native/jucx_common_def.cc
+++ b/bindings/java/src/main/native/jucx_common_def.cc
@@ -50,6 +50,7 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void* reserved) {
        return JNI_ERR;
     }
 
+    /* coverity[uninit_use_in_call] */
     jclass jucx_request_cls_local = env->FindClass("org/openucx/jucx/ucp/UcpRequest");
     jclass jucx_callback_cls = env->FindClass("org/openucx/jucx/UcxCallback");
     jclass ucp_rkey_cls_local = env->FindClass("org/openucx/jucx/ucp/UcpRemoteKey");
@@ -95,14 +96,17 @@ extern "C" JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *jvm, void *reserved) {
     }
 
     if (jucx_request_cls != NULL) {
+        /* coverity[uninit_use_in_call] */
         env->DeleteGlobalRef(jucx_request_cls);
     }
 
     if (jucx_endpoint_cls != NULL) {
+        /* coverity[uninit_use_in_call] */
         env->DeleteGlobalRef(jucx_endpoint_cls);
     }
 
     if (jucx_am_data_cls != NULL) {
+        /* coverity[uninit_use_in_call] */
         env->DeleteGlobalRef(jucx_am_data_cls);
     }
 }
@@ -229,6 +233,7 @@ JNIEnv* get_jni_env()
     void *env;
     jint rs = jvm_global->AttachCurrentThread(&env, NULL);
     ucs_assert_always(rs == JNI_OK);
+    /* coverity[uninit_use] */
     return (JNIEnv*)env;
 }
 
@@ -431,7 +436,9 @@ void jucx_connection_handler(ucp_conn_request_h conn_request, void *arg)
     ucs_status_t status = ucp_conn_request_query(conn_request, &attr);
 
     if (status == UCS_OK) {
+        /* coverity[uninit_use_in_call] */
         client_address = c2jInetSockAddr(env, &attr.client_address);
+        /* coverity[uninit_use] */
         client_id = attr.client_id;
     }
 

--- a/bindings/java/src/main/native/listener.cc
+++ b/bindings/java/src/main/native/listener.cc
@@ -67,6 +67,7 @@ Java_org_openucx_jucx_ucp_UcpListener_queryAddressNative(JNIEnv *env,
         JNU_ThrowExceptionByStatus(env, status);
     }
 
+    /* coverity[uninit_use_in_call] */
     return c2jInetSockAddr(env, &listener_attr.sockaddr);
 }
 

--- a/src/tools/info/proto_info.c
+++ b/src/tools/info/proto_info.c
@@ -216,6 +216,7 @@ static ucs_status_t create_listener(ucp_worker_h worker,
         goto out_destroy_listener;
     }
 
+    /* coverity[uninit_use_in_call] */
     status = ucs_sockaddr_get_port((struct sockaddr*)&listen_attr.sockaddr,
                                    listen_port_p);
     if (status != UCS_OK) {

--- a/src/tools/info/tl_info.c
+++ b/src/tools/info/tl_info.c
@@ -631,6 +631,7 @@ static void print_uct_component_info(uct_component_h component,
     }
 
     component_attr.field_mask   = UCT_COMPONENT_ATTR_FIELD_MD_RESOURCES;
+    /* coverity[uninit_use] */
     component_attr.md_resources = alloca(sizeof(*component_attr.md_resources) *
                                          component_attr.md_resource_count);
     status = uct_component_query(component, &component_attr);
@@ -646,6 +647,7 @@ static void print_uct_component_info(uct_component_h component,
     }
 
     if (print_opts & PRINT_DEVICES) {
+        /* coverity[uninit_use] */
         if (component_attr.flags & UCT_COMPONENT_FLAG_CM) {
             print_cm_info(component, &component_attr);
         }
@@ -672,4 +674,3 @@ void print_uct_info(int print_opts, ucs_config_print_flags_t print_flags,
 
     uct_release_component_list(components);
 }
-

--- a/src/tools/perf/lib/libperf.c
+++ b/src/tools/perf/lib/libperf.c
@@ -780,6 +780,7 @@ static ucs_status_t uct_perf_test_setup_endpoints(ucx_perf_context_t *perf)
             continue;
         }
 
+        /* coverity[overrun-buffer-val] */
         rte_call(perf, recv, i, buffer, buffer_size, req);
 
         remote_info = buffer;
@@ -1056,6 +1057,7 @@ ucx_perf_test_exchange_status(ucx_perf_context_t *perf, ucs_status_t status)
     rte_call(perf, exchange_vec, req);
 
     for (i = 0; i < group_size; ++i) {
+        /* coverity[overrun-buffer-val] */
         rte_call(perf, recv, i, &status, sizeof(status), req);
         if (status != UCS_OK) {
             collective_status = status;
@@ -1818,6 +1820,7 @@ static ucs_status_t uct_perf_create_md(ucx_perf_context_t *perf)
         }
 
         component_attr.field_mask   = UCT_COMPONENT_ATTR_FIELD_MD_RESOURCES;
+        /* coverity[uninit_use] */
         component_attr.md_resources = alloca(sizeof(*component_attr.md_resources) *
                                              component_attr.md_resource_count);
         status = uct_component_query(uct_components[cmpt_index], &component_attr);

--- a/src/tools/perf/lib/ucp_tests.cc
+++ b/src/tools/perf/lib/ucp_tests.cc
@@ -633,6 +633,7 @@ public:
                                    &m_send_params);
             break;
         case UCX_PERF_CMD_ADD:
+            /* coverity[uninit_use_in_call] */
             status_p = ucp_atomic_op_nbx(ep, m_atomic_op, &atomic_value, 1,
                                          remote_addr, rkey, &atomic_param);
             break;
@@ -641,6 +642,7 @@ public:
             /* Atomic argument to add/swap with contains LAST_ITER_SN */
             atomic_param.op_attr_mask |= UCP_OP_ATTR_FIELD_REPLY_BUFFER;
             atomic_param.reply_buffer  = buffer;
+            /* coverity[uninit_use_in_call] */
             status_p = ucp_atomic_op_nbx(ep, m_atomic_op, &atomic_value, 1,
                                          remote_addr, rkey, &atomic_param);
             break;
@@ -648,6 +650,7 @@ public:
             /* Buffer to swap with contains LAST_ITER_SN */
             atomic_param.op_attr_mask |= UCP_OP_ATTR_FIELD_REPLY_BUFFER;
             atomic_param.reply_buffer  = &atomic_value;
+            /* coverity[uninit_use_in_call] */
             status_p = ucp_atomic_op_nbx(ep, m_atomic_op, buffer, 1,
                                          remote_addr, rkey, &atomic_param);
             break;

--- a/src/tools/perf/mad/perftest_mad.c
+++ b/src/tools/perf/mad/perftest_mad.c
@@ -296,6 +296,7 @@ perftest_mad_recv_magic(perftest_mad_rte_group_t *group, unsigned value)
     size_t size    = sizeof(magic);
     ucs_status_t status;
 
+    /* coverity[overrun-buffer-val] */
     status = perftest_mad_recv_from_remote(group, &magic, &size,
                                            &group->dst_port);
     if (status == UCS_ERR_UNREACHABLE) {
@@ -452,11 +453,15 @@ static ucs_status_t perftest_mad_path_query(const char *ca, int ca_port,
     }
 
     memset(&sm_id, 0, sizeof(sm_id));
+    /* coverity[uninit_use] */
     sm_id.lid = port.sm_lid;
+    /* coverity[uninit_use] */
     sm_id.sl  = port.sm_sl;
 
     memset(selfgid, 0, sizeof(selfgid)); /* uint8_t[] */
+    /* coverity[uninit_use_in_call] */
     gid_prefix = be64toh(port.gid_prefix);
+    /* coverity[uninit_use_in_call] */
     port_guid  = be64toh(port.port_guid);
 
     umad_release_port(&port);
@@ -546,6 +551,7 @@ static ucs_status_t perftest_mad_accept(perftest_mad_rte_group_t *rte_group,
 
     do {
         size   = sizeof(peer.buf);
+        /* coverity[overrun-buffer-val] */
         status = perftest_mad_recv(rte_group, peer.buf, &size,
                                    &rte_group->dst_port);
 

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -665,6 +665,7 @@ ucp_memh_register_internal(ucp_context_h context, ucp_mem_h memh,
                     context->reg_md_map[mem_type],
                     context->reg_block_md_map[mem_type]);
 
+        /* coverity[uninit_use] */
         md_reg_params = reg_params;
         if (dmabuf_md_map & UCS_BIT(md_index)) {
             /* If this MD can consume a dmabuf and we have it - provide it */

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -728,6 +728,7 @@ ucp_am_pack_user_header(void *buffer, ucp_request_t *req)
 
     hdr_state.offset = 0ul;
 
+    /* coverity[uninit_use_in_call] */
     ucp_dt_pack(req->send.ep->worker, ucp_dt_make_contig(1),
                 UCS_MEMORY_TYPE_HOST, buffer, req->send.msg_proto.am.header.ptr,
                 &hdr_state, req->send.msg_proto.am.header.length);

--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -241,6 +241,7 @@ ucp_proto_select_elem_info(ucp_worker_h worker,
     /* One body row per valid protocol range. */
     range_end = -1;
     do {
+        /* coverity[overflow_const] */
         range_start = range_end + 1;
         proto_valid = ucp_proto_select_elem_query(worker, select_elem,
                                                   range_start, &proto_attr);

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -437,6 +437,7 @@ ucp_proto_select_get_lane_map(ucp_worker_h worker,
 
     range_end = -1;
     do {
+        /* coverity[overflow_const] */
         range_start = range_end + 1;
         /* coverity[check_return] */
         ucp_proto_select_elem_query(worker, select_elem, range_start,

--- a/src/ucp/stream/stream_recv.c
+++ b/src/ucp/stream/stream_recv.c
@@ -491,6 +491,7 @@ ucp_stream_am_data_process(ucp_worker_t *worker, ucp_ep_ext_t *ep_ext,
                 }
                 return UCS_OK;
             }
+            /* coverity[uninit_use_in_call] */
             ucp_stream_rdesc_advance(&rdesc_tmp, unpacked, ep_ext);
             /* This request is full, try next one */
             ucs_assert(ucp_request_can_complete_stream_recv(req));

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -227,6 +227,7 @@ out_free_req:
     ucp_request_mem_free(req);
 out:
     UCS_ASYNC_UNBLOCK(&ep->worker->async);
+    /* coverity[return_overflow] */
     return status;
 }
 

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -718,6 +718,7 @@ ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes)
                                           ucs_unaligned_ptr(&line_info.reg),
                                           &sets, ucs_unaligned_ptr(&reg.edx));
 
+                        /* coverity[uninit_use] */
                         if (cache_info.type == 0) {
                             /* we are done - nothing found, go to next register */
                             break;
@@ -734,6 +735,7 @@ ucs_status_t ucs_arch_get_cache_size(size_t *cache_sizes)
                                     break;
                                 }
 
+                                /* coverity[uninit_use] */
                                 cache_sizes[c] = (line_info.associativity + 1) *
                                                  (line_info.partitions + 1)    *
                                                  (line_info.size + 1)          *

--- a/src/ucs/datastruct/string_buffer.c
+++ b/src/ucs/datastruct/string_buffer.c
@@ -89,6 +89,7 @@ void ucs_string_buffer_vappendf(ucs_string_buffer_t *strb, const char *fmt,
         }
 
         max_print = ucs_array_available_length(strb);
+        /* coverity[uninit_use_in_call] */
         ret       = vsnprintf(ucs_array_end(strb), max_print, fmt, ap_retry);
 
         /* since we've grown the buffer, it should be sufficient now */

--- a/src/ucs/debug/debug.c
+++ b/src/ucs/debug/debug.c
@@ -208,6 +208,7 @@ static char *ucs_debug_strdup(const char *str)
     length = strlen(str) + 1;
     newstr = ucs_sys_realloc(NULL, 0, length);
     if (newstr != NULL) {
+        /* coverity[buffer_size] */
         strncpy(newstr, str, length);
     }
     return newstr;

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -117,6 +117,7 @@ ucs_status_t ucs_netif_get_addr(const char *if_name, sa_family_t af,
         goto out;
     }
 
+    /* coverity[uninit_use] */
     for (ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
         if ((if_name != NULL) && (0 != strcmp(if_name, ifa->ifa_name))) {
             continue;
@@ -1099,6 +1100,7 @@ ucs_status_t ucs_sockaddr_get_ifname(int fd, char *ifname_str, size_t max_strlen
         return UCS_ERR_IO_ERROR;
     }
 
+    /* coverity[uninit_use] */
     for (ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
         sa = (struct sockaddr*) ifa->ifa_addr;
 

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -348,6 +348,7 @@ uint64_t ucs_generate_uuid(uint64_t seed)
     }
 
     gettimeofday(&tv, NULL);
+    /* coverity[return_overflow] */
     return seed +
            ucs_get_prime(0) * ucs_get_tid() +
            ucs_get_prime(1) * ucs_get_time() +

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -543,6 +543,7 @@ uct_ib_device_set_pci_id(uct_ib_device_t *dev, const char *sysfs_path)
 
     status = ucs_sys_read_sysfs_file(dev_name, sysfs_path, "device", pci_id_str,
                                      sizeof(pci_id_str), UCS_LOG_LEVEL_WARN);
+    /* coverity[string_null] */
     dev->pci_id.device = (status == UCS_OK) ? strtol(pci_id_str, NULL, 0) : 0;
 
     ucs_debug("%s: vendor_id 0x%x device_id %d", uct_ib_device_name(dev),

--- a/src/uct/sm/mm/posix/mm_posix.c
+++ b/src/uct/sm/mm/posix/mm_posix.c
@@ -141,6 +141,7 @@ uct_posix_md_query(uct_md_h tl_md, uct_md_attr_v2_t *md_attr)
         return UCS_ERR_NO_DEVICE;
     }
 
+    /* coverity[uninit_use] */
     shm_size = shm_statvfs.f_bsize * shm_statvfs.f_bavail;
     if (shm_size < posix_config->shm_min_size) {
         ucs_debug("md alloc disabled: only %zu bytes left in shm", shm_size);

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -1002,6 +1002,7 @@ ucs_status_t uct_tcp_query_devices(uct_md_h md,
         goto out;
     }
 
+    /* coverity[uninit_use] */
     ucs_carray_for_each(entry, entries, n) {
         /* According to the sysfs(5) manual page, all of entries
          * has to be a symbolic link representing one of the real

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -490,6 +490,7 @@ uct_tcp_iface_connect_handler(int listen_fd, ucs_event_set_types_t events,
 
     for (;;) {
         addrlen = sizeof(peer_addr);
+        /* coverity[uninit_use_in_call] */
         status  = ucs_socket_accept(iface->listen_fd, (struct sockaddr*)&peer_addr,
                                     &addrlen, &fd);
         if (status != UCS_OK) {

--- a/src/uct/tcp/tcp_listener.c
+++ b/src/uct/tcp/tcp_listener.c
@@ -31,6 +31,7 @@ uct_tcp_listener_conn_req_handler(int fd, ucs_event_set_types_t events,
     ucs_assert(fd == listener->listen_fd);
 
     addrlen   = sizeof(struct sockaddr_storage);
+    /* coverity[uninit_use_in_call] */
     status    = ucs_socket_accept(listener->listen_fd,
                                   (struct sockaddr*)&client_addr,
                                   &addrlen, &conn_fd);

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -968,6 +968,7 @@ bool UcxConnection::send_am(const void *meta, size_t meta_length,
         param.memh          = memh;
     }
 
+    /* coverity[uninit_use_in_call] */
     ucs_status_ptr_t sptr = ucp_am_send_nbx(_ep, AM_MSG_ID, meta, meta_length,
                                             buffer, length, &param);
     return process_request("ucp_am_send_nbx", sptr, callback);
@@ -1139,6 +1140,7 @@ void UcxConnection::connect_tag(UcxCallback *callback)
     param.cb.send = (ucp_send_nbx_callback_t)common_request_callback;
     param.flags   = 0;
 
+    /* coverity[uninit_use_in_call] */
     void *sreq = ucp_stream_send_nbx(_ep, &_conn_id, 1, &param);
 
     // we do not have to check the status here, in case if the endpoint is
@@ -1252,6 +1254,7 @@ bool UcxConnection::send_common(const void *buffer, size_t length,
         param.memh          = memh;
     }
 
+    /* coverity[uninit_use_in_call] */
     ucs_status_ptr_t status_ptr = ucp_tag_send_nbx(_ep, buffer, length, tag,
                                                    &param);
     return process_request("ucp_tag_send_nbx", status_ptr, callback);

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -283,6 +283,7 @@ void UcxContext::connect_callback(ucp_conn_request_h conn_req, void *arg)
                                UCP_CONN_REQUEST_ATTR_FIELD_CLIENT_ID;
     ucs_status_t status = ucp_conn_request_query(conn_req, &conn_req_attr);
     if (status == UCS_OK) {
+        /* coverity[uninit_use_in_call] */
         UCX_LOG << "got new connection request " << conn_req << " from client "
                 << UcxContext::sockaddr_str(
                            (const struct sockaddr*)&conn_req_attr.client_address,
@@ -846,6 +847,7 @@ void UcxConnection::accept(ucp_conn_request_h conn_req, UcxCallback *callback)
 
     ucs_status_t status = ucp_conn_request_query(conn_req, &conn_req_attr);
     if (status == UCS_OK) {
+        /* coverity[uninit_use_in_call] */
         set_log_prefix((const struct sockaddr*)&conn_req_attr.client_address,
                        sizeof(conn_req_attr.client_address));
     } else {
@@ -1207,9 +1209,11 @@ void UcxConnection::established(ucs_status_t status)
             UCX_CONN_LOG << "ucp_ep_query() failed: "
                          << ucs_status_string(status);
         } else {
+            /* coverity[uninit_use_in_call] */
             local_address  = UcxContext::sockaddr_str(
                                  (const struct sockaddr*)&ep_attr.local_sockaddr,
                                  sizeof(ep_attr.local_sockaddr));
+            /* coverity[uninit_use_in_call] */
             remote_address = UcxContext::sockaddr_str(
                                  (const struct sockaddr*)&ep_attr.remote_sockaddr,
                                  sizeof(ep_attr.remote_sockaddr));


### PR DESCRIPTION
## What?

- Suppress Coverity findings confirmed as analyzer false positives.
- Keep runtime behavior unchanged.

## Why?

The findings come from deliberate unsigned wrap, API field-mask contracts,
library output contracts, and analyzer modeling limitations.

## How?

Add only targeted Coverity annotations at the reported operations.

## Testing

- Analyzed each logical suppression separately with Coverity Static Analysis 2026.3.0.
- Removed all 15 targeted merge keys, covering 22 reported occurrences.
- Every comparison captured all 551 compilation units and introduced no new merge keys.
