### PR TITLE
UCT/ROCM: Propagate asynchronous copy signal failures

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -134,6 +134,7 @@ Yiltan Hassan Temucin <yiltan.temucin@amd.com>
 Yossi Itigin <yosefe@nvidia.com>
 Yuriy Shestakov <yuriis@mellanox.com>
 Zhenlong Ma <zhenlongm@nvidia.com>
+Zhixian Li <anjoj0@users.noreply.github.com>
 Zhongkai Zhang <zhzhang@habana.ai>
 Zhu Yanjun <yanjunz@mellanox.com>
 Zihao Zhao <zizhao@nvidia.com>

--- a/src/uct/rocm/base/rocm_signal.c
+++ b/src/uct/rocm/base/rocm_signal.c
@@ -45,13 +45,25 @@ unsigned uct_rocm_base_progress(ucs_queue_head_t *signal_queue)
     static const unsigned max_signals = 16;
     unsigned count                    = 0;
     uct_rocm_base_signal_desc_t *rocm_signal;
+    hsa_signal_value_t signal_value;
     hsa_status_t status;
+    ucs_status_t completion_status;
 
     ucs_queue_for_each_extract(rocm_signal, signal_queue, queue,
-			       (hsa_signal_load_scacquire(rocm_signal->signal) == 0) &&
-			       (count < max_signals)) {
+                               (hsa_signal_load_scacquire(
+                                        rocm_signal->signal) <= 0) &&
+                               (count < max_signals)) {
+        signal_value = hsa_signal_load_scacquire(rocm_signal->signal);
+        if (signal_value < 0) {
+            ucs_error("rocm async copy failed with signal value %ld",
+                      (long)signal_value);
+            completion_status = UCS_ERR_IO_ERROR;
+        } else {
+            completion_status = UCS_OK;
+        }
+
         if (rocm_signal->comp != NULL) {
-            uct_invoke_completion(rocm_signal->comp, UCS_OK);
+            uct_invoke_completion(rocm_signal->comp, completion_status);
         }
 
         if (rocm_signal->mapped_addr != NULL) {
@@ -62,11 +74,11 @@ unsigned uct_rocm_base_progress(ucs_queue_head_t *signal_queue)
             rocm_signal->mapped_addr = NULL;
         }
 
-        ucs_trace_poll("rocm signal done :%p", rocm_signal);
+        ucs_trace_poll("rocm signal done :%p status:%s", rocm_signal,
+                       ucs_status_string(completion_status));
         ucs_mpool_put(rocm_signal);
         count++;
     }
 
     return count;
 }
-

