### PR TITLE
UCP/CORE: Log git branch, revision and configuration flags

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -2730,14 +2730,14 @@ ucp_version_check(unsigned api_major_version, unsigned api_minor_version)
     if (ucs_log_is_enabled(log_level)) {
         ret = dladdr(ucp_init_version, &dl_info);
         if (ret != 0) {
-            ucs_string_buffer_appendf(&strb, " (loaded from %s)",
-                                      dl_info.dli_fname);
+            ucs_string_buffer_appendf(
+                    &strb, " (loaded from %s, git branch %s, revision %s)",
+                    dl_info.dli_fname, UCT_SCM_BRANCH, UCT_SCM_VERSION);
         }
         ucs_log(log_level, "%s", ucs_string_buffer_cstr(&strb));
     }
 
-    ucs_debug("git branch '%s', revision %s", UCT_SCM_BRANCH, UCT_SCM_VERSION);
-    ucs_debug("configured with: %s", UCX_CONFIGURE_FLAGS);
+    ucs_debug("Configured with: %s", UCX_CONFIGURE_FLAGS);
 }
 
 ucs_status_t ucp_init_version(unsigned api_major_version, unsigned api_minor_version,

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -2728,15 +2728,16 @@ ucp_version_check(unsigned api_major_version, unsigned api_minor_version)
     }
 
     if (ucs_log_is_enabled(log_level)) {
+        ucs_string_buffer_appendf(&strb, " (");
+
         ret = dladdr(ucp_init_version, &dl_info);
         if (ret != 0) {
-            ucs_string_buffer_appendf(
-                    &strb, " (loaded from %s, git branch %s, revision %s)",
-                    dl_info.dli_fname, UCT_SCM_BRANCH, UCT_SCM_VERSION);
-        } else {
-            ucs_string_buffer_appendf(&strb, " (git branch %s, revision %s)",
-                                      UCT_SCM_BRANCH, UCT_SCM_VERSION);
+            ucs_string_buffer_appendf(&strb, "loaded from %s, ",
+                                      dl_info.dli_fname);
         }
+
+        ucs_string_buffer_appendf(&strb, "git branch %s, revision %s)",
+                                  UCT_SCM_BRANCH, UCT_SCM_VERSION);
         ucs_log(log_level, "%s", ucs_string_buffer_cstr(&strb));
     }
 

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -2735,6 +2735,9 @@ ucp_version_check(unsigned api_major_version, unsigned api_minor_version)
         }
         ucs_log(log_level, "%s", ucs_string_buffer_cstr(&strb));
     }
+
+    ucs_debug("git branch '%s', revision %s", UCT_SCM_BRANCH, UCT_SCM_VERSION);
+    ucs_debug("configured with: %s", UCX_CONFIGURE_FLAGS);
 }
 
 ucs_status_t ucp_init_version(unsigned api_major_version, unsigned api_minor_version,

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -2733,6 +2733,9 @@ ucp_version_check(unsigned api_major_version, unsigned api_minor_version)
             ucs_string_buffer_appendf(
                     &strb, " (loaded from %s, git branch %s, revision %s)",
                     dl_info.dli_fname, UCT_SCM_BRANCH, UCT_SCM_VERSION);
+        } else {
+            ucs_string_buffer_appendf(&strb, " (git branch %s, revision %s)",
+                                      UCT_SCM_BRANCH, UCT_SCM_VERSION);
         }
         ucs_log(log_level, "%s", ucs_string_buffer_cstr(&strb));
     }

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -2705,7 +2705,7 @@ static void ucp_context_create_vfs(ucp_context_h context)
 static void
 ucp_version_check(unsigned api_major_version, unsigned api_minor_version)
 {
-    UCS_STRING_BUFFER_ONSTACK(strb, 256);
+    UCS_STRING_BUFFER_ONSTACK(strb, 512);
     unsigned major_version, minor_version, release_number;
     ucs_log_level_t log_level;
     Dl_info dl_info;


### PR DESCRIPTION
## What?
Log git branch, revision next to the existing version and lib path log.
Log the configuration flags in debug mode.

## Why?
Currently this information is available only through `ucx_info -v` and does not appear in debug logs that users provide.
Instead of asking them to provide the output of `ucx_info -v` separately, all of the available information will be in the debug logs.
