### PR TITLE
GITHUB: Add initial CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 #
 # TODO: maintainers, please replace @openucx/MAINTAINERS-TEAM with the correct
 # team slug, and add per-subsystem reviewers where you want narrower routing.
+# The individual owners below are self-nominations, not confirmed assignments.
 #
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
@@ -66,10 +67,10 @@
 /src/tools/perf/cuda/ @openucx/MAINTAINERS-TEAM
 
 # ROCm
-/config/m4/rocm.m4    @openucx/MAINTAINERS-TEAM
-/src/ucm/rocm/        @openucx/MAINTAINERS-TEAM
-/src/uct/rocm/        @openucx/MAINTAINERS-TEAM
-/src/tools/perf/rocm/ @openucx/MAINTAINERS-TEAM
+/config/m4/rocm.m4    @edgargabriel @mshanthagit @openucx/MAINTAINERS-TEAM
+/src/ucm/rocm/        @edgargabriel @mshanthagit @openucx/MAINTAINERS-TEAM
+/src/uct/rocm/        @edgargabriel @mshanthagit @openucx/MAINTAINERS-TEAM
+/src/tools/perf/rocm/ @edgargabriel @mshanthagit @openucx/MAINTAINERS-TEAM
 
 # Level Zero (ZE)
 /config/m4/ze.m4            @yafshar @j-xiong @openucx/MAINTAINERS-TEAM

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,10 +9,12 @@
 * @openucx/ucx-maintainers
 
 # ROCm
-/config/m4/rocm.m4    @edgargabriel @mshanthagit @openucx/ucx-maintainers
-/src/ucm/rocm/        @edgargabriel @mshanthagit @openucx/ucx-maintainers
-/src/uct/rocm/        @edgargabriel @mshanthagit @openucx/ucx-maintainers
-/src/tools/perf/rocm/ @edgargabriel @mshanthagit @openucx/ucx-maintainers
+/config/m4/rocm.m4            @edgargabriel @mshanthagit @openucx/ucx-maintainers
+/src/ucm/rocm/                @edgargabriel @mshanthagit @openucx/ucx-maintainers
+/src/uct/rocm/                @edgargabriel @mshanthagit @openucx/ucx-maintainers
+/src/tools/perf/rocm/         @edgargabriel @mshanthagit @openucx/ucx-maintainers
+/test/gtest/ucm/rocm_hooks.cc @edgargabriel @mshanthagit @openucx/ucx-maintainers
+/test/gtest/uct/rocm/         @edgargabriel @mshanthagit @openucx/ucx-maintainers
 
 # Level Zero (ZE)
 /config/m4/ze.m4            @yafshar @j-xiong @openucx/ucx-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,70 +1,16 @@
 # UCX code owners
 #
-# Each line is a file pattern followed by one or more owners. The owners of the
-# last matching pattern are automatically requested for review when a pull
-# request touches a matching file.
-#
 # Notes:
-# - Order matters: for a given file, only the last matching pattern applies.
-#   Keep general patterns above the more specific ones that refine them.
+# - Only the last matching pattern applies, so the ROCm and ZE entries below
+#   refine the '*' default.
 # - GitHub ignores owners that do not have write access to this repository.
 # - This file only routes review requests. Requiring code-owner approval is a
 #   separate branch protection setting and is not affected by this file.
-#
-# TODO: maintainers, please replace @openucx/MAINTAINERS-TEAM with the correct
-# team slug, and add per-subsystem reviewers where you want narrower routing.
-# The individual owners below are self-nominations, not confirmed assignments.
 #
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owners
 * @openucx/MAINTAINERS-TEAM
-
-# Build system and packaging
-/Makefile.am        @openucx/MAINTAINERS-TEAM
-/autogen.sh         @openucx/MAINTAINERS-TEAM
-/configure.ac       @openucx/MAINTAINERS-TEAM
-/cmake/             @openucx/MAINTAINERS-TEAM
-/config/            @openucx/MAINTAINERS-TEAM
-/ucx.pc.in          @openucx/MAINTAINERS-TEAM
-/ucx.spec.in        @openucx/MAINTAINERS-TEAM
-/debian/            @openucx/MAINTAINERS-TEAM
-
-# CI
-/.ci/               @openucx/MAINTAINERS-TEAM
-/.github/           @openucx/MAINTAINERS-TEAM
-/buildlib/          @openucx/MAINTAINERS-TEAM
-/contrib/           @openucx/MAINTAINERS-TEAM
-
-# This file
-/.github/CODEOWNERS @openucx/MAINTAINERS-TEAM
-
-# Documentation
-/docs/              @openucx/MAINTAINERS-TEAM
-
-# Core layers
-/src/ucs/           @openucx/MAINTAINERS-TEAM
-/src/ucm/           @openucx/MAINTAINERS-TEAM
-/src/ucp/           @openucx/MAINTAINERS-TEAM
-/src/uct/           @openucx/MAINTAINERS-TEAM
-
-# Tools
-/src/tools/         @openucx/MAINTAINERS-TEAM
-
-# Bindings
-/bindings/          @openucx/MAINTAINERS-TEAM
-
-# Tests and examples
-/test/              @openucx/MAINTAINERS-TEAM
-/examples/          @openucx/MAINTAINERS-TEAM
-
-# GPU backends - listed after the generic layers above so they take precedence
-
-# CUDA
-/config/m4/cuda.m4    @openucx/MAINTAINERS-TEAM
-/src/ucm/cuda/        @openucx/MAINTAINERS-TEAM
-/src/uct/cuda/        @openucx/MAINTAINERS-TEAM
-/src/tools/perf/cuda/ @openucx/MAINTAINERS-TEAM
 
 # ROCm
 /config/m4/rocm.m4    @edgargabriel @mshanthagit @openucx/MAINTAINERS-TEAM

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,26 +1,22 @@
-# UCX code owners
 #
