### PR TITLE
COVERITY: Fix high-confidence findings

### DIFF
--- a/bindings/java/src/main/native/context.cc
+++ b/bindings/java/src/main/native/context.cc
@@ -98,6 +98,7 @@ Java_org_openucx_jucx_ucp_UcpContext_createContextNative(JNIEnv *env, jclass cls
         status = ucp_config_read(NULL, NULL, &config);
         if (status != UCS_OK) {
             JNU_ThrowExceptionByStatus(env, status);
+            return 0;
         }
 
         jucx_map_apply_config(env, config, &config_map);
@@ -107,12 +108,13 @@ Java_org_openucx_jucx_ucp_UcpContext_createContextNative(JNIEnv *env, jclass cls
     ucp_params.name = "jucx";
 
     status = ucp_init(&ucp_params, config, &ucp_context);
-    if (status != UCS_OK) {
-        JNU_ThrowExceptionByStatus(env, status);
-    }
-
     if (config != NULL) {
         ucp_config_release(config);
+    }
+
+    if (status != UCS_OK) {
+        JNU_ThrowExceptionByStatus(env, status);
+        return 0;
     }
 
     return (native_ptr)ucp_context;

--- a/bindings/java/src/main/native/context.cc
+++ b/bindings/java/src/main/native/context.cc
@@ -176,6 +176,7 @@ Java_org_openucx_jucx_ucp_UcpContext_memoryMapNative(JNIEnv *env, jobject ctx,
     ucs_status_t status = ucp_mem_map((ucp_context_h)ucp_context_ptr, &params, &memh);
     if (status != UCS_OK) {
         JNU_ThrowExceptionByStatus(env, status);
+        return NULL;
     }
 
     ucp_mem_attr_t attr = {0};
@@ -185,7 +186,9 @@ Java_org_openucx_jucx_ucp_UcpContext_memoryMapNative(JNIEnv *env, jobject ctx,
 
     status = ucp_mem_query(memh, &attr);
     if (status != UCS_OK) {
+        ucp_mem_unmap((ucp_context_h)ucp_context_ptr, memh);
         JNU_ThrowExceptionByStatus(env, status);
+        return NULL;
     }
 
     // Construct UcpMemory class
@@ -212,6 +215,7 @@ Java_org_openucx_jucx_ucp_UcpContext_queryMemTypesNative(JNIEnv *env, jclass cls
     ucs_status_t status = ucp_context_query((ucp_context_h)ucp_context_ptr, &params);
     if (status != UCS_OK) {
         JNU_ThrowExceptionByStatus(env, status);
+        return 0;
     }
 
     return params.memory_types;

--- a/bindings/java/src/main/native/endpoint.cc
+++ b/bindings/java/src/main/native/endpoint.cc
@@ -119,7 +119,12 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_createEndpointNative(JNIEnv *env, jobject 
         env->ReleaseStringChars(name, (const jchar*)ep_params.name);
     }
     if (status != UCS_OK) {
+        if (ep_params.field_mask & UCP_EP_PARAM_FIELD_ERR_HANDLER) {
+            env->DeleteWeakGlobalRef(
+                    reinterpret_cast<jweak>(ep_params.err_handler.arg));
+        }
         JNU_ThrowExceptionByStatus(env, status);
+        return 0;
     }
 
     return (native_ptr)endpoint;
@@ -161,6 +166,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_queryLocalAddressNative(JNIEnv *env,
     ucs_status_t status = ucp_ep_query((ucp_ep_h)ep_ptr, &ep_attr);
     if (status != UCS_OK) {
         JNU_ThrowExceptionByStatus(env, status);
+        return NULL;
     }
 
     return c2jInetSockAddr(env, &ep_attr.local_sockaddr);
@@ -177,6 +183,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_queryRemoteAddressNative(JNIEnv *env,
     ucs_status_t status = ucp_ep_query((ucp_ep_h)ep_ptr, &ep_attr);
     if (status != UCS_OK) {
         JNU_ThrowExceptionByStatus(env, status);
+        return NULL;
     }
 
     return c2jInetSockAddr(env, &ep_attr.remote_sockaddr);
@@ -191,6 +198,7 @@ Java_org_openucx_jucx_ucp_UcpEndpoint_unpackRemoteKey(JNIEnv *env, jclass cls,
     ucs_status_t status = ucp_ep_rkey_unpack((ucp_ep_h)ep_ptr, (void *)addr, &rkey);
     if (status != UCS_OK) {
         JNU_ThrowExceptionByStatus(env, status);
+        return NULL;
     }
 
     jobject result = new_rkey_instance(env, rkey);

--- a/bindings/java/src/main/native/listener.cc
+++ b/bindings/java/src/main/native/listener.cc
@@ -48,7 +48,12 @@ Java_org_openucx_jucx_ucp_UcpListener_createUcpListener(JNIEnv *env, jobject lis
 
     ucs_status_t status = ucp_listener_create(ucp_worker, &params, &listener);
     if (status != UCS_OK) {
+        if (params.field_mask & UCP_LISTENER_PARAM_FIELD_CONN_HANDLER) {
+            env->DeleteWeakGlobalRef(
+                    reinterpret_cast<jweak>(params.conn_handler.arg));
+        }
         JNU_ThrowExceptionByStatus(env, status);
+        return 0;
     }
 
     return (native_ptr)listener;
@@ -65,6 +70,7 @@ Java_org_openucx_jucx_ucp_UcpListener_queryAddressNative(JNIEnv *env,
     ucs_status_t status = ucp_listener_query((ucp_listener_h)listener_ptr, &listener_attr);
     if (status != UCS_OK) {
         JNU_ThrowExceptionByStatus(env, status);
+        return NULL;
     }
 
     return c2jInetSockAddr(env, &listener_attr.sockaddr);

--- a/bindings/java/src/main/native/worker.cc
+++ b/bindings/java/src/main/native/worker.cc
@@ -184,6 +184,7 @@ Java_org_openucx_jucx_ucp_UcpWorker_getEventFDNative(JNIEnv *env, jclass cls, jl
 
     if (status != UCS_OK) {
         JNU_ThrowExceptionByStatus(env, status);
+        return -1;
     }
 
     return fd;

--- a/src/ucm/util/sys.c
+++ b/src/ucm/util/sys.c
@@ -349,28 +349,31 @@ char *ucm_concat_path(char *buffer, size_t max, const char *dir, const char *fil
 {
     size_t len;
 
+    if (max == 0) {
+        return buffer;
+    }
+
     len = strlen(dir);
     while (len && (dir[len - 1] == '/')) {
         len--; /* trim closing '/' */
     }
 
-    len = ucs_min(len, max);
+    len = ucs_min(len, max - 1);
     memcpy(buffer, dir, len);
-    max -= len;
-    if (max < 2) { /* buffer is shorter than dir - copy dir only */
-        buffer[len - 1] = '\0';
+    buffer[len] = '\0';
+    if (len == (max - 1)) { /* buffer is shorter than dir - copy dir only */
         return buffer;
     }
 
-    buffer[len] = '/';
-    max--;
+    buffer[len++] = '/';
+    max          -= len;
 
     while (file[0] == '/') {
         file++; /* trim beginning '/' */
     }
 
-    strncpy(buffer + len + 1, file, max);
-    buffer[max + len] = '\0'; /* force close string */
+    strncpy(buffer + len, file, max);
+    buffer[max + len - 1] = '\0'; /* force close string */
 
     return buffer;
 }
@@ -399,4 +402,3 @@ void UCS_F_CTOR ucm_init()
     ucm_init_log();
     ucm_init_malloc_hook();
 }
-

--- a/src/ucs/arch/x86_64/cpu.c
+++ b/src/ucs/arch/x86_64/cpu.c
@@ -254,7 +254,7 @@ static double ucs_arch_x86_tsc_freq_from_cpu_model()
     warn = 0;
     max_ghz = 0.0;
     while (fgets(buf, sizeof(buf), f)) {
-        rc = sscanf(buf, "model name : %s", model);
+        rc = sscanf(buf, "model name : %255s", model);
         if (rc != 1) {
             continue;
         }
@@ -264,7 +264,7 @@ static double ucs_arch_x86_tsc_freq_from_cpu_model()
             continue;
         }
 
-        rc = sscanf(rate, "@ %lfGHz%[\n]", &ghz, newline);
+        rc = sscanf(rate, "@ %lfGHz%1[\n]", &ghz, newline);
         if (rc != 2) {
             continue;
         }

--- a/src/ucs/debug/memtrack.c
+++ b/src/ucs/debug/memtrack.c
@@ -311,6 +311,11 @@ static void ucs_memtrack_vfs_read(void *obj, ucs_string_buffer_t *strb,
     FILE *f;
 
     f = open_memstream(&buffer, &size);
+    if (f == NULL) {
+        ucs_string_buffer_appendf(strb, "<failed to create memory stream>");
+        return;
+    }
+
     ucs_memtrack_dump(f);
     fclose(f);
 

--- a/src/ucs/memory/numa.c
+++ b/src/ucs/memory/numa.c
@@ -197,7 +197,7 @@ ucs_numa_node_t ucs_numa_node_of_cpu(int cpu)
 
 ucs_numa_node_t ucs_numa_node_of_device(const char *dev_path)
 {
-    long parsed_node;
+    long parsed_node = -1;
     ucs_status_t status;
 
     status = ucs_read_file_number(&parsed_node, 1, "%s/numa_node", dev_path);

--- a/src/ucs/sys/sys.c
+++ b/src/ucs/sys/sys.c
@@ -33,6 +33,7 @@
 #include <dirent.h>
 #include <sched.h>
 #include <ctype.h>
+#include <limits.h>
 #ifdef HAVE_SYS_THR_H
 #include <sys/thr.h>
 #endif
@@ -675,17 +676,20 @@ static ssize_t ucs_get_meminfo_entry(const char* pattern, int is_kb)
 {
     char buf[256];
     char final_pattern[80];
-    int val = 0;
+    long long val;
+    long long scale = is_kb ? 1024 : 1;
     ssize_t val_b = -1;
     FILE *f;
 
     f = fopen("/proc/meminfo", "r");
     if (f != NULL) {
         snprintf(final_pattern, sizeof(final_pattern), "%s: %s%s", pattern,
-                 "%d", is_kb ? " kB" : "");
+                 "%lld", is_kb ? " kB" : "");
         while (fgets(buf, sizeof(buf), f)) {
             if (sscanf(buf, final_pattern, &val) == 1) {
-                val_b = val * (is_kb ? 1024ull : 1);
+                if ((val >= 0) && (val <= (SSIZE_MAX / scale))) {
+                    val_b = val * scale;
+                }
                 break;
             }
         }

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -1521,7 +1521,7 @@ double ucs_topo_get_pci_bw(const char *dev_name, const char *sysfs_path)
         goto out_max_bw;
     }
 
-    if ((sscanf(pci_speed_str, "%lf%s", &bw_gbps, gts) < 2) ||
+    if ((sscanf(pci_speed_str, "%lf%15s", &bw_gbps, gts) < 2) ||
         strcasecmp("GT/s", ucs_strtrim(gts))) {
         ucs_debug("%s: incorrect format of %s file: expected: <double> GT/s, "
                   "actual: %s\n",

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -248,6 +248,7 @@ uct_xpmem_rmem_add(xpmem_segid_t xsegid, uct_xpmem_remote_mem_t **rmem_p)
         goto err_free;
     }
 
+    ucs_rcache_set_default_params(&rcache_params);
     rcache_params.region_struct_size = sizeof(uct_xpmem_remote_region_t);
     rcache_params.ucm_events         = 0;
     rcache_params.ucm_event_priority = 0;

--- a/src/uct/tcp/tcp_net.c
+++ b/src/uct/tcp/tcp_net.c
@@ -125,7 +125,8 @@ ucs_status_t uct_tcp_netif_is_default(const char *if_name, int *result_p)
     Iface  Destination  Gateway  Flags  RefCnt  Use  Metric  Mask  MTU  Window  IRTT
     */
     while (fgets(str, sizeof(str), f) != NULL) {
-        ret = sscanf(str, "%s %*x %*x %*d %*d %*d %*d %x", name, &netmask);
+        ret = sscanf(str, "%127s %*x %*x %*d %*d %*d %*d %x", name,
+                     &netmask);
         if ((ret == 2) && !strcmp(name, if_name) && (netmask == 0)) {
             *result_p = 1;
             goto out;

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -104,6 +104,7 @@ gtest_SOURCES = \
 	common/test.cc \
 	\
 	ucm/malloc_hook.cc \
+	ucm/test_sys.cc \
 	\
 	uct/test_amo.cc \
 	uct/test_atomic_key_reg_rdma_mem_type.cc \

--- a/test/gtest/ucm/test_sys.cc
+++ b/test/gtest/ucm/test_sys.cc
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+
+extern "C" {
+#include <ucm/util/sys.h>
+}
+
+
+class test_ucm_sys : public ucs::test {
+};
+
+
+UCS_TEST_F(test_ucm_sys, concat_path_zero_capacity)
+{
+    char storage[] = {'x', 'y'};
+    char *buffer   = &storage[1];
+
+    EXPECT_EQ(buffer, ucm_concat_path(buffer, 0, "dir", "file"));
+    EXPECT_EQ('x', storage[0]);
+    EXPECT_EQ('y', storage[1]);
+}
+
+
+UCS_TEST_F(test_ucm_sys, concat_path_one_byte_empty_dir)
+{
+    char storage[] = {'x', 'y'};
+    char *buffer   = &storage[1];
+
+    EXPECT_EQ(buffer, ucm_concat_path(buffer, 1, "", "file"));
+    EXPECT_EQ('x', storage[0]);
+    EXPECT_EQ('\0', storage[1]);
+}
+
+
+UCS_TEST_F(test_ucm_sys, concat_path)
+{
+    char buffer[16];
+
+    EXPECT_EQ(buffer, ucm_concat_path(buffer, sizeof(buffer), "/usr/", "/lib"));
+    EXPECT_STREQ("/usr/lib", buffer);
+}


### PR DESCRIPTION
## What?

- Stop JUCX context creation after configuration or initialization failures.
- Handle zero-capacity path buffers.
- Initialize XPMEM remote cache defaults.
- Initialize the NUMA failure-path value.
- Handle memtrack memory-stream allocation failure.

## Why?

These are confirmed error-path, boundary, and initialization defects reported by Coverity.

## How?

Apply the smallest behavior-correcting change for each defect and add a focused
regression test for the path-buffer boundary case.

## Testing

- Analyzed each fix separately with Coverity Static Analysis 2026.3.0.
- Every retained fix removed its intended finding set.
- Every comparison captured all 551 compilation units and introduced no new merge keys.
- Passed all 3 focused UCM path-buffer tests.
