### PR TITLE
UCT/IB/MLX5/GDAKI: Deleted extra cuMemset.

### DIFF
--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -981,13 +981,6 @@ uct_rc_gdaki_ep_get_device_ep(uct_ep_h tl_ep, uct_device_ep_h *device_ep_p)
             goto out_ctx;
         }
 
-        status = UCT_CUDADRV_FUNC_LOG_ERR(
-                cuMemsetD8((CUdeviceptr)ep->channel_block->gpu_ptr, 0,
-                           dev_ep_host_size));
-        if (status != UCS_OK) {
-            goto out_free;
-        }
-
         dev_ep->atomic_va    = iface->atomic_buff;
         dev_ep->atomic_lkey  = htonl(iface->atomic_mr->lkey);
         dev_ep->sq_wqe_num   = uct_ib_mlx5_devx_sq_length(
@@ -1041,7 +1034,7 @@ out_unreg:
         (void)cuMemHostUnregister(
                 ep->channel_block->channels[i].qp.reg->addr.ptr);
     } while (i-- > 0);
-out_free:
+
     ucs_free(dev_ep);
 out_ctx:
     (void)UCT_CUDADRV_FUNC_LOG_WARN(cuCtxPopCurrent(NULL));


### PR DESCRIPTION
## What?
Deleted extra `cuMemsetD8`. This call sets `dev_ep_host_size` bytes at `ep->channel_block->gpu_ptr` to zeros. Which is redundant, as the subsequent `cuMemcpyHtoD` copies the same amount of bytes from host to the same address. And the source host memory is allocated using `calloc`.