-# Notes:
-# - Only the last matching pattern applies, so the ROCm and ZE entries below
-#   refine the '*' default.
-# - GitHub ignores owners that do not have write access to this repository.
-# - This file only routes review requests. Requiring code-owner approval is a
-#   separate branch protection setting and is not affected by this file.
+# Copyright (c) Intel Corporation, 2026. ALL RIGHTS RESERVED.
+# See file LICENSE for terms.
 #
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
 
 # Default owners
-* @openucx/MAINTAINERS-TEAM
+* @openucx/ucx-maintainers
 
 # ROCm
-/config/m4/rocm.m4    @edgargabriel @mshanthagit @openucx/MAINTAINERS-TEAM
-/src/ucm/rocm/        @edgargabriel @mshanthagit @openucx/MAINTAINERS-TEAM
-/src/uct/rocm/        @edgargabriel @mshanthagit @openucx/MAINTAINERS-TEAM
-/src/tools/perf/rocm/ @edgargabriel @mshanthagit @openucx/MAINTAINERS-TEAM
+/config/m4/rocm.m4    @edgargabriel @mshanthagit @openucx/ucx-maintainers
+/src/ucm/rocm/        @edgargabriel @mshanthagit @openucx/ucx-maintainers
+/src/uct/rocm/        @edgargabriel @mshanthagit @openucx/ucx-maintainers
+/src/tools/perf/rocm/ @edgargabriel @mshanthagit @openucx/ucx-maintainers
 
 # Level Zero (ZE)
