### PR TITLE
UCX: Replace empty `SCM_BRANCH` and `SCM_VERSION` with default values

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,9 @@ AC_CHECK_PROG(GITBIN, git, yes)
 AS_IF([test x"${GITBIN}" = x"yes"],
       [# remove preceding "refs/heads/" (11 characters) for symbolic ref
        AC_SUBST(SCM_BRANCH,  esyscmd([sh -c 'git symbolic-ref --quiet   HEAD | sed "s/^.\{11\}//"']))
-       AC_SUBST(SCM_VERSION, esyscmd([sh -c 'git rev-parse    --short=7 HEAD']))],
+       AC_SUBST(SCM_VERSION, esyscmd([sh -c 'git rev-parse    --short=7 HEAD']))
+       SCM_BRANCH="${SCM_BRANCH:-"<unknown>"}"
+       SCM_VERSION="${SCM_VERSION:-"0000000"}"],
       [AC_SUBST(SCM_BRANCH,  "<unknown>")
        AC_SUBST(SCM_VERSION, "0000000")])
 

--- a/configure.ac
+++ b/configure.ac
@@ -31,15 +31,19 @@ valgrind_libpath=""
 AC_USE_SYSTEM_EXTENSIONS
 AC_CONFIG_HEADERS([config.h])
 
+SCM_BRANCH=
+SCM_VERSION=
 AC_CHECK_PROG(GITBIN, git, yes)
 AS_IF([test x"${GITBIN}" = x"yes"],
       [# remove preceding "refs/heads/" (11 characters) for symbolic ref
-       AC_SUBST(SCM_BRANCH,  esyscmd([sh -c 'git symbolic-ref --quiet   HEAD | sed "s/^.\{11\}//"']))
-       AC_SUBST(SCM_VERSION, esyscmd([sh -c 'git rev-parse    --short=7 HEAD']))
-       SCM_BRANCH="${SCM_BRANCH:-"<unknown>"}"
-       SCM_VERSION="${SCM_VERSION:-"0000000"}"],
-      [AC_SUBST(SCM_BRANCH,  "<unknown>")
-       AC_SUBST(SCM_VERSION, "0000000")])
+       SCM_BRANCH=esyscmd([sh -c 'git symbolic-ref --quiet   HEAD | sed "s/^.\{11\}//"'])
+       SCM_VERSION=esyscmd([sh -c 'git rev-parse --short=7 HEAD'])])
+
+SCM_BRANCH="${SCM_BRANCH:-"<unknown>"}"
+SCM_VERSION="${SCM_VERSION:-"0000000"}"
+
+AC_SUBST(SCM_BRANCH)
+AC_SUBST(SCM_VERSION)
 
 AH_TOP([
 #ifndef UCX_CONFIG_H
@@ -71,7 +75,6 @@ AC_SUBST(MAJOR_VERSION)
 AC_SUBST(MINOR_VERSION)
 AC_SUBST(PATCH_VERSION)
 AC_SUBST(EXTRA_VERSION)
-AC_SUBST(SCM_VERSION)
 AC_SUBST(SOVERSION)
 
 UCX_LT_RELEASE=


### PR DESCRIPTION
## What?
Replace empty `SCM_BRANCH` and `SCM_VERSION` with default values `<unknown>` and `0000000`.

## Why?
Currently these default values are already set when `git` is not available, but in the case that `git` is available and the project is not a git repository `SCM_BRANCH` and `SCM_VERSION` are set to empty values instead.
This happens for example when using the `benchmark/nixlbench/contrib/build.sh` script where the ucx folder is copied into the container.
The added lines set the correct default values in case they are empty.

Example output of `ucx_info -v` before the fix:
` Git branch '', revision `

And after the fix:
`Git branch '<unknown>', revision 0000000`