### PR TITLE
UCT/GDR_COPY: Mandate registrable memory before use

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -716,6 +716,15 @@ ucp_memory_info_set_host(ucp_memory_info_t *mem_info)
     mem_info->flags   = UCS_MEM_FLAG_REGISTRABLE;
 }
 
+/* True when a memtype-cache entry is complete enough to skip MD slowpath. */
+static UCS_F_ALWAYS_INLINE int
+ucp_memory_info_is_complete(const ucs_memory_info_t *mem_info)
+{
+    return (mem_info->type != UCS_MEMORY_TYPE_UNKNOWN) &&
+           ((mem_info->sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) ||
+            (mem_info->mem_flags != 0));
+}
+
 static UCS_F_ALWAYS_INLINE void
 ucp_memory_detect_internal(ucp_context_h context, const void *address,
                            size_t length, ucs_memory_info_t *mem_info)
@@ -740,10 +749,7 @@ ucp_memory_detect_internal(ucp_context_h context, const void *address,
                       address, length);
         goto out_host_mem;
     } else if (ucs_likely(status == UCS_OK)) {
-        if (ucs_unlikely(
-                    (mem_info->type == UCS_MEMORY_TYPE_UNKNOWN) ||
-                    ((mem_info->sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) &&
-                     (mem_info->mem_flags == 0)))) {
+        if (ucs_unlikely(!ucp_memory_info_is_complete(mem_info))) {
             ucs_trace_req("address %p length %zu: querying memory attributes",
                     address, length);
             ucp_memory_detect_slowpath(context, address, length, mem_info);

--- a/src/ucp/core/ucp_mm.c
+++ b/src/ucp/core/ucp_mm.c
@@ -1306,16 +1306,22 @@ static void ucp_mtype_pack_dereg(ucp_context_h context,
 ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
                                       size_t length, ucs_memory_type_t mem_type,
                                       ucp_md_index_t md_index,
+                                      unsigned uct_flags,
                                       ucp_mtype_pack_context_t *pack_context)
 {
-    ucp_context_h context            = worker->context;
-    const uct_md_attr_v2_t *md_attr  = &context->tl_mds[md_index].attr;
+    ucp_context_h context           = worker->context;
+    const uct_md_attr_v2_t *md_attr = &context->tl_mds[md_index].attr;
     uct_md_mkey_pack_params_t params = { .field_mask = 0 };
+    ucs_log_level_t log_level;
     uct_md_mem_reg_params_t reg_params;
     uct_component_h cmpt;
     ucp_tl_md_t *tl_md;
     ucs_status_t status;
     char *rkey_buffer;
+
+    log_level = (uct_flags & UCT_MD_MEM_FLAG_HIDE_ERRORS) ?
+                        UCS_LOG_LEVEL_DEBUG :
+                        UCS_LOG_LEVEL_ERROR;
 
     if (!(md_attr->flags & UCT_MD_FLAG_NEED_RKEY)) {
         pack_context->rkey_bundle.handle = NULL;
@@ -1328,7 +1334,7 @@ ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
     cmpt   = context->tl_cmpts[tl_md->cmpt_index].cmpt;
     if (!(context->cache_md_map[mem_type] & UCS_BIT(md_index))) {
         reg_params.field_mask = UCT_MD_MEM_REG_FIELD_FLAGS;
-        reg_params.flags      = UCT_MD_MEM_ACCESS_ALL;
+        reg_params.flags      = UCT_MD_MEM_ACCESS_ALL | uct_flags;
         if (!(UCS_BIT(mem_type) & UCS_MEMORY_TYPES_CPU_ACCESSIBLE)) {
             reg_params.field_mask |= UCT_MD_MEM_REG_FIELD_MEM_TYPE;
             reg_params.mem_type    = mem_type;
@@ -1344,10 +1350,18 @@ ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
         pack_context->ucp_memh = NULL;
     } else {
         status = ucp_memh_get(context, remote_addr, length, mem_type,
-                              UCS_BIT(md_index), UCT_MD_MEM_ACCESS_ALL,
-                              "mem_type", &pack_context->ucp_memh);
+                              UCS_BIT(md_index),
+                              UCT_MD_MEM_ACCESS_ALL | uct_flags, "mem_type",
+                              &pack_context->ucp_memh);
         if (status != UCS_OK) {
             return status;
+        }
+
+        /* MD may be skipped by required_mem_flags filtering */
+        if (!(pack_context->ucp_memh->md_map & UCS_BIT(md_index)) ||
+            (pack_context->ucp_memh->uct[md_index] == NULL)) {
+            ucp_memh_put(pack_context->ucp_memh);
+            return UCS_ERR_UNSUPPORTED;
         }
 
         pack_context->uct_memh = pack_context->ucp_memh->uct[md_index];
@@ -1358,15 +1372,15 @@ ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
     status = uct_md_mkey_pack_v2(tl_md->md, pack_context->uct_memh, remote_addr,
                                  length, &params, rkey_buffer);
     if (status != UCS_OK) {
-        ucs_error("failed to pack key from md[%d]: %s",
-                  md_index, ucs_status_string(status));
+        ucs_log(log_level, "failed to pack key from md[%d]: %s", md_index,
+                ucs_status_string(status));
         goto out_dereg_mem;
     }
 
     status = uct_rkey_unpack(cmpt, rkey_buffer, &pack_context->rkey_bundle);
     if (status != UCS_OK) {
-        ucs_error("failed to unpack key from md[%d]: %s",
-                  md_index, ucs_status_string(status));
+        ucs_log(log_level, "failed to unpack key from md[%d]: %s", md_index,
+                ucs_status_string(status));
         goto out_dereg_mem;
     }
     return UCS_OK;

--- a/src/ucp/core/ucp_mm.h
+++ b/src/ucp/core/ucp_mm.h
@@ -188,6 +188,7 @@ ucs_status_t ucp_mem_rereg_mds(ucp_context_h context, ucp_md_map_t reg_md_map,
 ucs_status_t ucp_mem_type_reg_buffers(ucp_worker_h worker, void *remote_addr,
                                       size_t length, ucs_memory_type_t mem_type,
                                       ucp_md_index_t md_index,
+                                      unsigned uct_flags,
                                       ucp_mtype_pack_context_t *pack_context);
 
 void ucp_mem_type_unreg_buffers(ucp_worker_h worker,

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -62,7 +62,7 @@ ucs_status_t ucp_dt_mem_info_verify(const char *dt_name, size_t index,
 
 /*
  * Select an RMA lane whose MD accepts the buffer mem_flags, starting the search
- * from the given lane index.
+ * from the given lane index. Returns UCP_NULL_LANE if no lane is compatible.
  */
 static ucp_lane_index_t
 ucp_mem_type_ep_lane_by_flags(ucp_ep_h ep, uint8_t mem_flags, unsigned first)
@@ -81,7 +81,7 @@ ucp_mem_type_ep_lane_by_flags(ucp_ep_h ep, uint8_t mem_flags, unsigned first)
         }
     }
 
-    return key->rma_lanes[0];
+    return UCP_NULL_LANE;
 }
 
 /* Select the mem-type endpoint lane which can access the buffer and register */
@@ -105,8 +105,8 @@ ucp_mem_type_lane_reg(ucp_worker_h worker, ucp_ep_h ep, void *address,
         goto out_reg;
     }
 
-    /* The memory flags are already known, for example set by a memory hook on
-     * allocation */
+    /* The memory flags may already be known, for example set by a memory hook
+     * on allocation, use them to pick a compatible lane */
     status = ucs_memtype_cache_lookup(address, length, &cache_info);
     if ((status == UCS_OK) && ucp_memory_info_is_complete(&cache_info)) {
         lane = ucp_mem_type_ep_lane_by_flags(ep, cache_info.mem_flags, 0);
@@ -123,12 +123,19 @@ ucp_mem_type_lane_reg(ucp_worker_h worker, ucp_ep_h ep, void *address,
         return UCS_OK;
     }
 
-    /* Query the memory attributes to fall back to another lane, skipping the
-     * preferred one which just failed to register */
+    /* Preferred MD rejected the buffer: detect attributes for a fallback lane
+     * (also warms the memtype cache). Coverity fnptr model false positive. */
+    /* coverity[use_after_free] */
     ucp_memory_detect(context, address, length, &mem_info);
     lane = ucp_mem_type_ep_lane_by_flags(ep, mem_info.flags, 1);
 
 out_reg:
+    if (lane == UCP_NULL_LANE) {
+        ucs_error("no mem type rma lane can register %s buffer %p length %zu",
+                  ucs_memory_type_names[mem_type], address, length);
+        return UCS_ERR_UNSUPPORTED;
+    }
+
     md_index = ucp_ep_md_index(ep, lane);
     *lane_p  = lane;
     return ucp_mem_type_reg_buffers(worker, address, length, mem_type, md_index,

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -61,32 +61,78 @@ ucs_status_t ucp_dt_mem_info_verify(const char *dt_name, size_t index,
 
 
 /*
- * Select the memory type endpoint lane which can access the buffer. A memory
- * domain such as gdr_copy cannot register memory which is not registrable, so
- * fall back to the next lane (for example cuda_copy) in that case.
+ * Select an RMA lane whose MD accepts the buffer mem_flags, starting the search
+ * from the given lane index.
  */
 static ucp_lane_index_t
-ucp_mem_type_ep_lane(ucp_worker_h worker, ucp_ep_h ep, const void *address,
-                     size_t length)
+ucp_mem_type_ep_lane_by_flags(ucp_ep_h ep, uint8_t mem_flags, unsigned first)
 {
-    ucp_context_h context          = worker->context;
+    ucp_context_h context          = ep->worker->context;
     const ucp_ep_config_key_t *key = &ucp_ep_config(ep)->key;
     const uct_md_attr_v2_t *md_attr;
-    ucp_memory_info_t mem_info;
     ucp_lane_index_t lane;
     unsigned i;
 
-    ucp_memory_detect(context, address, length, &mem_info);
-
-    for (i = 0; key->rma_lanes[i] != UCP_NULL_LANE; ++i) {
+    for (i = first; key->rma_lanes[i] != UCP_NULL_LANE; ++i) {
         lane    = key->rma_lanes[i];
         md_attr = &context->tl_mds[ucp_ep_md_index(ep, lane)].attr;
-        if (ucs_test_all_flags(mem_info.flags, md_attr->required_mem_flags)) {
+        if (ucs_test_all_flags(mem_flags, md_attr->required_mem_flags)) {
             return lane;
         }
     }
 
     return key->rma_lanes[0];
+}
+
+/* Select the mem-type endpoint lane which can access the buffer and register */
+static ucs_status_t
+ucp_mem_type_lane_reg(ucp_worker_h worker, ucp_ep_h ep, void *address,
+                      size_t length, ucs_memory_type_t mem_type,
+                      ucp_lane_index_t *lane_p,
+                      ucp_mtype_pack_context_t *pack_context)
+{
+    ucp_context_h context            = worker->context;
+    const ucp_ep_config_key_t *key   = &ucp_ep_config(ep)->key;
+    ucp_lane_index_t lane            = key->rma_lanes[0];
+    ucp_md_index_t md_index          = ucp_ep_md_index(ep, lane);
+    const uct_md_attr_v2_t *md_attr  = &context->tl_mds[md_index].attr;
+    ucs_memory_info_t cache_info;
+    ucp_memory_info_t mem_info;
+    ucs_status_t status;
+
+    /* The preferred MD accepts any memory, no need to know the buffer flags */
+    if (md_attr->required_mem_flags == 0) {
+        goto out_reg;
+    }
+
+    /* The memory flags are already known, for example set by a memory hook on
+     * allocation */
+    status = ucs_memtype_cache_lookup(address, length, &cache_info);
+    if ((status == UCS_OK) && ucp_memory_info_is_complete(&cache_info)) {
+        lane = ucp_mem_type_ep_lane_by_flags(ep, cache_info.mem_flags, 0);
+        goto out_reg;
+    }
+
+    /* Unknown memory: attempt the preferred MD instead of querying attributes,
+     * a memory domain such as gdr_copy fails on non-registrable memory */
+    status = ucp_mem_type_reg_buffers(worker, address, length, mem_type,
+                                      md_index, UCT_MD_MEM_FLAG_HIDE_ERRORS,
+                                      pack_context);
+    if (status == UCS_OK) {
+        *lane_p = lane;
+        return UCS_OK;
+    }
+
+    /* Query the memory attributes to fall back to another lane, skipping the
+     * preferred one which just failed to register */
+    ucp_memory_detect(context, address, length, &mem_info);
+    lane = ucp_mem_type_ep_lane_by_flags(ep, mem_info.flags, 1);
+
+out_reg:
+    md_index = ucp_ep_md_index(ep, lane);
+    *lane_p  = lane;
+    return ucp_mem_type_reg_buffers(worker, address, length, mem_type, md_index,
+                                    0, pack_context);
 }
 
 UCS_PROFILE_FUNC_VOID(ucp_mem_type_unpack,
@@ -96,7 +142,6 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_unpack,
 {
     ucp_ep_h ep = worker->mem_type_ep[mem_type];
     ucp_lane_index_t lane;
-    unsigned md_index;
     ucs_status_t status;
     ucp_mtype_pack_context_t pack_context;
 
@@ -104,11 +149,8 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_unpack,
         return;
     }
 
-    lane     = ucp_mem_type_ep_lane(worker, ep, buffer, recv_length);
-    md_index = ucp_ep_md_index(ep, lane);
-
-    status = ucp_mem_type_reg_buffers(worker, buffer, recv_length, mem_type,
-                                      md_index, &pack_context);
+    status = ucp_mem_type_lane_reg(worker, ep, buffer, recv_length, mem_type,
+                                   &lane, &pack_context);
     if (status != UCS_OK) {
         ucs_fatal("failed to register buffer with mem type domain %s",
                   ucs_memory_type_names[mem_type]);
@@ -131,7 +173,6 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_pack,
 {
     ucp_ep_h ep = worker->mem_type_ep[mem_type];
     ucp_lane_index_t lane;
-    ucp_md_index_t md_index;
     ucs_status_t status;
     ucp_mtype_pack_context_t pack_context;
 
@@ -139,11 +180,8 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_pack,
         return;
     }
 
-    lane     = ucp_mem_type_ep_lane(worker, ep, src, length);
-    md_index = ucp_ep_md_index(ep, lane);
-
-    status = ucp_mem_type_reg_buffers(worker, (void *)src, length, mem_type,
-                                      md_index, &pack_context);
+    status = ucp_mem_type_lane_reg(worker, ep, (void*)src, length, mem_type,
+                                   &lane, &pack_context);
     if (status != UCS_OK) {
         ucs_fatal("failed to register buffer with mem type domain %s",
                   ucs_memory_type_names[mem_type]);

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -124,8 +124,10 @@ ucp_mem_type_lane_reg(ucp_worker_h worker, ucp_ep_h ep, void *address,
     }
 
     /* Preferred MD rejected the buffer: detect attributes for a fallback lane
-     * (also warms the memtype cache). Coverity fnptr model false positive. */
-    /* coverity[use_after_free] */
+     * (also warms the memtype cache) */
+    /* Coverity wrongly resolves the memory domain deregister function pointer
+     * to 'uct_cuda_ipc_mem_dereg' and considers 'address' as freed */
+    /* coverity[pass_freed_arg] */
     ucp_memory_detect(context, address, length, &mem_info);
     lane = ucp_mem_type_ep_lane_by_flags(ep, mem_info.flags, 1);
 

--- a/src/ucp/dt/dt.c
+++ b/src/ucp/dt/dt.c
@@ -60,6 +60,35 @@ ucs_status_t ucp_dt_mem_info_verify(const char *dt_name, size_t index,
 }
 
 
+/*
+ * Select the memory type endpoint lane which can access the buffer. A memory
+ * domain such as gdr_copy cannot register memory which is not registrable, so
+ * fall back to the next lane (for example cuda_copy) in that case.
+ */
+static ucp_lane_index_t
+ucp_mem_type_ep_lane(ucp_worker_h worker, ucp_ep_h ep, const void *address,
+                     size_t length)
+{
+    ucp_context_h context          = worker->context;
+    const ucp_ep_config_key_t *key = &ucp_ep_config(ep)->key;
+    const uct_md_attr_v2_t *md_attr;
+    ucp_memory_info_t mem_info;
+    ucp_lane_index_t lane;
+    unsigned i;
+
+    ucp_memory_detect(context, address, length, &mem_info);
+
+    for (i = 0; key->rma_lanes[i] != UCP_NULL_LANE; ++i) {
+        lane    = key->rma_lanes[i];
+        md_attr = &context->tl_mds[ucp_ep_md_index(ep, lane)].attr;
+        if (ucs_test_all_flags(mem_info.flags, md_attr->required_mem_flags)) {
+            return lane;
+        }
+    }
+
+    return key->rma_lanes[0];
+}
+
 UCS_PROFILE_FUNC_VOID(ucp_mem_type_unpack,
                       (worker, buffer, recv_data, recv_length, mem_type),
                       ucp_worker_h worker, void *buffer, const void *recv_data,
@@ -75,7 +104,7 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_unpack,
         return;
     }
 
-    lane     = ucp_ep_config(ep)->key.rma_lanes[0];
+    lane     = ucp_mem_type_ep_lane(worker, ep, buffer, recv_length);
     md_index = ucp_ep_md_index(ep, lane);
 
     status = ucp_mem_type_reg_buffers(worker, buffer, recv_length, mem_type,
@@ -110,7 +139,7 @@ UCS_PROFILE_FUNC_VOID(ucp_mem_type_pack,
         return;
     }
 
-    lane     = ucp_ep_config(ep)->key.rma_lanes[0];
+    lane     = ucp_mem_type_ep_lane(worker, ep, src, length);
     md_index = ucp_ep_md_index(ep, lane);
 
     status = ucp_mem_type_reg_buffers(worker, (void *)src, length, mem_type,

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -116,11 +116,12 @@ uct_gdr_copy_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
     uct_gdr_copy_md_t *md = ucs_derived_of(uct_md, uct_gdr_copy_md_t);
 
     uct_md_base_md_query(md_attr);
-    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;
-    md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->access_mem_types = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
-    md_attr->rkey_packed_size = sizeof(uct_gdr_copy_key_t);
-    md_attr->reg_cost         = md->reg_cost;
+    md_attr->flags              = UCT_MD_FLAG_REG | UCT_MD_FLAG_NEED_RKEY;
+    md_attr->reg_mem_types      = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->access_mem_types   = UCS_BIT(UCS_MEMORY_TYPE_CUDA);
+    md_attr->rkey_packed_size   = sizeof(uct_gdr_copy_key_t);
+    md_attr->reg_cost           = md->reg_cost;
+    md_attr->required_mem_flags = UCS_MEM_FLAG_REGISTRABLE;
 
     /* In absence of own cache require proper alignment from the global cache */
     if (md->rcache == NULL) {

--- a/test/gtest/ucp/test_ucp_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_mem_type.cc
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2017. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -7,10 +7,15 @@
 #include "ucp_test.h"
 #include <common/mem_buffer.h>
 
+#include <cstring>
+#include <vector>
+
 extern "C" {
 #include <uct/api/uct.h>
 #include <ucp/core/ucp_context.h>
+#include <ucp/core/ucp_ep.inl>
 #include <ucp/core/ucp_mm.h>
+#include <ucp/dt/dt.h>
 }
 
 
@@ -181,3 +186,108 @@ UCS_TEST_P(test_ucp_cuda, sparse_regions) {
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_cuda, all, "all")
+
+/*
+ * gdr_copy cannot pin non-REGISTRABLE CUDA memory. Async CUDA allocations are
+ * naturally non-REGISTRABLE (same property as localized device memory).
+ * ucp_mem_type_pack/unpack must fall back from the preferred CUDA mem-type RMA
+ * lane (gdr_copy) to cuda_copy. Pack is exercised on the CUDA mem_type_ep
+ * because that is where gdr_copy is present; async buffers are detected as
+ * CUDA_MANAGED.
+ */
+class test_ucp_mem_type_pack_non_reg : public ucp_test {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant(variants, UCP_FEATURE_AM);
+    }
+
+protected:
+    static constexpr size_t BUF_SIZE = 65536;
+    static constexpr uint64_t SEED   = 0xdeadbeefcafebabeull;
+
+    ucp_ep_h cuda_mem_type_ep()
+    {
+        return sender().worker()->mem_type_ep[UCS_MEMORY_TYPE_CUDA];
+    }
+
+    /* True when lane 0 needs REGISTRABLE and a later lane does not. */
+    bool has_registrable_fallback(ucp_ep_h ep)
+    {
+        ucp_context_h context          = sender().ucph();
+        const ucp_ep_config_key_t *key = &ucp_ep_config(ep)->key;
+        ucp_lane_index_t lane;
+        ucp_md_index_t md_index;
+        unsigned i;
+
+        if (key->rma_lanes[0] == UCP_NULL_LANE) {
+            return false;
+        }
+
+        md_index = ucp_ep_md_index(ep, key->rma_lanes[0]);
+        if (!(context->tl_mds[md_index].attr.required_mem_flags &
+              UCS_MEM_FLAG_REGISTRABLE)) {
+            return false;
+        }
+
+        for (i = 1; key->rma_lanes[i] != UCP_NULL_LANE; ++i) {
+            lane     = key->rma_lanes[i];
+            md_index = ucp_ep_md_index(ep, lane);
+            if (!(context->tl_mds[md_index].attr.required_mem_flags &
+                  UCS_MEM_FLAG_REGISTRABLE)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+};
+
+UCS_TEST_P(test_ucp_mem_type_pack_non_reg, pack_unpack_fallback)
+{
+    ucp_memory_info_t mem_info;
+    ucp_ep_h ep;
+    std::vector<uint8_t> host_buf(BUF_SIZE);
+
+    if (!mem_buffer::is_async_supported(UCS_MEMORY_TYPE_CUDA)) {
+        UCS_TEST_SKIP_R("CUDA async allocation is not supported");
+    }
+
+    ep = cuda_mem_type_ep();
+    if (ep == NULL) {
+        UCS_TEST_SKIP_R("no CUDA mem_type endpoint");
+    }
+
+    if (!has_registrable_fallback(ep)) {
+        UCS_TEST_SKIP_R("mem_type EP has no gdr_copy->cuda_copy RMA fallback");
+    }
+
+    scoped_async_cuda_buffer src(BUF_SIZE);
+    scoped_async_cuda_buffer dst(BUF_SIZE);
+
+    ucp_memory_detect(sender().ucph(), src.ptr(), BUF_SIZE, &mem_info);
+    if (mem_info.type != UCS_MEMORY_TYPE_CUDA_MANAGED) {
+        UCS_TEST_SKIP_R("CUDA async memory is not classified as CUDA managed");
+    }
+    ASSERT_EQ(0, mem_info.flags & UCS_MEM_FLAG_REGISTRABLE);
+
+    mem_buffer::pattern_fill(src.ptr(), BUF_SIZE, SEED,
+                             UCS_MEMORY_TYPE_CUDA_MANAGED);
+    mem_buffer::pattern_fill(dst.ptr(), BUF_SIZE, 0,
+                             UCS_MEMORY_TYPE_CUDA_MANAGED);
+    memset(host_buf.data(), 0, BUF_SIZE);
+
+    /* Use the CUDA mem_type_ep (where gdr_copy is preferred). Lane selection
+     * still sees the buffer as non-REGISTRABLE via memory detect. */
+    ucp_mem_type_pack(sender().worker(), host_buf.data(), src.ptr(), BUF_SIZE,
+                      UCS_MEMORY_TYPE_CUDA);
+    mem_buffer::pattern_check(host_buf.data(), BUF_SIZE, SEED);
+
+    ucp_mem_type_unpack(sender().worker(), dst.ptr(), host_buf.data(),
+                        BUF_SIZE, UCS_MEMORY_TYPE_CUDA);
+    mem_buffer::pattern_check(dst.ptr(), BUF_SIZE, SEED,
+                              UCS_MEMORY_TYPE_CUDA_MANAGED);
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_mem_type_pack_non_reg, cuda,
+                              "all")

--- a/test/gtest/ucp/test_ucp_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_mem_type.cc
@@ -13,8 +13,8 @@
 extern "C" {
 #include <uct/api/uct.h>
 #include <ucp/core/ucp_context.h>
-#include <ucp/core/ucp_ep.inl>
 #include <ucp/core/ucp_mm.h>
+#include <ucp/core/ucp_worker.h>
 #include <ucp/dt/dt.h>
 }
 
@@ -188,12 +188,9 @@ UCS_TEST_P(test_ucp_cuda, sparse_regions) {
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_cuda, all, "all")
 
 /*
- * gdr_copy cannot pin non-REGISTRABLE CUDA memory. Async CUDA allocations are
- * naturally non-REGISTRABLE (same property as localized device memory).
- * ucp_mem_type_pack/unpack must fall back from the preferred CUDA mem-type RMA
- * lane (gdr_copy) to cuda_copy. Pack is exercised on the CUDA mem_type_ep
- * because that is where gdr_copy is present; async buffers are detected as
- * CUDA_MANAGED.
+ * Async CUDA allocations are not REGISTRABLE, same as localized device memory,
+ * and cannot be pinned by gdr_copy. Round-trip such a buffer through the CUDA
+ * mem-type endpoint, which is where gdr_copy is used when available.
  */
 class test_ucp_mem_type_pack_non_reg : public ucp_test {
 public:
@@ -205,89 +202,42 @@ public:
 protected:
     static constexpr size_t BUF_SIZE = 65536;
     static constexpr uint64_t SEED   = 0xdeadbeefcafebabeull;
-
-    ucp_ep_h cuda_mem_type_ep()
-    {
-        return sender().worker()->mem_type_ep[UCS_MEMORY_TYPE_CUDA];
-    }
-
-    /* True when lane 0 needs REGISTRABLE and a later lane does not. */
-    bool has_registrable_fallback(ucp_ep_h ep)
-    {
-        ucp_context_h context          = sender().ucph();
-        const ucp_ep_config_key_t *key = &ucp_ep_config(ep)->key;
-        ucp_lane_index_t lane;
-        ucp_md_index_t md_index;
-        unsigned i;
-
-        if (key->rma_lanes[0] == UCP_NULL_LANE) {
-            return false;
-        }
-
-        md_index = ucp_ep_md_index(ep, key->rma_lanes[0]);
-        if (!(context->tl_mds[md_index].attr.required_mem_flags &
-              UCS_MEM_FLAG_REGISTRABLE)) {
-            return false;
-        }
-
-        for (i = 1; key->rma_lanes[i] != UCP_NULL_LANE; ++i) {
-            lane     = key->rma_lanes[i];
-            md_index = ucp_ep_md_index(ep, lane);
-            if (!(context->tl_mds[md_index].attr.required_mem_flags &
-                  UCS_MEM_FLAG_REGISTRABLE)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
 };
 
-UCS_TEST_P(test_ucp_mem_type_pack_non_reg, pack_unpack_fallback)
+UCS_TEST_P(test_ucp_mem_type_pack_non_reg, pack_unpack)
 {
-    ucp_memory_info_t mem_info;
-    ucp_ep_h ep;
     std::vector<uint8_t> host_buf(BUF_SIZE);
+    ucs_memory_type_t buf_mem_type;
+    ucp_memory_info_t mem_info;
 
     if (!mem_buffer::is_async_supported(UCS_MEMORY_TYPE_CUDA)) {
         UCS_TEST_SKIP_R("CUDA async allocation is not supported");
     }
 
-    ep = cuda_mem_type_ep();
-    if (ep == NULL) {
-        UCS_TEST_SKIP_R("no CUDA mem_type endpoint");
-    }
-
-    if (!has_registrable_fallback(ep)) {
-        UCS_TEST_SKIP_R("mem_type EP has no gdr_copy->cuda_copy RMA fallback");
+    if (sender().worker()->mem_type_ep[UCS_MEMORY_TYPE_CUDA] == NULL) {
+        UCS_TEST_SKIP_R("no CUDA mem type endpoint");
     }
 
     scoped_async_cuda_buffer src(BUF_SIZE);
     scoped_async_cuda_buffer dst(BUF_SIZE);
 
     ucp_memory_detect(sender().ucph(), src.ptr(), BUF_SIZE, &mem_info);
-    if (mem_info.type != UCS_MEMORY_TYPE_CUDA_MANAGED) {
-        UCS_TEST_SKIP_R("CUDA async memory is not classified as CUDA managed");
+    if (mem_info.flags & UCS_MEM_FLAG_REGISTRABLE) {
+        UCS_TEST_SKIP_R("CUDA async memory is registrable");
     }
-    ASSERT_EQ(0, mem_info.flags & UCS_MEM_FLAG_REGISTRABLE);
 
-    mem_buffer::pattern_fill(src.ptr(), BUF_SIZE, SEED,
-                             UCS_MEMORY_TYPE_CUDA_MANAGED);
-    mem_buffer::pattern_fill(dst.ptr(), BUF_SIZE, 0,
-                             UCS_MEMORY_TYPE_CUDA_MANAGED);
+    buf_mem_type = static_cast<ucs_memory_type_t>(mem_info.type);
+    mem_buffer::pattern_fill(src.ptr(), BUF_SIZE, SEED, buf_mem_type);
+    mem_buffer::pattern_fill(dst.ptr(), BUF_SIZE, 0, buf_mem_type);
     memset(host_buf.data(), 0, BUF_SIZE);
 
-    /* Use the CUDA mem_type_ep (where gdr_copy is preferred). Lane selection
-     * still sees the buffer as non-REGISTRABLE via memory detect. */
     ucp_mem_type_pack(sender().worker(), host_buf.data(), src.ptr(), BUF_SIZE,
                       UCS_MEMORY_TYPE_CUDA);
     mem_buffer::pattern_check(host_buf.data(), BUF_SIZE, SEED);
 
-    ucp_mem_type_unpack(sender().worker(), dst.ptr(), host_buf.data(),
-                        BUF_SIZE, UCS_MEMORY_TYPE_CUDA);
-    mem_buffer::pattern_check(dst.ptr(), BUF_SIZE, SEED,
-                              UCS_MEMORY_TYPE_CUDA_MANAGED);
+    ucp_mem_type_unpack(sender().worker(), dst.ptr(), host_buf.data(), BUF_SIZE,
+                        UCS_MEMORY_TYPE_CUDA);
+    mem_buffer::pattern_check(dst.ptr(), BUF_SIZE, SEED, buf_mem_type);
 }
 
-UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_mem_type_pack_non_reg, cuda,
-                              "all")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_mem_type_pack_non_reg, all, "all")

--- a/test/gtest/ucp/test_ucp_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_mem_type.cc
@@ -188,9 +188,9 @@ UCS_TEST_P(test_ucp_cuda, sparse_regions) {
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_cuda, all, "all")
 
 /*
- * Async CUDA allocations are not REGISTRABLE, same as localized device memory,
- * and cannot be pinned by gdr_copy. Round-trip such a buffer through the CUDA
- * mem-type endpoint, which is where gdr_copy is used when available.
+ * Async CUDA allocations are not REGISTRABLE, so gdr_copy cannot pin them.
+ * Pack/unpack via the CUDA mem-type endpoint must fall back from a preferred
+ * gdr_copy RMA lane to cuda_copy.
  */
 class test_ucp_mem_type_pack_non_reg : public ucp_test {
 public:


### PR DESCRIPTION
## What?
`gdr_copy` cannot pin non-registrable CUDA memory. Advertise `UCS_MEM_FLAG_REGISTRABLE` as required for `gdr_copy`, and fall back to another mem-type RMA lane in `ucp_mem_type_pack` / `unpack` when that flag is missing, instead of fatalling on pin failure.

## Why?
On such buffers, mem-type pack always used `mem_type_ep` `rma_lanes[0]`, hit `gdr_pin_buffer_v2` failure, and aborted with `failed to register buffer with mem type domain cuda`. Protocol selection / memh registration already honor `required_mem_flags`, but the pack/unpack helper did not.

## How?
- Set `required_mem_flags = UCS_MEM_FLAG_REGISTRABLE` in `uct_gdr_copy_md_query`.
- In pack/unpack, pick the first mem-type RMA lane whose `required_mem_flags` are satisfied by the buffer.
- GTEST: async CUDA pack/unpack round-trip over `gdr_copy,cuda_copy` to cover the fallback.