-/config/m4/ze.m4            @yafshar @j-xiong @openucx/MAINTAINERS-TEAM
-/src/ucm/ze/                @yafshar @j-xiong @openucx/MAINTAINERS-TEAM
-/src/uct/ze/                @yafshar @j-xiong @openucx/MAINTAINERS-TEAM
-/src/tools/perf/ze/         @yafshar @j-xiong @openucx/MAINTAINERS-TEAM
-/test/gtest/ucm/ze_hooks.cc @yafshar @j-xiong @openucx/MAINTAINERS-TEAM
+/config/m4/ze.m4            @yafshar @j-xiong @openucx/ucx-maintainers
+/src/ucm/ze/                @yafshar @j-xiong @openucx/ucx-maintainers
+/src/uct/ze/                @yafshar @j-xiong @openucx/ucx-maintainers
+/src/tools/perf/ze/         @yafshar @j-xiong @openucx/ucx-maintainers
+/test/gtest/ucm/ze_hooks.cc @yafshar @j-xiong @openucx/ucx-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,79 @@
+# UCX code owners
+#
+# Each line is a file pattern followed by one or more owners. The owners of the
+# last matching pattern are automatically requested for review when a pull
+# request touches a matching file.
+#
+# Notes:
+# - Order matters: for a given file, only the last matching pattern applies.
+#   Keep general patterns above the more specific ones that refine them.
+# - GitHub ignores owners that do not have write access to this repository.
+# - This file only routes review requests. Requiring code-owner approval is a
+#   separate branch protection setting and is not affected by this file.
+#
+# TODO: maintainers, please replace @openucx/MAINTAINERS-TEAM with the correct
+# team slug, and add per-subsystem reviewers where you want narrower routing.
+#
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners
+* @openucx/MAINTAINERS-TEAM
+
+# Build system and packaging
+/Makefile.am        @openucx/MAINTAINERS-TEAM
+/autogen.sh         @openucx/MAINTAINERS-TEAM
+/configure.ac       @openucx/MAINTAINERS-TEAM
+/cmake/             @openucx/MAINTAINERS-TEAM
+/config/            @openucx/MAINTAINERS-TEAM
+/ucx.pc.in          @openucx/MAINTAINERS-TEAM
+/ucx.spec.in        @openucx/MAINTAINERS-TEAM
+/debian/            @openucx/MAINTAINERS-TEAM
+
+# CI
+/.ci/               @openucx/MAINTAINERS-TEAM
+/.github/           @openucx/MAINTAINERS-TEAM
+/buildlib/          @openucx/MAINTAINERS-TEAM
+/contrib/           @openucx/MAINTAINERS-TEAM
+
+# This file
+/.github/CODEOWNERS @openucx/MAINTAINERS-TEAM
+
+# Documentation
+/docs/              @openucx/MAINTAINERS-TEAM
+
+# Core layers
+/src/ucs/           @openucx/MAINTAINERS-TEAM
+/src/ucm/           @openucx/MAINTAINERS-TEAM
+/src/ucp/           @openucx/MAINTAINERS-TEAM
+/src/uct/           @openucx/MAINTAINERS-TEAM
+
+# Tools
+/src/tools/         @openucx/MAINTAINERS-TEAM
+
+# Bindings
+/bindings/          @openucx/MAINTAINERS-TEAM
+
+# Tests and examples
+/test/              @openucx/MAINTAINERS-TEAM
+/examples/          @openucx/MAINTAINERS-TEAM
+
+# GPU backends - listed after the generic layers above so they take precedence
+
+# CUDA
+/config/m4/cuda.m4    @openucx/MAINTAINERS-TEAM
+/src/ucm/cuda/        @openucx/MAINTAINERS-TEAM
+/src/uct/cuda/        @openucx/MAINTAINERS-TEAM
+/src/tools/perf/cuda/ @openucx/MAINTAINERS-TEAM
+
+# ROCm
+/config/m4/rocm.m4    @openucx/MAINTAINERS-TEAM
+/src/ucm/rocm/        @openucx/MAINTAINERS-TEAM
+/src/uct/rocm/        @openucx/MAINTAINERS-TEAM
+/src/tools/perf/rocm/ @openucx/MAINTAINERS-TEAM
+
+# Level Zero (ZE)
+/config/m4/ze.m4            @yafshar @j-xiong @openucx/MAINTAINERS-TEAM
+/src/ucm/ze/                @yafshar @j-xiong @openucx/MAINTAINERS-TEAM
+/src/uct/ze/                @yafshar @j-xiong @openucx/MAINTAINERS-TEAM
+/src/tools/perf/ze/         @yafshar @j-xiong @openucx/MAINTAINERS-TEAM
+/test/gtest/ucm/ze_hooks.cc @yafshar @j-xiong @openucx/MAINTAINERS-TEAM


### PR DESCRIPTION
## What?

Adds an initial `.github/CODEOWNERS` defining a path-based layout for automatic
review requests.

Every entry includes an `@openucx/MAINTAINERS-TEAM` placeholder. The intent is
to propose the layout rather than to assign reviewers, so the file establishes
the path structure and leaves reviewer assignment to the maintainers.

Individuals are listed only where they volunteered: `@yafshar` and `@j-xiong`
on the ZE paths, and `@edgargabriel` and `@mshanthagit` on the ROCm paths, as
requested in the discussion below. Commit history suggests plausible owners for
several other subsystems, but that is nomination evidence rather than agreement,
so those entries are left as the placeholder.

Kept as a draft until the placeholder team slug is filled in.

## Why?

Requested by @brminich following a discussion about ZE review routing.

ZE changes currently have no default reviewer. Without a CODEOWNERS entry
covering the ZE paths, ZE pull requests are not assigned automatically and can
fall out of the review queue. The same gap applies to any path without an
explicit reviewer, so the file covers the repository rather than only the ZE
subtree.

## How?

Layout:

- A `*` default owner, so every path has a fallback reviewer.
- `/.github/CODEOWNERS` owns itself, so future edits to it are reviewed.
- Coarse per-area entries for build, CI, docs, the core layers, tools,
  bindings, and tests. These can be split further wherever narrower routing is
  wanted.
- GPU backend entries listed last, so they take precedence over the generic
  `/src/uct/`, `/src/ucm/`, and `/src/tools/perf/` entries. CODEOWNERS applies
  only the last matching pattern.

All path patterns are root-anchored and were checked against the tree; none are
dead. Pattern resolution was verified per file for the GPU backends and the
generic layers.

### Notes for maintainers

- `@openucx/MAINTAINERS-TEAM` is a placeholder. Please replace all occurrences
  with the correct team slug. The team must be visible and have explicit write
  access to the repository, otherwise it is ignored.
- Owners are resolved individually: any user or team without explicit write
  access is ignored without affecting the other owners on the same line. The ZE
  entries can therefore generate review requests independently for each of
  `@yafshar` and `@j-xiong` that has write access, regardless of the placeholder
  team.
- Merging this does not require code-owner approval on pull requests. That is a
  separate branch protection setting and is unaffected by this file.

Happy to adjust the granularity, path list, or reviewer sets however you prefer.
