### PR TITLE
UCS/TOPO: Dedup devices with the same BDF for class ordinal

### DIFF
--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -1053,7 +1053,7 @@ unsigned ucs_topo_sys_device_get_bdf_class_ordinal(ucs_sys_device_t sys_dev)
 {
     ucs_topo_device_class_t device_class;
     ucs_bus_id_bit_rep_t ref_key, key;
-    unsigned ordinal, d;
+    unsigned ordinal, d, prev_d;
 
     if (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) {
         return UCS_SYS_DEVICE_ORDINAL_INVALID;
@@ -1078,10 +1078,8 @@ unsigned ucs_topo_sys_device_get_bdf_class_ordinal(ucs_sys_device_t sys_dev)
         goto out_unlock;
     }
 
-    /* The ordinal is the rank of the device's bus id (BDF) among all devices
-     * of the same class. Counting devices with a smaller BDF is equivalent to
-     * sorting the class by BDF and taking the index, and yields a stable,
-     * name-independent ordering. */
+    /* The ordinal is the rank of the device's bus id (BDF) among all unique
+     * BDFs of the same class. */
     ref_key = ucs_topo_get_bus_id_bit_repr(
             &ucs_topo_global_ctx.devices[sys_dev].bus_id);
     ordinal = 0;
@@ -1092,7 +1090,21 @@ unsigned ucs_topo_sys_device_get_bdf_class_ordinal(ucs_sys_device_t sys_dev)
 
         key = ucs_topo_get_bus_id_bit_repr(
                 &ucs_topo_global_ctx.devices[d].bus_id);
-        if (key < ref_key) {
+        if (key >= ref_key) {
+            continue;
+        }
+
+        /* Count only the first same-class record for this BDF. */
+        for (prev_d = 0; prev_d < d; ++prev_d) {
+            if ((ucs_topo_global_ctx.devices[prev_d].device_class ==
+                 device_class) &&
+                (ucs_topo_get_bus_id_bit_repr(
+                         &ucs_topo_global_ctx.devices[prev_d].bus_id) == key)) {
+                break;
+            }
+        }
+
+        if (prev_d == d) {
             ++ordinal;
         }
     }

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -398,13 +398,14 @@ ucs_topo_sys_device_set_class(ucs_sys_device_t sys_dev,
                               ucs_topo_device_class_t device_class);
 
 /**
- * Get the ordinal of a given system device: its rank among all system devices
- * of the same class, ordered by PCI bus id (BDF).
+ * Get the ordinal of a given system device: the rank of its PCI bus id (BDF)
+ * among all unique BDFs of the same class.
  *
  * For example, with GPUs (class @ref UCS_TOPO_DEVICE_CLASS_ACC) registered, the
  * device with the smallest BDF returns 0, the next returns 1, and so on. The
  * ordering depends only on the bus id, not on the device name or discovery
- * order.
+ * order. Multiple system device records of the same class that share a BDF
+ * also share the same ordinal.
  *
  * @param [in]  sys_dev System device to query.
  *

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -441,6 +441,56 @@ UCS_TEST_F(test_topo, device_bdf_ordinal) {
                       UCS_SYS_DEVICE_ID_UNKNOWN));
 }
 
+UCS_TEST_F(test_topo, device_bdf_ordinal_aliases) {
+    static const uintptr_t user_value1 = 17;
+    static const uintptr_t user_value2 = 42;
+    ucs_sys_device_t acc_lo_alias1, acc_lo_alias2, acc_lo_bdf, acc_hi_alias;
+    ucs_sys_bus_id_t bus_id;
+
+    bus_id.domain   = 0xfefd;
+    bus_id.bus      = 0x10;
+    bus_id.slot     = 0x1f;
+    bus_id.function = 0;
+
+    ASSERT_UCS_OK(
+            ucs_topo_find_device_by_bus_id_and_user_value(&bus_id, user_value1,
+                                                          &acc_lo_alias1));
+    ASSERT_UCS_OK(
+            ucs_topo_find_device_by_bus_id_and_user_value(&bus_id, user_value2,
+                                                          &acc_lo_alias2));
+
+    bus_id.bus = 0x20;
+    ASSERT_UCS_OK(ucs_topo_find_device_by_bus_id_and_user_value(&bus_id,
+                                                                user_value1,
+                                                                &acc_hi_alias));
+
+    ASSERT_UCS_OK(ucs_topo_sys_device_set_class(acc_lo_alias1,
+                                                UCS_TOPO_DEVICE_CLASS_ACC));
+    ASSERT_UCS_OK(ucs_topo_sys_device_set_class(acc_lo_alias2,
+                                                UCS_TOPO_DEVICE_CLASS_ACC));
+    ASSERT_UCS_OK(ucs_topo_sys_device_set_class(acc_hi_alias,
+                                                UCS_TOPO_DEVICE_CLASS_ACC));
+
+    EXPECT_NE(acc_lo_alias1, acc_lo_alias2);
+    EXPECT_EQ(0u, ucs_topo_sys_device_get_bdf_class_ordinal(acc_lo_alias1));
+    EXPECT_EQ(0u, ucs_topo_sys_device_get_bdf_class_ordinal(acc_lo_alias2));
+    EXPECT_EQ(1u, ucs_topo_sys_device_get_bdf_class_ordinal(acc_hi_alias));
+
+    /* Adding a BDF-only record invalidates the cached ordinal, but does not
+     * add another physical device. */
+    bus_id.bus = 0x10;
+    ASSERT_UCS_OK(ucs_topo_find_device_by_bus_id(&bus_id, &acc_lo_bdf));
+    ASSERT_UCS_OK(ucs_topo_sys_device_set_class(acc_lo_bdf,
+                                                UCS_TOPO_DEVICE_CLASS_ACC));
+
+    EXPECT_NE(acc_lo_alias1, acc_lo_bdf);
+    EXPECT_NE(acc_lo_alias2, acc_lo_bdf);
+    EXPECT_EQ(0u, ucs_topo_sys_device_get_bdf_class_ordinal(acc_lo_bdf));
+    EXPECT_EQ(0u, ucs_topo_sys_device_get_bdf_class_ordinal(acc_lo_alias1));
+    EXPECT_EQ(0u, ucs_topo_sys_device_get_bdf_class_ordinal(acc_lo_alias2));
+    EXPECT_EQ(1u, ucs_topo_sys_device_get_bdf_class_ordinal(acc_hi_alias));
+}
+
 static std::vector<ucs_numa_node_t> get_online_numa_nodes()
 {
     std::vector<ucs_numa_node_t> nodes;

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -442,15 +442,24 @@ UCS_TEST_F(test_topo, device_bdf_ordinal) {
 }
 
 UCS_TEST_F(test_topo, device_bdf_ordinal_aliases) {
-    static const uintptr_t user_value1 = 17;
-    static const uintptr_t user_value2 = 42;
-    ucs_sys_device_t acc_lo_alias1, acc_lo_alias2, acc_lo_bdf, acc_hi_alias;
+    static const uintptr_t user_value1    = 17;
+    static const uintptr_t user_value2    = 42;
+    static const uintptr_t user_value_net = 99;
+    ucs_sys_device_t net_same_bdf, acc_lo_alias1, acc_lo_alias2, acc_lo_bdf,
+            acc_hi_alias;
     ucs_sys_bus_id_t bus_id;
 
     bus_id.domain   = 0xfefd;
     bus_id.bus      = 0x10;
     bus_id.slot     = 0x1f;
     bus_id.function = 0;
+
+    /* Same BDF, different class, registered first: must not hide the ACC BDF. */
+    ASSERT_UCS_OK(ucs_topo_find_device_by_bus_id_and_user_value(&bus_id,
+                                                                user_value_net,
+                                                                &net_same_bdf));
+    ASSERT_UCS_OK(ucs_topo_sys_device_set_class(net_same_bdf,
+                                                UCS_TOPO_DEVICE_CLASS_NET));
 
     ASSERT_UCS_OK(
             ucs_topo_find_device_by_bus_id_and_user_value(&bus_id, user_value1,
@@ -475,6 +484,7 @@ UCS_TEST_F(test_topo, device_bdf_ordinal_aliases) {
     EXPECT_EQ(0u, ucs_topo_sys_device_get_bdf_class_ordinal(acc_lo_alias1));
     EXPECT_EQ(0u, ucs_topo_sys_device_get_bdf_class_ordinal(acc_lo_alias2));
     EXPECT_EQ(1u, ucs_topo_sys_device_get_bdf_class_ordinal(acc_hi_alias));
+    EXPECT_EQ(0u, ucs_topo_sys_device_get_bdf_class_ordinal(net_same_bdf));
 
     /* Adding a BDF-only record invalidates the cached ordinal, but does not
      * add another physical device. */


### PR DESCRIPTION
## What?
Treat same-class system-device records sharing a PCI BDF as one physical device when calculating class ordinals.

## Why?
CUDA/MLOPart aliases can create multiple `sys_dev` records per GPU, causing gaps between ordinals.

## How?
Count each lower BDF once while preserving ordinal caching and invalidation. 