--- a/src/uct/rocm/base/rocm_signal.c
+++ b/src/uct/rocm/base/rocm_signal.c
@@ -50,10 +50,9 @@ unsigned uct_rocm_base_progress(ucs_queue_head_t *signal_queue)
     ucs_status_t completion_status;
 
     ucs_queue_for_each_extract(rocm_signal, signal_queue, queue,
-                               (hsa_signal_load_scacquire(
-                                        rocm_signal->signal) <= 0) &&
+                               ((signal_value = hsa_signal_load_scacquire(
+                                         rocm_signal->signal)) <= 0) &&
                                (count < max_signals)) {
-        signal_value = hsa_signal_load_scacquire(rocm_signal->signal);
         if (signal_value < 0) {
             ucs_error("rocm async copy failed with signal value %ld",
                       (long)signal_value);

--- a/src/uct/rocm/base/rocm_signal.c
+++ b/src/uct/rocm/base/rocm_signal.c
@@ -52,7 +52,7 @@ unsigned uct_rocm_base_progress(ucs_queue_head_t *signal_queue)
     ucs_queue_for_each_extract(rocm_signal, signal_queue, queue,
                                ((signal_value = hsa_signal_load_scacquire(
                                          rocm_signal->signal)) <= 0) &&
-                               (count < max_signals)) {
+                                       (count < max_signals)) {
         if (signal_value < 0) {
             ucs_error("rocm async copy failed with signal value %ld",
                       (long)signal_value);

--- a/test/gtest/Makefile.am
+++ b/test/gtest/Makefile.am
@@ -317,15 +317,19 @@ include $(top_srcdir)/config/hip.am
 gtest_SOURCES += \
 	ucm/rocm_hooks.cc \
 	uct/rocm/test_kernels_uct.hip \
-	uct/rocm/test_rocm_ipc_device.hip
+	uct/rocm/test_rocm_ipc_device.hip \
+	uct/rocm/test_rocm_signal.cc
 
 gtest_CPPFLAGS += \
-	$(HIP_CPPFLAGS)
+	$(HIP_CPPFLAGS) \
+	$(ROCM_CPPFLAGS)
 gtest_CXXFLAGS += \
 	$(HIP_CXXFLAGS)
 gtest_LDADD += \
 	$(HIP_LDFLAGS) \
 	$(HIP_LIBS) \
+	$(ROCM_LDFLAGS) \
+	$(ROCM_LIBS) \
 	$(top_builddir)/src/uct/rocm/libuct_rocm.la
 endif # HAVE_GNUXX11
 endif # HAVE_HIP

--- a/test/gtest/uct/rocm/test_rocm_signal.cc
+++ b/test/gtest/uct/rocm/test_rocm_signal.cc
@@ -16,8 +16,8 @@ class test_rocm_signal : public ucs::test {
 protected:
     struct completion : uct_completion_t {
         completion() :
-            uct_completion_t({.func   = completion_cb,
-                              .count  = 1,
+            uct_completion_t({.func = completion_cb,
+                              .count = 1,
                               .status = UCS_OK}),
             callback_count(0)
         {
@@ -66,8 +66,7 @@ protected:
 };
 
 
-UCS_TEST_F(test_rocm_signal, async_error)
-{
+UCS_TEST_F(test_rocm_signal, async_error) {
     uct_rocm_base_signal_desc_t *signal_desc;
     completion comp;
 

--- a/test/gtest/uct/rocm/test_rocm_signal.cc
+++ b/test/gtest/uct/rocm/test_rocm_signal.cc
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) Zhixian Li 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <common/test.h>
+
+extern "C" {
+#include <uct/rocm/base/rocm_base.h>
+#include <uct/rocm/base/rocm_signal.h>
+}
+
+
+class test_rocm_signal : public ucs::test {
+protected:
+    struct completion : uct_completion_t {
+        completion() :
+            uct_completion_t({.func   = completion_cb,
+                              .count  = 1,
+                              .status = UCS_OK}),
+            callback_count(0)
+        {
+        }
+
+        static void completion_cb(uct_completion_t *comp)
+        {
+            reinterpret_cast<completion*>(comp)->callback_count++;
+        }
+
+        unsigned callback_count;
+    };
+
+    void init() override
+    {
+        ucs_mpool_params_t mp_params;
+
+        ucs::test::init();
+        if (uct_rocm_base_init() != HSA_STATUS_SUCCESS) {
+            UCS_TEST_SKIP_R("ROCm is unavailable");
+        }
+
+        ucs_mpool_params_reset(&mp_params);
+        mp_params.elem_size       = sizeof(uct_rocm_base_signal_desc_t);
+        mp_params.elems_per_chunk = 1;
+        mp_params.max_elems       = 1;
+        mp_params.ops             = &uct_rocm_base_signal_desc_mpool_ops;
+        mp_params.name            = "ROCM signal test objects";
+        ASSERT_UCS_OK(ucs_mpool_init(&mp_params, &m_signal_pool));
+        m_signal_pool_initialized = true;
+        ucs_queue_head_init(&m_signal_queue);
+    }
+
+    void cleanup() override
+    {
+        if (m_signal_pool_initialized) {
+            ucs_mpool_cleanup(&m_signal_pool, 1);
+        }
+
+        ucs::test::cleanup();
+    }
+
+    ucs_mpool_t m_signal_pool;
+    ucs_queue_head_t m_signal_queue;
+    bool m_signal_pool_initialized = false;
+};
+
+
+UCS_TEST_F(test_rocm_signal, async_error)
+{
+    uct_rocm_base_signal_desc_t *signal_desc;
+    completion comp;
+
+    signal_desc = static_cast<uct_rocm_base_signal_desc_t*>(
+            ucs_mpool_get(&m_signal_pool));
+    ASSERT_NE(nullptr, signal_desc);
+
+    signal_desc->comp        = &comp;
+    signal_desc->mapped_addr = nullptr;
+    hsa_signal_store_screlease(signal_desc->signal, -1);
+    ucs_queue_push(&m_signal_queue, &signal_desc->queue);
+
+    scoped_log_handler log_handler(wrap_errors_logger);
+    EXPECT_EQ(1u, uct_rocm_base_progress(&m_signal_queue));
+    EXPECT_EQ(1u, comp.callback_count);
+    EXPECT_EQ(UCS_ERR_IO_ERROR, comp.status);
+    EXPECT_TRUE(ucs_queue_is_empty(&m_signal_queue));
+}


### PR DESCRIPTION
## Summary

HSA completion signals use `0` for successful completion and a negative value for an asynchronous failure. `uct_rocm_base_progress()` previously extracted only signals equal to `0`, so a failed ROCm copy remained in the pending queue and its UCT completion was never invoked.

This change:

- treats non-positive completion signals as terminal;
- reports `UCS_OK` for `0` and `UCS_ERR_IO_ERROR` for negative values;
- logs the failing HSA signal value;
- adds a focused GTest that drives the real HSA signal mpool and verifies the error callback.

This is intentionally independent of the ROCm IPC peer-capability work in #11299.

## Validation

On an AMD W7900 with the ROCm SDK in the vLLM container:

- out-of-source `contrib/configure-devel` build, `make -j16`, and `make install`: passed;
- `test_rocm_signal.async_error`: passed;
- negative control with the source predicate restored to `signal == 0`: failed as expected (`progress=0`, callback count `0`, queue non-empty);
- existing W7900 IPC/copy experiments continue to report successful 1 GiB transfers and preserve the previously tested peer-exit behavior.

The broad `*rocm*` GTest run was stopped after an unrelated `rocm_copy/uct_p2p_rma_test.put_short` payload mismatch (after approximately 511 s); it did not involve the new signal test or this code path.

## Scope

This fixes propagation when ROCr produces a negative completion signal. It does not claim to solve exporter-invalidated stale IPC registrations where ROCr leaves the signal pending; that case needs a separate registration-generation/retirement protocol.