### PR TITLE
DEBIAN: Strip versioned libnvidia-compute dependency from ucx-cuda

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,6 @@
 Aboorva Devarajan <aboorvad@linux.ibm.com>
 Adit Ranadive <aranadive@nvidia.com>
+Ahmed Hussein <ahussein@nvidia.com>
 Akshay Venkatesh <akvenkatesh@nvidia.com>
 Alastair McKinstry <mckinstry@debian.org>
 Aleksey Senin <alekseys@nvidia.com>

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -36,9 +36,7 @@ override_dh_auto_install:
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
 	if [ -e $(CUDA_SUBSTVARS) ]; then \
-		sed -i -e 's/libnvidia-compute-[0-9]\+\( ([^)]*)\)\?, //g' \
-			-e 's/, libnvidia-compute-[0-9]\+\( ([^)]*)\)\?//g' \
-			$(CUDA_SUBSTVARS); \
+		sed -i -e 's/, libnvidia-compute-[0-9]\+[^,]*//g' $(CUDA_SUBSTVARS); \
 		echo "shlibs:Recommends=libnvidia-compute | libnvidia-ml1" >> \
 			$(CUDA_SUBSTVARS); \
 	fi

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -36,7 +36,9 @@ override_dh_auto_install:
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
 	if [ -e $(CUDA_SUBSTVARS) ]; then \
-		sed -i -e 's/libnvidia-compute-\([0-9]\+\), //g' $(CUDA_SUBSTVARS); \
+		sed -i -e 's/libnvidia-compute-[0-9]\+\( ([^)]*)\)\?, //g' \
+			-e 's/, libnvidia-compute-[0-9]\+\( ([^)]*)\)\?//g' \
+			$(CUDA_SUBSTVARS); \
 		echo "shlibs:Recommends=libnvidia-compute | libnvidia-ml1" >> \
 			$(CUDA_SUBSTVARS); \
 	fi


### PR DESCRIPTION
## What?

Fix the shlibdeps post-processing in `debian/rules.in` so it also strips `libnvidia-compute-<N>` when `dpkg-shlibdeps` emits it with a version constraint.

Fixes #11257.

## Why?

`override_dh_shlibdeps` already removes the driver package that `dpkg-shlibdeps` generates, but the pattern requires the comma to follow the package name immediately:

```
s/libnvidia-compute-\([0-9]\+\), //g
```

When `dpkg-shlibdeps` emits a version constraint, the substvar reads `libnvidia-compute-580 (>= 580.65.06), ` — the pattern does not match, and the dependency survives into the published package. That is what happens in the CUDA 13 release build.

From the v1.22.0 release tarballs (`ubuntu22.04`, x86_64 and aarch64 identical):

| Variant | `ucx-cuda` Depends |
|---|---|
| cuda11 | `libc6 (>= 2.34), ucx` |
| cuda12 | `libc6 (>= 2.34), ucx` |
| cuda13 | `libc6, libgcc-s1, libgomp1, **libnvidia-compute-580 (>= 580.65.06)**, libstdc++6, ucx` |

Installing `ucx-cuda` from the CUDA 13 tarball therefore pulls NVIDIA driver userspace libraries into the container and shadows the host-provided `libcuda.so.1`. This is the breakage #11257 describes, and `--no-install-recommends` cannot avoid it because this is a hard `Depends`, not a `Recommends`.

Reproduced with `apt-get install --simulate` in `nvidia/cuda:13.0.1-runtime-ubuntu22.04`.
v1.21.0 behaves the same way.


## How?

Two changes to the pattern:

1. Make the version constraint optional — `\( ([^)]*)\)\?` — so both `libnvidia-compute-580,` and `libnvidia-compute-580 (>= 580.65.06),` are matched.
2. Match the separator on either side (`pkg, ` and `, pkg`) so the result does not depend on where the package lands in the sorted dependency list. The current pattern only handles the case where another dependency sorts after it.

Verified against the four substvars shapes, running the patched recipe through `make` so the
Makefile quoting is exercised as-is:

| Input `shlibs:Depends=` | Result |
|---|---|
| `libc6 (>= 2.34), libgcc-s1 (>= 3.0), libgomp1 (>= 4.9), libnvidia-compute-580 (>= 580.65.06), libstdc++6 (>= 5.2)` | `libc6 (>= 2.34), libgcc-s1 (>= 3.0), libgomp1 (>= 4.9), libstdc++6 (>= 5.2)` |
| `libc6 (>= 2.34), libnvidia-compute-580, libstdc++6 (>= 5.2)` *(previous behavior — regression check)* | `libc6 (>= 2.34), libstdc++6 (>= 5.2)` |
| `libc6 (>= 2.34), libgomp1 (>= 4.9), libnvidia-compute-580 (>= 580.65.06)` *(trailing)* | `libc6 (>= 2.34), libgomp1 (>= 4.9)` |
| `libc6 (>= 2.34), libstdc++6 (>= 5.2)` *(no driver dep — no-op)* | unchanged |

No `$` in the patterns, so nothing needs Makefile escaping.

### Alternatives considered

| Option | Handles the reported bug | Handles trailing position | Notes |
|---|---|---|---|
| Keep as-is | ✗ | ✗ | current state |
| Only make the version optional | ✓ | ✗ | smallest diff; one token added |
| **Chosen: optional version + separator on either side** | ✓ | ✓ | position-independent |
| Post-strip + `s/, $//` cleanup | ✓ | ✓ | needs `$$` escaping in the Makefile |

Chose the position-independent form because the bug being fixed is *itself* the result of a pattern that was too narrowly matched; repeating that shape invites the next regression. If a maintainer prefers the minimal one-token change, the smaller variant is `s/libnvidia-compute-[0-9]\+\( ([^)]*)\)\?, //g` alone.

The `libnvidia-compute-<N>` entry cannot currently be the *first* or *only* dependency — `libc6` always sorts ahead of it — so no leading-position handling is needed.
