### PR TITLE
UCT/CUDA/CUDA_IPC: Unmap memhandle mapped at rkey unpack, rkey ptr, mem element pack - v1.22.x

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -752,6 +752,19 @@ run_mpi_tests() {
 				${MPIRUN_COMMON} -np 2 ./test/mpi/test_rma_cuda
 			fi
 
+			if [ "X$have_cuda" != "Xno" ] && [ -x ./test/mpi/test_ucp_rkey_destroy ]
+			then
+				echo "==== Running UCP RKEY destroy tests ===="
+				# The test checks that after destroying a UCP remote key on the
+				# remote process, the local memory can be released. However, the
+				# internal caches may hold references to the memory, e.g. via
+				# opened CUDA IPC memory handle. All the caches are disabled
+				# to be able to release the memory after the remote key is
+				# destroyed.
+				${MPIRUN_COMMON} -np 2 -x UCX_MEMTYPE_CACHE=n \
+								./test/mpi/test_ucp_rkey_destroy
+			fi
+
 			# Restore LD_LIBRARY_PATH so subsequent tests will not take UCX libs
 			# from installation directory
 			export LD_LIBRARY_PATH=${save_LD_LIBRARY_PATH}

--- a/src/ucp/core/ucp_device.c
+++ b/src/ucp/core/ucp_device.c
@@ -22,10 +22,18 @@
 #include "ucp_ep.inl"
 #include "ucp_mm.inl"
 
+typedef struct {
+    uct_md_h md;
+    void     *release_handle;
+} ucp_device_mem_elem_release_handle_t;
+
+UCS_ARRAY_DECLARE_TYPE(ucp_device_mem_elem_release_handles_t, unsigned,
+                       ucp_device_mem_elem_release_handle_t);
 
 typedef struct {
-    uct_allocated_memory_t mem;
-    uint32_t               mem_list_length;
+    uct_allocated_memory_t                mem;
+    uint32_t                              mem_list_length;
+    ucp_device_mem_elem_release_handles_t release_handles;
 } ucp_device_handle_info_t;
 
 #define ucp_device_handle_hash_key(_handle) \
@@ -60,9 +68,40 @@ void ucp_device_cleanup(void)
     ucs_spinlock_destroy(&ucp_device_handle_hash_lock);
 }
 
-static ucs_status_t
-ucp_device_mem_handle_hash_insert(const uct_allocated_memory_t *mem_handle,
-                                  uint32_t mem_list_length)
+static ucs_status_t ucp_device_mem_elem_release_handles_append(
+        ucp_device_mem_elem_release_handles_t *release_handles, uct_md_h md,
+        void *release_handle)
+{
+    ucp_device_mem_elem_release_handle_t *it;
+
+    it     = ucs_array_append(release_handles, return UCS_ERR_NO_MEMORY);
+    it->md = md;
+    it->release_handle = release_handle;
+    return UCS_OK;
+}
+
+static void ucp_device_mem_elem_release_handles_cleanup(
+        ucp_device_mem_elem_release_handles_t *release_handles)
+{
+    ucp_device_mem_elem_release_handle_t *it;
+
+    /* Check buffer explicitly: Coverity issues FORWARD_NULL error;
+       ucs_array_is_empty is not enough as Coverity does not correlate
+       non-zero length with a non-NULL buffer after create_handle paths. */
+    if (ucs_array_begin(release_handles) == NULL) {
+        return;
+    }
+
+    ucs_array_for_each(it, release_handles) {
+        uct_md_mem_elem_release(it->md, it->release_handle);
+    }
+
+    ucs_array_cleanup_dynamic(release_handles);
+}
+
+static ucs_status_t ucp_device_mem_handle_hash_insert(
+        const uct_allocated_memory_t *mem_handle, uint32_t mem_list_length,
+        ucp_device_mem_elem_release_handles_t *release_handles)
 {
     ucs_status_t status;
     khiter_t iter;
@@ -71,6 +110,7 @@ ucp_device_mem_handle_hash_insert(const uct_allocated_memory_t *mem_handle,
 
     info.mem             = *mem_handle;
     info.mem_list_length = mem_list_length;
+    info.release_handles = *release_handles;
 
     ucs_spin_lock(&ucp_device_handle_hash_lock);
     iter = kh_put(ucp_device_handle_allocs, &ucp_device_handle_hash,
@@ -84,25 +124,27 @@ ucp_device_mem_handle_hash_insert(const uct_allocated_memory_t *mem_handle,
     } else {
         kh_value(&ucp_device_handle_hash, iter) = info;
         status                                  = UCS_OK;
+        /* Ownership of the array moved to the hash */
+        ucs_array_init_dynamic(release_handles);
     }
 
     ucs_spin_unlock(&ucp_device_handle_hash_lock);
     return status;
 }
 
-static uct_allocated_memory_t ucp_device_mem_handle_hash_remove(void *handle)
+static ucp_device_handle_info_t ucp_device_mem_handle_hash_remove(void *handle)
 {
     khiter_t iter;
-    uct_allocated_memory_t mem;
+    ucp_device_handle_info_t info;
 
     ucs_spin_lock(&ucp_device_handle_hash_lock);
     iter = kh_get(ucp_device_handle_allocs, &ucp_device_handle_hash, handle);
     ucs_assertv_always((iter != kh_end(&ucp_device_handle_hash)), "handle=%p",
                        handle);
-    mem = kh_value(&ucp_device_handle_hash, iter).mem;
+    info = kh_value(&ucp_device_handle_hash, iter);
     kh_del(ucp_device_handle_allocs, &ucp_device_handle_hash, iter);
     ucs_spin_unlock(&ucp_device_handle_hash_lock);
-    return mem;
+    return info;
 }
 
 static ucs_status_t
@@ -181,13 +223,15 @@ ucp_device_get_tl_bitmap(const ucp_worker_h worker,
 static ucs_status_t ucp_device_local_mem_list_element_pack(
         const ucp_worker_h worker, const ucp_worker_iface_t *wiface,
         const ucp_device_mem_list_elem_t *element,
-        const ucs_memory_type_t mem_type, uct_device_mem_elem_t *mem_element)
+        const ucs_memory_type_t mem_type, uct_device_mem_elem_t *mem_element,
+        ucp_device_mem_elem_release_handles_t *release_handles)
 {
     ucp_tl_resource_desc_t *resource;
     ucp_md_index_t md_index;
     ucp_mem_h memh;
     uct_mem_h uct_memh;
     ucp_tl_md_t *ucp_md;
+    void *release_handle;
     ucs_status_t status;
 
     if (wiface == NULL) {
@@ -206,11 +250,18 @@ static ucs_status_t ucp_device_local_mem_list_element_pack(
     }
 
     status = uct_md_mem_elem_pack(ucp_md->md, uct_memh, UCT_INVALID_RKEY,
-                                  mem_element);
+                                  mem_element, &release_handle);
     if (status != UCS_OK) {
         ucs_error("failed to pack local mem element for memh=%p", memh);
+        return status;
     }
 
+    status = ucp_device_mem_elem_release_handles_append(release_handles,
+                                                        ucp_md->md,
+                                                        release_handle);
+    if (status != UCS_OK) {
+        uct_md_mem_elem_release(ucp_md->md, release_handle);
+    }
     return status;
 }
 
@@ -239,7 +290,8 @@ static ucs_status_t ucp_device_mem_list_export_handle(
 
 static ucs_status_t ucp_device_local_mem_list_create_handle(
         const ucp_device_mem_list_params_t *params, ucs_memory_type_t mem_type,
-        uct_allocated_memory_t *mem, ucs_sys_device_t local_sys_dev)
+        ucs_sys_device_t local_sys_dev, uct_allocated_memory_t *mem,
+        ucp_device_mem_elem_release_handles_t *release_handles)
 {
     const ucp_worker_h worker   = UCS_PARAM_VALUE(
             UCP_DEVICE_MEM_LIST_PARAMS_FIELD, params, worker, WORKER, NULL);
@@ -282,7 +334,8 @@ static ucs_status_t ucp_device_local_mem_list_create_handle(
             status = ucp_device_local_mem_list_element_pack(worker, wiface,
                                                             ucp_element,
                                                             mem_type,
-                                                            tl_element);
+                                                            tl_element,
+                                                            release_handles);
             if (status != UCS_OK) {
                 ucs_error("failed to pack local mem list element for "
                           "element=%zu",
@@ -365,6 +418,8 @@ ucp_device_local_mem_list_create(const ucp_device_mem_list_params_t *params,
                                  ucp_device_local_mem_list_h *mem_list_h)
 {
     const ucs_memory_type_t export_mem_type = UCS_MEMORY_TYPE_CUDA;
+    ucp_device_mem_elem_release_handles_t release_handles =
+            UCS_ARRAY_DYNAMIC_INITIALIZER;
     ucs_status_t status;
     uct_allocated_memory_t mem;
     ucs_sys_device_t local_sys_dev;
@@ -378,21 +433,27 @@ ucp_device_local_mem_list_create(const ucp_device_mem_list_params_t *params,
     }
 
     status = ucp_device_local_mem_list_create_handle(params, export_mem_type,
-                                                     &mem, local_sys_dev);
+                                                     local_sys_dev, &mem,
+                                                     &release_handles);
     if (status != UCS_OK) {
         ucs_error("failed to create local mem list handle: %s",
                   ucs_status_string(status));
-        return status;
+        goto err;
     }
 
     /* Track memory allocator for later release */
-    status = ucp_device_mem_handle_hash_insert(&mem, params->num_elements);
+    status = ucp_device_mem_handle_hash_insert(&mem, params->num_elements,
+                                               &release_handles);
     if (status != UCS_OK) {
         uct_mem_free(&mem);
-    } else {
-        *mem_list_h = mem.address;
+        goto err;
     }
 
+    *mem_list_h = mem.address;
+    return UCS_OK;
+
+err:
+    ucp_device_mem_elem_release_handles_cleanup(&release_handles);
     return status;
 }
 
@@ -431,15 +492,18 @@ ucp_device_ep_check_lanes(const ucp_ep_h ep, ucp_tl_bitmap_t *tl_bitmap)
 
 static ucs_status_t ucp_device_remote_mem_list_element_pack(
         const ucp_device_mem_list_elem_t *element, ucp_rsc_index_t tl_id,
-        uct_device_remote_tl_elem_t *mem_element)
+        uct_device_remote_tl_elem_t *mem_element,
+        ucp_device_mem_elem_release_handles_t *release_handles)
 {
     const ucp_ep_h ep     = element->ep;
     const ucp_rkey_h rkey = element->rkey;
     ucp_ep_config_t *ep_config = ucp_ep_config(ep);
+    uct_md_h md;
     uint8_t rkey_index;
     uct_rkey_t uct_rkey;
     uct_ep_h uct_ep;
     uct_device_ep_h device_ep;
+    void *release_handle;
     ucs_status_t status;
     ucp_lane_index_t lane;
 
@@ -461,11 +525,19 @@ static ucs_status_t ucp_device_remote_mem_list_element_pack(
     uct_rkey   = ucp_rkey_get_tl_rkey(rkey, rkey_index);
     ucs_assert(uct_rkey != UCT_INVALID_RKEY);
 
+    md              = ucp_ep_md(ep, lane);
     mem_element->ep = device_ep;
-    status          = uct_md_mem_elem_pack(ucp_ep_md(ep, lane), NULL, uct_rkey,
-                                           &mem_element->uct);
+    status = uct_md_mem_elem_pack(md, NULL, uct_rkey, &mem_element->uct,
+                                  &release_handle);
     if (status != UCS_OK) {
         ucs_error("failed to pack uct memory element for lane=%u", lane);
+        return status;
+    }
+
+    status = ucp_device_mem_elem_release_handles_append(release_handles, md,
+                                                        release_handle);
+    if (status != UCS_OK) {
+        uct_md_mem_elem_release(md, release_handle);
     }
 
     return status;
@@ -505,10 +577,11 @@ static ucp_ep_h ucp_device_remote_mem_list_get_first_ep(
     return NULL;
 }
 
-static ucs_status_t
-ucp_device_remote_mem_list_fill(const ucp_device_mem_list_elem_t *ucp_element,
-                                ucp_tl_bitmap_t *tl_bitmap, size_t num_lanes,
-                                uct_device_remote_mem_elem_t *uct_element)
+static ucs_status_t ucp_device_remote_mem_list_fill(
+        const ucp_device_mem_list_elem_t *ucp_element,
+        const ucp_tl_bitmap_t *tl_bitmap, size_t num_lanes,
+        uct_device_remote_mem_elem_t *uct_element,
+        ucp_device_mem_elem_release_handles_t *release_handles)
 {
     uct_device_remote_tl_elem_t *tl_element;
     ucp_rsc_index_t tl_id;
@@ -520,7 +593,8 @@ ucp_device_remote_mem_list_fill(const ucp_device_mem_list_elem_t *ucp_element,
     for (i = 0; i < num_lanes;) {
         UCS_STATIC_BITMAP_FOR_EACH_BIT(tl_id, tl_bitmap) {
             status = ucp_device_remote_mem_list_element_pack(ucp_element, tl_id,
-                                                             tl_element);
+                                                             tl_element,
+                                                             release_handles);
             if (status != UCS_OK) {
                 return status;
             }
@@ -535,7 +609,8 @@ ucp_device_remote_mem_list_fill(const ucp_device_mem_list_elem_t *ucp_element,
 
 static ucs_status_t ucp_device_remote_mem_list_create_handle(
         const ucp_device_mem_list_params_t *params, ucs_memory_type_t mem_type,
-        uct_allocated_memory_t *mem)
+        uct_allocated_memory_t *mem,
+        ucp_device_mem_elem_release_handles_t *release_handles)
 {
     const ucp_ep_h ep = ucp_device_remote_mem_list_get_first_ep(params);
     size_t uct_elem_size;
@@ -607,7 +682,8 @@ static ucs_status_t ucp_device_remote_mem_list_create_handle(
 
             status = ucp_device_remote_mem_list_fill(ucp_element,
                                                      &tl_bitmap[tl_type],
-                                                     num_lanes, uct_element);
+                                                     num_lanes, uct_element,
+                                                     release_handles);
             if (status != UCS_OK) {
                 goto out;
             }
@@ -684,6 +760,8 @@ ucp_device_remote_mem_list_create(const ucp_device_mem_list_params_t *params,
                                   ucp_device_remote_mem_list_h *mem_list_h)
 {
     const ucs_memory_type_t export_mem_type = UCS_MEMORY_TYPE_CUDA;
+    ucp_device_mem_elem_release_handles_t release_handles =
+            UCS_ARRAY_DYNAMIC_INITIALIZER;
     ucs_status_t status;
     uct_allocated_memory_t mem;
 
@@ -693,7 +771,7 @@ ucp_device_remote_mem_list_create(const ucp_device_mem_list_params_t *params,
     }
 
     status = ucp_device_remote_mem_list_create_handle(params, export_mem_type,
-                                                      &mem);
+                                                      &mem, &release_handles);
     if (status != UCS_OK) {
         /*
          * Do not log error for UCS_ERR_NOT_CONNECTED because it is expected
@@ -703,17 +781,22 @@ ucp_device_remote_mem_list_create(const ucp_device_mem_list_params_t *params,
         if (status != UCS_ERR_NOT_CONNECTED) {
             ucs_error("failed to create handle: %s", ucs_status_string(status));
         }
-        return status;
+        goto err;
     }
 
     /* Track memory allocator for later release */
-    status = ucp_device_mem_handle_hash_insert(&mem, params->num_elements);
+    status = ucp_device_mem_handle_hash_insert(&mem, params->num_elements,
+                                               &release_handles);
     if (status != UCS_OK) {
         uct_mem_free(&mem);
-    } else {
-        *mem_list_h = mem.address;
+        goto err;
     }
 
+    *mem_list_h = mem.address;
+    return UCS_OK;
+
+err:
+    ucp_device_mem_elem_release_handles_cleanup(&release_handles);
     return status;
 }
 
@@ -737,10 +820,11 @@ uint32_t ucp_device_get_mem_list_length(const void *mem_list_h)
 
 void ucp_device_mem_list_release(void *mem_list_h)
 {
-    uct_allocated_memory_t mem;
+    ucp_device_handle_info_t info;
 
-    mem = ucp_device_mem_handle_hash_remove(mem_list_h);
-    uct_mem_free(&mem);
+    info = ucp_device_mem_handle_hash_remove(mem_list_h);
+    ucp_device_mem_elem_release_handles_cleanup(&info.release_handles);
+    uct_mem_free(&info.mem);
 }
 
 static ucs_memory_type_t

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1540,15 +1540,28 @@ ucs_status_t uct_rkey_unpack_v2(uct_component_h component,
  * @ingroup UCT_MD
  * @brief Pack a memh and rkey into a device memory element structure.
  *
- * @param [in]  md           Memory domain.
- * @param [in]  memh         Memory handle to pack (can be NULL).
- * @param [in]  rkey         Remote key to pack (can be UCT_INVALID_RKEY).
- * @param [out] mem_elem     Filled with the packed memh and rkey.
+ * @param [in]  md                Memory domain.
+ * @param [in]  memh              Memory handle to pack (can be NULL).
+ * @param [in]  rkey              Remote key to pack (can be UCT_INVALID_RKEY).
+ * @param [out] mem_elem          Filled with the packed memh and rkey.
+ * @param [out] release_handle_p  Handle for releasing resources allocated
+ *                                during packing.
  *
  * @return UCS_OK on success or error code in case of failure.
  */
 ucs_status_t uct_md_mem_elem_pack(uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
-                                  uct_device_mem_elem_t *mem_elem);
+                                  uct_device_mem_elem_t *mem_elem,
+                                  void **release_handle_p);
+
+
+/**
+ * @ingroup UCT_MD
+ * @brief Release resources allocated by @ref uct_md_mem_elem_pack.
+ *
+ * @param [in] md              Memory domain.
+ * @param [in] release_handle  Handle for releasing resources.
+ */
+void uct_md_mem_elem_release(uct_md_h md, void *release_handle);
 
 END_C_DECLS
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -752,7 +752,13 @@ ucs_status_t uct_md_dummy_mem_dereg(uct_md_h uct_md,
 }
 
 ucs_status_t uct_md_mem_elem_pack(uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
-                                  uct_device_mem_elem_t *mem_elem)
+                                  uct_device_mem_elem_t *mem_elem,
+                                  void **release_handle_p)
 {
-    return md->ops->mem_elem_pack(md, memh, rkey, mem_elem);
+    return md->ops->mem_elem_pack(md, memh, rkey, mem_elem, release_handle_p);
+}
+
+void uct_md_mem_elem_release(uct_md_h md, void *release_handle)
+{
+    md->ops->mem_elem_release(md, release_handle);
 }

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -128,7 +128,10 @@ typedef ucs_status_t (*uct_md_detect_memory_type_func_t)(uct_md_h md,
 
 typedef ucs_status_t (*uct_md_mem_elem_pack_func_t)(
         uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
-        uct_device_mem_elem_t *mem_elem_p);
+        uct_device_mem_elem_t *mem_elem, void **release_handle_p);
+
+typedef void (*uct_md_mem_elem_release_func_t)(uct_md_h md,
+                                               void *release_handle);
 
 /**
  * Memory domain operations
@@ -146,6 +149,7 @@ struct uct_md_ops {
     uct_md_mem_attach_func_t             mem_attach;
     uct_md_detect_memory_type_func_t     detect_memory_type;
     uct_md_mem_elem_pack_func_t          mem_elem_pack;
+    uct_md_mem_elem_release_func_t       mem_elem_release;
 };
 
 

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -1041,6 +1041,7 @@ static uct_md_ops_t md_ops = {
     .mkey_pack          = (uct_md_mkey_pack_func_t)ucs_empty_function_return_success,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function,
     .detect_memory_type = uct_cuda_copy_md_detect_memory_type
 };
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc.inl
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc.inl
@@ -95,12 +95,22 @@ uct_cuda_ipc_is_rkey_local(pid_t rkey_pid, ucs_sys_ns_t rkey_pid_ns)
            (ucs_sys_get_ns(UCS_SYS_NS_TYPE_PID) == rkey_pid_ns);
 }
 
+static UCS_F_ALWAYS_INLINE void *
+uct_cuda_ipc_rkey_get_local_address(const uct_cuda_ipc_rkey_t *rkey,
+                                    uint64_t raddr, const void *mapped_addr)
+{
+    const ptrdiff_t offset = UCS_PTR_BYTE_DIFF(rkey->d_bptr, raddr);
+
+    ucs_assertv(offset <= rkey->b_len, "offset=%ld b_len=%lu", offset,
+                rkey->b_len);
+    return UCS_PTR_BYTE_OFFSET(mapped_addr, offset);
+}
+
 static UCS_F_ALWAYS_INLINE ucs_status_t uct_cuda_ipc_get_remote_address(
         uct_cuda_ipc_extended_rkey_t *rkey, uint64_t raddr, CUdevice cu_dev,
-        void **laddr_p, void **base_addr_p)
+        void **laddr_p, const void **base_addr_p)
 {
     ucs_status_t status;
-    ptrdiff_t offset;
     void *mapped_addr;
 
     status = uct_cuda_ipc_map_memhandle(rkey, cu_dev, &mapped_addr,
@@ -109,13 +119,9 @@ static UCS_F_ALWAYS_INLINE ucs_status_t uct_cuda_ipc_get_remote_address(
         return status;
     }
 
-    offset = UCS_PTR_BYTE_DIFF(rkey->super.d_bptr, raddr);
-    ucs_assertv(offset <= rkey->super.b_len, "offset:%ld b_len:%lu", offset,
-                rkey->super.b_len);
-    *laddr_p = UCS_PTR_BYTE_OFFSET(mapped_addr, offset);
-    if (base_addr_p != NULL) {
-        *base_addr_p = mapped_addr;
-    }
+    *base_addr_p = mapped_addr;
+    *laddr_p     = uct_cuda_ipc_rkey_get_local_address(&rkey->super, raddr,
+                                                       mapped_addr);
 
     return UCS_OK;
 }

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_ep.c
@@ -110,7 +110,7 @@ uct_cuda_ipc_post_cuda_async_copy(uct_ep_h tl_ep, uint64_t remote_addr,
     CUdevice cuda_device;
     int is_ctx_pushed;
     void *mapped_rem_addr;
-    void *mapped_addr;
+    const void *mapped_addr;
     uct_cuda_ipc_event_desc_t *cuda_ipc_event;
     uct_cuda_ipc_ctx_rsc_t *ctx_rsc;
     uct_cuda_queue_desc_t *q_desc;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -49,11 +49,6 @@ static ucs_config_field_t uct_cuda_ipc_iface_config_table[] = {
      "Max number of CUDA streams to make concurrent progress on",
       ucs_offsetof(uct_cuda_ipc_iface_config_t, params.max_streams), UCS_CONFIG_TYPE_UINT},
 
-    {"CACHE", "y",
-     "Enable remote endpoint IPC memhandle mapping cache",
-     ucs_offsetof(uct_cuda_ipc_iface_config_t, params.enable_cache),
-     UCS_CONFIG_TYPE_BOOL},
-
     {"ENABLE_GET_ZCOPY", "auto",
      "Enable get operations except for platforms known to have slower performance",
      ucs_offsetof(uct_cuda_ipc_iface_config_t, params.enable_get_zcopy),
@@ -329,8 +324,6 @@ static ucs_status_t uct_cuda_ipc_iface_query(uct_iface_h tl_iface,
 static void uct_cuda_ipc_complete_event(uct_iface_h tl_iface,
                                         uct_cuda_event_desc_t *cuda_event)
 {
-    uct_cuda_ipc_iface_t *iface               = ucs_derived_of(tl_iface,
-                                                               uct_cuda_ipc_iface_t);
     uct_cuda_ipc_event_desc_t *cuda_ipc_event = ucs_derived_of(cuda_event,
                                                                uct_cuda_ipc_event_desc_t);
 
@@ -338,7 +331,7 @@ static void uct_cuda_ipc_complete_event(uct_iface_h tl_iface,
                                  cuda_ipc_event->d_bptr,
                                  cuda_ipc_event->mapped_addr,
                                  cuda_ipc_event->cuda_device,
-                                 iface->config.enable_cache);
+                                 uct_cuda_ipc_component.enable_remote_cache);
 }
 
 static uct_iface_ops_t uct_cuda_ipc_iface_ops = {

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.h
@@ -23,7 +23,6 @@ typedef struct {
     unsigned                max_poll;            /* query attempts w.o success */
     unsigned                max_streams;         /* # concurrent streams for || progress*/
     unsigned                max_cuda_ipc_events; /* max mpool entries */
-    int                     enable_cache;        /* enable/disable ipc handle cache */
     ucs_on_off_auto_value_t enable_get_zcopy;    /* enable get_zcopy except for specific platforms */
     double                  bandwidth;           /* estimated bandwidth */
     double                  latency;             /* estimated latency */
@@ -45,7 +44,7 @@ typedef struct {
 
 typedef struct {
     uct_cuda_event_desc_t super;
-    void                  *mapped_addr;
+    const void            *mapped_addr;
     uct_cuda_ipc_ep_t     *ep;
     uintptr_t             d_bptr;
     pid_t                 pid;

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -38,6 +38,14 @@ typedef struct {
     CUdevice   cu_dev;
 } uct_cuda_ipc_rkey_handle_t;
 
+typedef struct {
+    pid_t        pid;
+    ucs_sys_ns_t pid_ns;
+    uintptr_t    d_bptr;
+    void         *mapped_addr;
+    CUdevice     cu_dev;
+} uct_cuda_ipc_mem_elem_release_handle_t;
+
 static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
     {"", "", NULL,
      ucs_offsetof(uct_cuda_ipc_md_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
@@ -692,11 +700,13 @@ static void uct_cuda_ipc_md_close(uct_md_h md)
 
 static ucs_status_t
 uct_cuda_ipc_md_mem_elem_pack(uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
-                              uct_device_mem_elem_t *mem_elem_p)
+                              uct_device_mem_elem_t *mem_elem,
+                              void **release_handle_p)
 {
     uct_cuda_ipc_unpacked_rkey_t *key = (uct_cuda_ipc_unpacked_rkey_t*)rkey;
     uct_cuda_ipc_md_device_mem_element_t *cuda_ipc_md_mem_element =
-            (uct_cuda_ipc_md_device_mem_element_t*)mem_elem_p;
+            (uct_cuda_ipc_md_device_mem_element_t*)mem_elem;
+    uct_cuda_ipc_mem_elem_release_handle_t *release_handle;
     ucs_status_t status;
     CUdevice cuda_device;
     void *mapped_addr;
@@ -705,16 +715,40 @@ uct_cuda_ipc_md_mem_elem_pack(uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
         return UCS_ERR_UNREACHABLE;
     }
 
+    release_handle = ucs_malloc(sizeof(*release_handle),
+                                "uct_cuda_ipc_mem_elem_release_handle");
+    if (release_handle == NULL) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
     status = uct_cuda_ipc_map_memhandle(&key->super, cuda_device, &mapped_addr,
                                         UCS_LOG_LEVEL_ERROR);
     if (ucs_unlikely(status != UCS_OK)) {
+        ucs_free(release_handle);
         return status;
     }
 
     cuda_ipc_md_mem_element->mapped_offset =
             UCS_PTR_BYTE_DIFF(key->super.super.d_bptr, mapped_addr);
 
+    release_handle->pid         = key->super.super.pid;
+    release_handle->pid_ns      = key->super.pid_ns;
+    release_handle->d_bptr      = key->super.super.d_bptr;
+    release_handle->mapped_addr = mapped_addr;
+    release_handle->cu_dev      = cuda_device;
+    *release_handle_p           = release_handle;
+
     return UCS_OK;
+}
+
+static void uct_cuda_ipc_md_mem_elem_release(uct_md_h md, void *release_handle)
+{
+    uct_cuda_ipc_mem_elem_release_handle_t *handle = release_handle;
+
+    uct_cuda_ipc_unmap_memhandle(handle->pid, handle->pid_ns, handle->d_bptr,
+                                 handle->mapped_addr, handle->cu_dev,
+                                 uct_cuda_ipc_component.enable_remote_cache);
+    ucs_free(handle);
 }
 
 static ucs_status_t
@@ -732,6 +766,7 @@ uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
         .mem_query          = (uct_md_mem_query_func_t)ucs_empty_function_return_unsupported,
         .mkey_pack          = uct_cuda_ipc_mkey_pack,
         .mem_elem_pack      = uct_cuda_ipc_md_mem_elem_pack,
+        .mem_elem_release   = uct_cuda_ipc_md_mem_elem_release,
         .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
     };

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -33,6 +33,11 @@
  * purposes. */
 #define UCT_CUDA_IPC_RKEY_FLAG_PID_NS UCS_BIT(31)
 
+typedef struct {
+    const void *mapped_addr;
+    CUdevice   cu_dev;
+} uct_cuda_ipc_rkey_handle_t;
+
 static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
     {"", "", NULL,
      ucs_offsetof(uct_cuda_ipc_md_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
@@ -54,6 +59,10 @@ static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
      "to each one. Regions are evicted in LRU order when this limit is exceeded.",
      ucs_offsetof(uct_cuda_ipc_md_config_t, cache_max_size),
      UCS_CONFIG_TYPE_MEMUNITS},
+
+    {"CACHE", "y", "Enable remote IPC memory handle mapping cache",
+     ucs_offsetof(uct_cuda_ipc_md_config_t, enable_remote_cache),
+     UCS_CONFIG_TYPE_BOOL},
 
     {NULL}
 };
@@ -390,15 +399,33 @@ found:
                                                     memh->dev_num));
 }
 
+static uct_cuda_ipc_rkey_handle_t *uct_cuda_ipc_create_rkey_handle()
+{
+    uct_cuda_ipc_rkey_handle_t *rkey_handle;
+
+    rkey_handle = ucs_malloc(sizeof(*rkey_handle), "uct_cuda_ipc_rkey_handle");
+    if (rkey_handle == NULL) {
+        ucs_error("failed to allocate memory for uct_cuda_ipc_rkey_handle");
+        return NULL;
+    }
+
+    rkey_handle->mapped_addr = NULL;
+    rkey_handle->cu_dev      = CU_DEVICE_INVALID;
+    return rkey_handle;
+}
+
 static ucs_status_t
 uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *component,
                                 uct_cuda_ipc_unpacked_rkey_t *rkey,
+                                uct_cuda_ipc_rkey_handle_t *rkey_handle,
                                 CUdevice cu_dev)
 {
     ucs_status_t status;
     void *d_mapped;
     uct_cuda_ipc_dev_cache_t *cache;
     uint8_t *accessible;
+
+    rkey_handle->cu_dev = cu_dev;
 
     pthread_mutex_lock(&component->lock);
 
@@ -433,6 +460,9 @@ uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *component,
          * accessible using rkey->pid. */
         status = uct_cuda_ipc_map_memhandle(&rkey->super, cu_dev, &d_mapped,
                                             UCS_LOG_LEVEL_DEBUG);
+        if (status == UCS_OK) {
+            rkey_handle->mapped_addr = d_mapped;
+        }
 
         *accessible = ((status == UCS_OK) || (status == UCS_ERR_ALREADY_EXISTS))
                       ? UCS_YES : UCS_NO;
@@ -455,6 +485,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_rkey_unpack,
                                                        uct_cuda_ipc_component_t);
     const uct_cuda_ipc_rkey_t *packed = rkey_buffer;
     uct_cuda_ipc_unpacked_rkey_t *unpacked;
+    uct_cuda_ipc_rkey_handle_t *rkey_handle;
     ucs_sys_device_t sys_dev;
     CUdevice cuda_device;
     CUdevice avail_cuda_device;
@@ -474,6 +505,12 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_rkey_unpack,
     unpacked->super.super      = *packed;
     unpacked->super.super.pid &= ~UCT_CUDA_IPC_RKEY_FLAG_PID_NS;
 
+    rkey_handle = uct_cuda_ipc_create_rkey_handle();
+    if (rkey_handle == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        goto err_free_key;
+    }
+
     /* Check if PID NS exists before using it (for wire compatibility) */
     if (packed->pid & UCT_CUDA_IPC_RKEY_FLAG_PID_NS) {
         ext_rkey               = (uct_cuda_ipc_extended_rkey_t*)packed;
@@ -487,31 +524,59 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_rkey_unpack,
                                              UCS_LOG_LEVEL_DEBUG);
     if (status != UCS_OK) {
         status = UCS_ERR_UNREACHABLE;
-        goto err_free_key;
+        goto err_free_rkey_handle;
     }
 
-    status = uct_cuda_ipc_is_peer_accessible(com, unpacked, avail_cuda_device);
+    /* Check if peer is accessible, and if that check required mapping a memory
+     * handle, save it in the rkey handle */
+    status = uct_cuda_ipc_is_peer_accessible(com, unpacked, rkey_handle,
+                                             avail_cuda_device);
     if (cuda_device != avail_cuda_device) {
         uct_cuda_ctx_primary_pop_and_release(avail_cuda_device);
     }
     if (status != UCS_OK) {
-        goto err_free_key;
+        goto err_free_rkey_handle;
     }
 
-    *handle_p = NULL;
+    *handle_p = rkey_handle;
     *rkey_p   = (uintptr_t) unpacked;
     return UCS_OK;
 
+err_free_rkey_handle:
+    ucs_free(rkey_handle);
 err_free_key:
     ucs_free(unpacked);
 err:
     return status;
 }
 
+static void uct_cuda_ipc_rkey_release_unmap_memhandle(uct_rkey_t uct_rkey,
+                                                      const void *handle)
+{
+    const uct_cuda_ipc_rkey_handle_t *rkey_handle = handle;
+    uct_cuda_ipc_unpacked_rkey_t *unpacked_rkey;
+    uct_cuda_ipc_extended_rkey_t *extended_rkey;
+    uct_cuda_ipc_rkey_t *rkey;
+
+    if ((uct_rkey == 0) || (rkey_handle == NULL) ||
+        (rkey_handle->mapped_addr == NULL)) {
+        return;
+    }
+
+    unpacked_rkey = (uct_cuda_ipc_unpacked_rkey_t*)uct_rkey;
+    extended_rkey = &unpacked_rkey->super;
+    rkey          = &extended_rkey->super;
+
+    uct_cuda_ipc_unmap_memhandle(rkey->pid, extended_rkey->pid_ns, rkey->d_bptr,
+                                 rkey_handle->mapped_addr, rkey_handle->cu_dev,
+                                 uct_cuda_ipc_component.enable_remote_cache);
+}
+
 static ucs_status_t uct_cuda_ipc_rkey_release(uct_component_t *component,
                                               uct_rkey_t rkey, void *handle)
 {
-    ucs_assert(NULL == handle);
+    uct_cuda_ipc_rkey_release_unmap_memhandle(rkey, handle);
+    ucs_free(handle);
     ucs_free((void *)rkey);
     return UCS_OK;
 }
@@ -672,7 +737,20 @@ uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
     };
     uct_cuda_ipc_md_config_t *ipc_config = ucs_derived_of(config,
                                                           uct_cuda_ipc_md_config_t);
+    static ucs_init_once_t init_enable_remote_cache = UCS_INIT_ONCE_INITIALIZER;
     uct_cuda_ipc_md_t* md;
+
+    UCS_INIT_ONCE(&init_enable_remote_cache) {
+        uct_cuda_ipc_component.enable_remote_cache =
+                ipc_config->enable_remote_cache;
+    }
+
+    if (uct_cuda_ipc_component.enable_remote_cache !=
+        ipc_config->enable_remote_cache) {
+        ucs_error("inconsistent CUDA IPC remote memory handle mapping cache "
+                  "enable parameter");
+        return UCS_ERR_INVALID_PARAM;
+    }
 
     md = ucs_calloc(1, sizeof(*md), "uct_cuda_ipc_md");
     if (md == NULL) {
@@ -695,16 +773,19 @@ uct_cuda_ipc_md_open(uct_component_t *component, const char *md_name,
 ucs_status_t uct_cuda_ipc_rkey_ptr(uct_component_t *component, uct_rkey_t rkey,
                                    void *handle, uint64_t raddr, void **laddr_p)
 {
-    CUdevice cu_dev;
-    ucs_status_t status;
+    uct_cuda_ipc_rkey_handle_t *rkey_handle     = handle;
+    uct_cuda_ipc_extended_rkey_t *extended_rkey =
+            (uct_cuda_ipc_extended_rkey_t*)rkey;
 
-    status = UCT_CUDADRV_FUNC_LOG_ERR(cuCtxGetDevice(&cu_dev));
-    if (ucs_unlikely(status != UCS_OK)) {
-        return status;
+    if (rkey_handle->mapped_addr != NULL) {
+        *laddr_p = uct_cuda_ipc_rkey_get_local_address(
+                &extended_rkey->super, raddr, rkey_handle->mapped_addr);
+        return UCS_OK;
     }
 
-    return uct_cuda_ipc_get_remote_address((uct_cuda_ipc_extended_rkey_t*)rkey,
-                                           raddr, cu_dev, laddr_p, NULL);
+    return uct_cuda_ipc_get_remote_address(extended_rkey, raddr,
+                                           rkey_handle->cu_dev, laddr_p,
+                                           &rkey_handle->mapped_addr);
 }
 
 uct_cuda_ipc_component_t uct_cuda_ipc_component = {
@@ -730,7 +811,8 @@ uct_cuda_ipc_component_t uct_cuda_ipc_component = {
                 (uct_component_md_vfs_init_func_t)ucs_empty_function
     },
     .uuid_hash              = KHASH_STATIC_INITIALIZER,
-    .lock                   = PTHREAD_MUTEX_INITIALIZER
+    .lock                   = PTHREAD_MUTEX_INITIALIZER,
+    .enable_remote_cache    = 0
 };
 UCT_COMPONENT_REGISTER(&uct_cuda_ipc_component.super);
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2018. ALL RIGHTS RESERVED.
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2018-2026. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -99,6 +99,8 @@ typedef struct {
     uct_component_t             super;
     khash_t(cuda_ipc_uuid_hash) uuid_hash;
     pthread_mutex_t             lock;
+    /** Enable remote IPC memory handle mapping cache */
+    int                         enable_remote_cache;
 } uct_cuda_ipc_component_t;
 
 extern uct_cuda_ipc_component_t uct_cuda_ipc_component;
@@ -111,6 +113,8 @@ typedef struct uct_cuda_ipc_md_config {
     ucs_ternary_auto_value_t enable_mnnvl;
     unsigned long            cache_max_regions; /**< Max cached IPC regions per peer */
     size_t                   cache_max_size;    /**< Max total cached IPC mapping size */
+    /** Enable remote IPC memory handle mapping cache */
+    int                      enable_remote_cache;
 } uct_cuda_ipc_md_config_t;
 
 

--- a/src/uct/cuda/gdr_copy/gdr_copy_md.c
+++ b/src/uct/cuda/gdr_copy/gdr_copy_md.c
@@ -399,6 +399,7 @@ static uct_md_ops_t uct_gdr_copy_md_ops = {
     .mkey_pack          = uct_gdr_copy_mkey_pack,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function,
     .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported
 };
 
@@ -467,7 +468,8 @@ static uct_md_ops_t uct_gdr_copy_md_rcache_ops = {
     .mkey_pack          = uct_gdr_copy_mkey_pack,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
 };
 
 static ucs_status_t

--- a/src/uct/gaudi/gaudi_gdr/gaudi_gdr_md.c
+++ b/src/uct/gaudi/gaudi_gdr/gaudi_gdr_md.c
@@ -145,7 +145,9 @@ static uct_md_ops_t md_ops = {
     .mkey_pack = (uct_md_mkey_pack_func_t)ucs_empty_function_return_unsupported,
     .mem_attach         = (uct_md_mem_attach_func_t)
             ucs_empty_function_return_unsupported,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)
+            ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function,
     .detect_memory_type = uct_gaudi_md_detect_memory_type,
 };
 

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1645,7 +1645,8 @@ static uct_ib_md_ops_t uct_ib_verbs_md_ops = {
         .mkey_pack          = uct_ib_verbs_mkey_pack,
         .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+        .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
     },
     .open = uct_ib_verbs_md_open,
 };

--- a/src/uct/ib/efa/base/ib_efa_md.c
+++ b/src/uct/ib/efa/base/ib_efa_md.c
@@ -109,7 +109,8 @@ static uct_ib_md_ops_t uct_ib_efa_md_ops = {
         .mkey_pack          = uct_ib_verbs_mkey_pack,
         .mem_attach         =(uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+        .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
     },
     .open = uct_ib_efa_md_open,
 };

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -3174,7 +3174,8 @@ uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
 static ucs_status_t
 uct_ib_md_mlx5_devx_md_mem_elem_pack(uct_md_h md, uct_mem_h memh,
                                      uct_rkey_t rkey,
-                                     uct_device_mem_elem_t *mem_elem_p)
+                                     uct_device_mem_elem_t *mem_elem_p,
+                                     void **pack_resources_p)
 {
     uct_ib_md_device_mem_element_t *mem_elem = (uct_ib_md_device_mem_element_t*)
             mem_elem_p;
@@ -3207,7 +3208,8 @@ static uct_ib_md_ops_t uct_ib_mlx5_devx_md_ops = {
         .mkey_pack          = uct_ib_mlx5_devx_mkey_pack,
         .mem_attach         = uct_ib_mlx5_devx_mem_attach,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-        .mem_elem_pack      = uct_ib_md_mlx5_devx_md_mem_elem_pack
+        .mem_elem_pack      = uct_ib_md_mlx5_devx_md_mem_elem_pack,
+        .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
     },
     .open = uct_ib_mlx5_devx_md_open,
 };
@@ -3433,7 +3435,8 @@ static uct_ib_md_ops_t uct_ib_mlx5_md_ops = {
         .mkey_pack          = uct_ib_verbs_mkey_pack,
         .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+        .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
     },
     .open = uct_ib_mlx5dv_md_open,
 };

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -891,7 +891,8 @@ static uct_md_ops_t uct_mlx5_gga_md_ops = {
     .mkey_pack          = uct_ib_mlx5_gga_mkey_pack,
     .mem_attach         = uct_ib_mlx5_gga_mem_attach,
     .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
 };
 
 static ucs_status_t

--- a/src/uct/rocm/copy/rocm_copy_md.c
+++ b/src/uct/rocm/copy/rocm_copy_md.c
@@ -294,7 +294,8 @@ static uct_md_ops_t md_ops = {
     .mkey_pack          = uct_rocm_copy_mkey_pack,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .detect_memory_type = uct_rocm_base_detect_memory_type,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
 };
 
 static inline uct_rocm_copy_rcache_region_t*
@@ -354,7 +355,8 @@ static uct_md_ops_t md_rcache_ops = {
     .mkey_pack          = uct_rocm_copy_mkey_pack,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .detect_memory_type = uct_rocm_base_detect_memory_type,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
 };
 
 static ucs_status_t

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -133,7 +133,8 @@ uct_rocm_ipc_md_open(uct_component_h component, const char *md_name,
         .mkey_pack          = uct_rocm_ipc_mkey_pack,
         .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+        .mem_elem_release = (uct_md_mem_elem_release_func_t)ucs_empty_function
     };
     static uct_md_t md = {
         .ops       = &md_ops,

--- a/src/uct/sm/scopy/cma/cma_md.c
+++ b/src/uct/sm/scopy/cma/cma_md.c
@@ -173,7 +173,8 @@ uct_cma_md_open(uct_component_t *component, const char *md_name,
         .mkey_pack          = (uct_md_mkey_pack_func_t)ucs_empty_function_return_unsupported,
         .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+        .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
     };
     uct_cma_md_t *cma_md;
 

--- a/src/uct/sm/scopy/knem/knem_md.c
+++ b/src/uct/sm/scopy/knem/knem_md.c
@@ -257,7 +257,8 @@ static uct_md_ops_t md_ops = {
     .mkey_pack          = uct_knem_mkey_pack,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
 };
 
 static ucs_status_t

--- a/src/uct/sm/self/self.c
+++ b/src/uct/sm/self/self.c
@@ -451,7 +451,8 @@ static ucs_status_t uct_self_md_open(uct_component_t *component, const char *md_
         .mkey_pack          = (uct_md_mkey_pack_func_t)ucs_empty_function_return_success,
         .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
         .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+        .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+        .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
     };
 
     static uct_self_md_t md;

--- a/src/uct/tcp/tcp_md.c
+++ b/src/uct/tcp/tcp_md.c
@@ -52,7 +52,8 @@ static uct_md_ops_t uct_tcp_md_ops = {
     .mkey_pack          = (uct_md_mkey_pack_func_t)ucs_empty_function_return_unsupported,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .detect_memory_type = (uct_md_detect_memory_type_func_t)ucs_empty_function_return_unsupported,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
 };
 
 static ucs_status_t

--- a/src/uct/ze/copy/ze_copy_md.c
+++ b/src/uct/ze/copy/ze_copy_md.c
@@ -280,7 +280,8 @@ static uct_md_ops_t md_ops = {
     .mkey_pack          = (uct_md_mkey_pack_func_t)ucs_empty_function_return_success,
     .mem_attach         = (uct_md_mem_attach_func_t)ucs_empty_function_return_unsupported,
     .detect_memory_type = uct_ze_copy_md_detect_memory_type,
-    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported
+    .mem_elem_pack      = (uct_md_mem_elem_pack_func_t)ucs_empty_function_return_unsupported,
+    .mem_elem_release   = (uct_md_mem_elem_release_func_t)ucs_empty_function
 };
 
 static ucs_status_t

--- a/test/gtest/uct/cuda/test_cuda_ipc_device.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_device.cc
@@ -190,8 +190,11 @@ UCS_TEST_P(test_cuda_ipc_rma, get_mem_elem_pack)
     mapped_buffer recvbuf(length, SEED2, *m_receiver, 0, UCS_MEMORY_TYPE_CUDA);
 
     uct_device_mem_elem_t mem_elem_host;
+    void *release_handle;
     EXPECT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
-                                       recvbuf.rkey(), &mem_elem_host));
+                                       recvbuf.rkey(), &mem_elem_host,
+                                       &release_handle));
+    uct_md_mem_elem_release(m_sender->md(), release_handle);
 }
 
 UCS_TEST_P(test_cuda_ipc_rma, get_device_ep)
@@ -222,8 +225,10 @@ UCS_TEST_P(test_cuda_ipc_rma_device, put_device)
     mapped_buffer recvbuf(length, SEED2, *m_receiver, 0, UCS_MEMORY_TYPE_CUDA);
 
     uct_device_mem_elem_t src_elem_host;
+    void *release_handle;
     ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
-                                       recvbuf.rkey(), &src_elem_host));
+                                       recvbuf.rkey(), &src_elem_host,
+                                       &release_handle));
 
 
     uct_device_mem_elem_t *src_elem;
@@ -248,6 +253,7 @@ UCS_TEST_P(test_cuda_ipc_rma_device, put_device)
     recvbuf.pattern_check(SEED1);
     cuMemFree((CUdeviceptr)src_elem);
     cuMemFree((CUdeviceptr)mem_elem);
+    uct_md_mem_elem_release(m_sender->md(), release_handle);
 }
 
 UCS_TEST_P(test_cuda_ipc_rma_device, atomic_add_device)
@@ -272,9 +278,10 @@ UCS_TEST_P(test_cuda_ipc_rma_device, atomic_add_device)
     ASSERT_UCS_OK(uct_ep_get_device_ep(m_sender->ep(0), &device_ep));
 
     uct_device_mem_elem_t mem_elem_host;
+    void *release_handle;
     ASSERT_EQ(CUDA_SUCCESS, cuMemAlloc((CUdeviceptr*)&mem_elem, mem_elem_size));
     ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), nullptr, signal.rkey(),
-                                       &mem_elem_host));
+                                       &mem_elem_host, &release_handle));
     ASSERT_EQ(CUDA_SUCCESS, cuMemcpyHtoD((CUdeviceptr)mem_elem, &mem_elem_host,
                                          mem_elem_size));
 
@@ -286,6 +293,7 @@ UCS_TEST_P(test_cuda_ipc_rma_device, atomic_add_device)
                                   UCS_MEMORY_TYPE_CUDA),
               1);
     cuMemFree((CUdeviceptr)mem_elem);
+    uct_md_mem_elem_release(m_sender->md(), release_handle);
 }
 
 _UCT_INSTANTIATE_TEST_CASE(test_cuda_ipc_rma_device, cuda_ipc)

--- a/test/gtest/uct/test_device.cc
+++ b/test/gtest/uct/test_device.cc
@@ -155,8 +155,10 @@ UCS_TEST_P(test_device, put)
     mapped_buffer recvbuf(length, SEED2, *m_receiver, 0, UCS_MEMORY_TYPE_CUDA);
 
     uct_device_mem_elem_t src_elem_host;
+    void *release_handle;
     ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
-                                       recvbuf.rkey(), &src_elem_host));
+                                       recvbuf.rkey(), &src_elem_host,
+                                       &release_handle));
 
     mapped_buffer src_elembuf(sizeof(src_elem_host), 0, *m_sender, 0,
                               UCS_MEMORY_TYPE_CUDA);
@@ -179,6 +181,7 @@ UCS_TEST_P(test_device, put)
 
     recvbuf.pattern_check(SEED1);
     recvbuf.pattern_fill(SEED2);
+    uct_md_mem_elem_release(m_sender->md(), release_handle);
 }
 
 UCS_TEST_P(test_device, atomic)
@@ -199,8 +202,9 @@ UCS_TEST_P(test_device, atomic)
     uct_device_mem_elem_t *mem_elem_host = (uct_device_mem_elem_t*)
                                                    elembuf_host.ptr();
     uct_device_mem_elem_t *mem_elem = (uct_device_mem_elem_t*)elembuf.ptr();
+    void *release_handle;
     ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), nullptr, signal.rkey(),
-                                       mem_elem_host));
+                                       mem_elem_host, &release_handle));
     ASSERT_EQ(CUDA_SUCCESS, cuMemcpyHtoD((CUdeviceptr)mem_elem, mem_elem_host,
                                          sizeof(uct_device_mem_elem_t)));
 
@@ -215,6 +219,7 @@ UCS_TEST_P(test_device, atomic)
                                     sizeof(signal_val), UCS_MEMORY_TYPE_CUDA))
             ;
     }
+    uct_md_mem_elem_release(m_sender->md(), release_handle);
 }
 
 _UCT_INSTANTIATE_TEST_CASE(test_device, rc_gda)

--- a/test/mpi/Makefile.am
+++ b/test/mpi/Makefile.am
@@ -22,9 +22,11 @@ noinst_LTLIBRARIES    = libtest_memhooks.la
 
 if HAVE_CUDA
 noinst_PROGRAMS      += test_mpi_cuda \
-                        test_rma_cuda
+                        test_rma_cuda \
+                        test_ucp_rkey_destroy
 
-noinst_LTLIBRARIES   += libtest_cuda_common.la
+noinst_LTLIBRARIES   += libtest_cuda_common.la \
+                        libtest_ucp.la
 endif
 endif
 
@@ -50,6 +52,12 @@ libtest_cuda_common_la_CFLAGS   = $(BASE_CFLAGS)
 libtest_cuda_common_la_LDFLAGS  = $(CUDA_LDFLAGS)
 libtest_cuda_common_la_LIBADD   = $(CUDA_LIBS) $(top_builddir)/src/ucs/libucs.la
 
+libtest_ucp_la_SOURCES  = test_ucp.c
+libtest_ucp_la_CPPFLAGS = $(BASE_CPPFLAGS)
+libtest_ucp_la_CFLAGS   = $(BASE_CFLAGS)
+libtest_ucp_la_LIBADD   = $(top_builddir)/src/ucs/libucs.la \
+                          $(top_builddir)/src/ucp/libucp.la
+
 test_mpi_cuda_SOURCES  = test_mpi_cuda.c
 test_mpi_cuda_CPPFLAGS = $(BASE_CPPFLAGS) $(CUDA_CPPFLAGS)
 test_mpi_cuda_CFLAGS   = $(BASE_CFLAGS)
@@ -63,7 +71,16 @@ test_rma_cuda_CFLAGS   = $(BASE_CFLAGS)
 test_rma_cuda_LDFLAGS  = $(CUDA_LDFLAGS)
 test_rma_cuda_LDADD    = $(CUDA_LIBS) $(top_builddir)/src/ucs/libucs.la \
                          $(top_builddir)/src/ucp/libucp.la \
-                         libtest_cuda_common.la
+                         libtest_cuda_common.la  \
+                         libtest_ucp.la
+
+test_ucp_rkey_destroy_SOURCES  = test_ucp_rkey_destroy.c
+test_ucp_rkey_destroy_CPPFLAGS = $(BASE_CPPFLAGS) $(CUDA_CPPFLAGS)
+test_ucp_rkey_destroy_CFLAGS   = $(BASE_CFLAGS)
+test_ucp_rkey_destroy_LDFLAGS  = $(CUDA_LDFLAGS)
+test_ucp_rkey_destroy_LDADD    = $(CUDA_LIBS) $(top_builddir)/src/ucs/libucs.la \
+                                 $(top_builddir)/src/ucp/libucp.la  \
+                                 libtest_ucp.la
 endif
 
 libtest_memhooks_la_SOURCES = test_memhooks_lib.c

--- a/test/mpi/test_cuda_check_def.h
+++ b/test/mpi/test_cuda_check_def.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef TEST_CUDA_CHECK_DEF_H
+#define TEST_CUDA_CHECK_DEF_H
+
+#include "test_lib_check_def.h"
+
+#include <cuda.h>
+
+#define _CUDA_ERROR_STRING(_err) \
+    ({ \
+        const char *_err_str; \
+        cuGetErrorString(_err, &_err_str); \
+        _err_str; \
+    })
+
+#define CUDA_CHECK(_func) \
+    LIB_CHECK(CUresult, _func, CUDA_SUCCESS, _CUDA_ERROR_STRING)
+
+#endif

--- a/test/mpi/test_cuda_common.c
+++ b/test/mpi/test_cuda_common.c
@@ -8,6 +8,7 @@
 #include "config.h"
 #endif
 
+#include "test_cuda_check_def.h"
 #include "test_cuda_common.h"
 
 #include <ucs/debug/log_def.h>
@@ -25,16 +26,6 @@
 
 #define TEST_NAME_FMT      "TEST[%zi:%-17s:%-17s:*       ]"
 #define TEST_NAME_SIZE_FMT "TEST[%zi:%-17s:%-17s:%-8zi]"
-
-#define _CUDA_ERROR_STRING(_err) \
-    ({ \
-        const char *_err_str; \
-        cuGetErrorString(_err, &_err_str); \
-        _err_str; \
-    })
-
-#define CUDA_CHECK(_func) \
-    LIB_CHECK(CUresult, _func, CUDA_SUCCESS, _CUDA_ERROR_STRING)
 
 typedef struct {
     CUcontext primary;

--- a/test/mpi/test_cuda_common.h
+++ b/test/mpi/test_cuda_common.h
@@ -22,17 +22,6 @@
     } while (0)
 
 
-#define LIB_CHECK(_err_t, _func, _success_code, _lib_error_string) \
-    do { \
-        _err_t _err = (_func); \
-        if (_err != _success_code) { \
-            fprintf(stderr, "%s failed: %d (%s)\n", UCS_PP_MAKE_STRING(_func), \
-                    _err, _lib_error_string(_err)); \
-            exit(_err); \
-        } \
-    } while (0)
-
-
 typedef struct init_params *init_params_h;
 
 

--- a/test/mpi/test_lib_check_def.h
+++ b/test/mpi/test_lib_check_def.h
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef TEST_LIB_CHECK_DEF_H
+#define TEST_LIB_CHECK_DEF_H
+
+#include "ucs/sys/preprocessor.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define LIB_CHECK(_err_t, _func, _success_code, _lib_error_string) \
+    do { \
+        _err_t _err = (_func); \
+        if (_err != _success_code) { \
+            fprintf(stderr, "%s failed: %d (%s)\n", UCS_PP_MAKE_STRING(_func), \
+                    _err, _lib_error_string(_err)); \
+            exit(_err); \
+        } \
+    } while (0)
+
+#endif

--- a/test/mpi/test_mpi_tags_def.h
+++ b/test/mpi/test_mpi_tags_def.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef TEST_MPI_TAGS_DEF_H
+#define TEST_MPI_TAGS_DEF_H
+
+#define MPI_TAG_WORKER_ADDRESS_LENGTH 777
+#define MPI_TAG_WORKER_ADDRESS        778
+#define MPI_TAG_ADDRESS               779
+#define MPI_TAG_PACKED_RKEY_SIZE      780
+#define MPI_TAG_PACKED_RKEY           781
+#define MPI_TAG_ACK                   782
+
+#endif

--- a/test/mpi/test_rma_cuda.c
+++ b/test/mpi/test_rma_cuda.c
@@ -9,22 +9,15 @@
 #endif
 
 #include "test_cuda_common.h"
+#include "test_mpi_tags_def.h"
+#include "test_ucp.h"
+#include "test_ucx_check_def.h"
 
 #include <ucp/api/ucp.h>
 #include <ucs/sys/string.h>
 
 #include <stdio.h>
 #include <mpi.h>
-
-#define MPI_TAG_WORKER_ADDRESS_LENGTH 777
-#define MPI_TAG_WORKER_ADDRESS        778
-#define MPI_TAG_ADDRESS               779
-#define MPI_TAG_PACKED_RKEY_SIZE      780
-#define MPI_TAG_PACKED_RKEY           781
-#define MPI_TAG_ACK                   782
-
-#define UCX_CHECK(_func) \
-    LIB_CHECK(ucs_status_t, _func, UCS_OK, ucs_status_string)
 
 typedef enum {
     OP_TYPE_GET,
@@ -38,97 +31,10 @@ typedef struct {
 
 typedef struct {
     const operation_t *operation;
-    ucp_context_h     ucp_context;
-    ucp_worker_h      ucp_worker;
-    ucp_ep_h          ucp_ep;
+    ucp_t             ucp;
 } xfer_args_t;
 
 const operation_t operations[] = {{"get", OP_TYPE_GET}, {"put", OP_TYPE_PUT}};
-
-static ucp_context_h create_ucp_context()
-{
-    ucp_params_t ucp_params;
-    ucp_config_t *ucp_config;
-    ucp_context_h ucp_context;
-
-    ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_NAME;
-    ucp_params.features   = UCP_FEATURE_RMA | UCP_FEATURE_WAKEUP;
-    ucp_params.name       = "test_rma_cuda_ctx";
-    UCX_CHECK(ucp_config_read(NULL, NULL, &ucp_config));
-    UCX_CHECK(ucp_init(&ucp_params, ucp_config, &ucp_context));
-    return ucp_context;
-}
-
-static ucp_worker_h create_ucp_worker(ucp_context_h ucp_context)
-{
-    ucp_worker_params_t ucp_worker_params;
-    ucp_worker_h ucp_worker;
-
-    ucp_worker_params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE |
-                                    UCP_WORKER_PARAM_FIELD_NAME;
-    ucp_worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
-    ucp_worker_params.name        = "test_rma_cuda_worker";
-    UCX_CHECK(ucp_worker_create(ucp_context, &ucp_worker_params, &ucp_worker));
-    return ucp_worker;
-}
-
-static void send_worker_address(int receiver_rank, ucp_worker_h ucp_worker)
-{
-    ucp_worker_attr_t ucp_worker_attr;
-
-    ucp_worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_ADDRESS;
-    UCX_CHECK(ucp_worker_query(ucp_worker, &ucp_worker_attr));
-
-    MPI_Send(&ucp_worker_attr.address_length,
-             sizeof(ucp_worker_attr.address_length), MPI_BYTE, receiver_rank,
-             MPI_TAG_WORKER_ADDRESS_LENGTH, MPI_COMM_WORLD);
-
-    MPI_Send(ucp_worker_attr.address, ucp_worker_attr.address_length, MPI_BYTE,
-             receiver_rank, MPI_TAG_WORKER_ADDRESS, MPI_COMM_WORLD);
-
-    ucp_worker_release_address(ucp_worker, ucp_worker_attr.address);
-}
-
-static void *recv_worker_address(int sender_rank)
-{
-    size_t ucp_worker_address_length;
-    void *ucp_worker_address;
-
-    MPI_Recv(&ucp_worker_address_length, sizeof(ucp_worker_address_length),
-             MPI_BYTE, sender_rank, MPI_TAG_WORKER_ADDRESS_LENGTH,
-             MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-
-    ucp_worker_address = malloc(ucp_worker_address_length);
-    MPI_Recv(ucp_worker_address, ucp_worker_address_length, MPI_BYTE,
-             sender_rank, MPI_TAG_WORKER_ADDRESS, MPI_COMM_WORLD,
-             MPI_STATUS_IGNORE);
-
-    return ucp_worker_address;
-}
-
-static ucp_ep_h create_ucp_ep(ucp_worker_h ucp_worker)
-{
-    int rank;
-    void *ucp_worker_address;
-    ucp_ep_params_t ucp_ep_params;
-    ucp_ep_h ucp_ep;
-
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    if (rank == 0) {
-        send_worker_address(1, ucp_worker);
-        ucp_worker_address = recv_worker_address(1);
-    } else {
-        ucp_worker_address = recv_worker_address(0);
-        send_worker_address(0, ucp_worker);
-    }
-
-    ucp_ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
-    ucp_ep_params.address    = (ucp_address_t*)ucp_worker_address;
-
-    UCX_CHECK(ucp_ep_create(ucp_worker, &ucp_ep_params, &ucp_ep));
-    free(ucp_worker_address);
-    return ucp_ep;
-}
 
 static int is_initiator(int sender, op_type_t op_type)
 {
@@ -162,82 +68,36 @@ void initiate_rma(int peer_rank, op_type_t op_type, ucp_worker_h ucp_worker,
 {
     ucp_request_param_t ucp_request_param = {0};
     int ack                               = 0;
-    uint64_t remote_address;
-    size_t ucp_packed_rkey_size;
-    void *ucp_packed_rkey;
-    ucp_rkey_h ucp_rkey;
+    rkey_t rkey;
 
-    MPI_Recv(&remote_address, sizeof(remote_address), MPI_BYTE, peer_rank,
-             MPI_TAG_ADDRESS, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-
-    MPI_Recv(&ucp_packed_rkey_size, sizeof(ucp_packed_rkey_size), MPI_BYTE,
-             peer_rank, MPI_TAG_PACKED_RKEY_SIZE, MPI_COMM_WORLD,
-             MPI_STATUS_IGNORE);
-
-    ucp_packed_rkey = malloc(ucp_packed_rkey_size);
-    MPI_Recv(ucp_packed_rkey, ucp_packed_rkey_size, MPI_BYTE, peer_rank,
-             MPI_TAG_PACKED_RKEY, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-
-    UCX_CHECK(ucp_ep_rkey_unpack(ucp_ep, ucp_packed_rkey, &ucp_rkey));
-    free(ucp_packed_rkey);
+    rkey = recv_rkey(peer_rank, ucp_ep);
 
     if (op_type == OP_TYPE_GET) {
         request_wait(ucp_worker,
-                     ucp_get_nbx(ucp_ep, buffer, size, remote_address, ucp_rkey,
-                                 &ucp_request_param));
+                     ucp_get_nbx(ucp_ep, buffer, size, rkey.remote_address,
+                                 rkey.rkey, &ucp_request_param));
     } else {
         request_wait(ucp_worker,
-                     ucp_put_nbx(ucp_ep, buffer, size, remote_address, ucp_rkey,
-                                 &ucp_request_param));
+                     ucp_put_nbx(ucp_ep, buffer, size, rkey.remote_address,
+                                 rkey.rkey, &ucp_request_param));
 
         request_wait(ucp_worker, ucp_ep_flush_nbx(ucp_ep, &ucp_request_param));
     }
 
     MPI_Ssend(&ack, 1, MPI_INT, peer_rank, MPI_TAG_ACK, MPI_COMM_WORLD);
 
-    ucp_rkey_destroy(ucp_rkey);
-}
-
-static ucp_mem_h
-create_ucp_mem(void *buffer, size_t size, ucp_context_h ucp_context)
-{
-    ucp_mem_map_params_t ucp_mem_map_params;
-    ucp_mem_h ucp_mem;
-
-    ucp_mem_map_params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
-                                    UCP_MEM_MAP_PARAM_FIELD_LENGTH;
-    ucp_mem_map_params.address    = buffer;
-    ucp_mem_map_params.length     = size;
-    UCX_CHECK(ucp_mem_map(ucp_context, &ucp_mem_map_params, &ucp_mem));
-    return ucp_mem;
+    ucp_rkey_destroy(rkey.rkey);
 }
 
 void complete_rma(int peer_rank, op_type_t op_type, ucp_context_h ucp_context,
                   ucp_worker_h ucp_worker, void *buffer, size_t size)
 {
-    uint64_t local_address = (uint64_t)buffer;
-    ucp_memh_buffer_release_params_t ucp_memh_buffer_release_params = {};
-    int request_complete                                            = 0;
+    int request_complete = 0;
     ucp_mem_h ucp_mem;
-    void *ucp_packed_rkey;
-    size_t ucp_packed_rkey_size;
     int ack;
     MPI_Request request;
 
-    MPI_Send(&local_address, sizeof(local_address), MPI_BYTE, peer_rank,
-             MPI_TAG_ADDRESS, MPI_COMM_WORLD);
-
-    ucp_mem = create_ucp_mem(buffer, size, ucp_context);
-    UCX_CHECK(ucp_rkey_pack(ucp_context, ucp_mem, &ucp_packed_rkey,
-                            &ucp_packed_rkey_size));
-
-    MPI_Send(&ucp_packed_rkey_size, sizeof(ucp_packed_rkey_size), MPI_BYTE,
-             peer_rank, MPI_TAG_PACKED_RKEY_SIZE, MPI_COMM_WORLD);
-
-    MPI_Send(ucp_packed_rkey, ucp_packed_rkey_size, MPI_BYTE, peer_rank,
-             MPI_TAG_PACKED_RKEY, MPI_COMM_WORLD);
-
-    ucp_memh_buffer_release(ucp_packed_rkey, &ucp_memh_buffer_release_params);
+    ucp_mem = send_rkey(peer_rank, buffer, size, ucp_context);
 
     MPI_Irecv(&ack, 1, MPI_INT, peer_rank, MPI_TAG_ACK, MPI_COMM_WORLD,
               &request);
@@ -262,17 +122,17 @@ static const operation_t *get_operation(const xfer_params_t *params)
 
 static ucp_context_h get_ucp_context(const xfer_params_t *params)
 {
-    return get_xfer_args(params)->ucp_context;
+    return get_xfer_args(params)->ucp.context;
 }
 
 static ucp_worker_h get_ucp_worker(const xfer_params_t *params)
 {
-    return get_xfer_args(params)->ucp_worker;
+    return get_xfer_args(params)->ucp.worker;
 }
 
 static ucp_ep_h get_ucp_ep(const xfer_params_t *params)
 {
-    return get_xfer_args(params)->ucp_ep;
+    return get_xfer_args(params)->ucp.ep;
 }
 
 void ucp_rma(int sender, const xfer_params_t *params)
@@ -297,15 +157,6 @@ static void ucp_rma_pingpong(const xfer_params_t *params)
     ucp_rma(1, params);
 }
 
-static void destroy_ucp_ep(ucp_ep_h ucp_ep)
-{
-    ucp_request_param_t ucp_request_param;
-
-    ucp_request_param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
-    ucp_request_param.flags        = UCP_EP_CLOSE_FLAG_FORCE;
-    ucp_ep_close_nbx(ucp_ep, &ucp_request_param);
-}
-
 int main(int argc, char **argv)
 {
     init_params_h init_params;
@@ -316,9 +167,7 @@ int main(int argc, char **argv)
         return -1;
     }
 
-    xfer_args.ucp_context = create_ucp_context();
-    xfer_args.ucp_worker  = create_ucp_worker(xfer_args.ucp_context);
-    xfer_args.ucp_ep      = create_ucp_ep(xfer_args.ucp_worker);
+    xfer_args.ucp = create_ucp();
 
     for (operation_idx = 0; operation_idx < ucs_static_array_size(operations);
          ++operation_idx) {
@@ -327,9 +176,7 @@ int main(int argc, char **argv)
         test_cuda(init_params, ucp_rma_pingpong, &xfer_args);
     }
 
-    destroy_ucp_ep(xfer_args.ucp_ep);
-    ucp_worker_destroy(xfer_args.ucp_worker);
-    ucp_cleanup(xfer_args.ucp_context);
+    destroy_ucp(xfer_args.ucp);
     test_cuda_cleanup(init_params);
     return 0;
 }

--- a/test/mpi/test_ucp.c
+++ b/test/mpi/test_ucp.c
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "test_ucp.h"
+
+#include "test_mpi_tags_def.h"
+#include "test_ucx_check_def.h"
+
+#include <mpi.h>
+
+static ucp_context_h create_ucp_context()
+{
+    ucp_params_t params;
+    ucp_config_t *config;
+    ucp_context_h context;
+
+    params.field_mask = UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_NAME;
+    params.features   = UCP_FEATURE_RMA | UCP_FEATURE_WAKEUP;
+    params.name       = "test_context";
+    UCX_CHECK(ucp_config_read(NULL, NULL, &config));
+    UCX_CHECK(ucp_init(&params, config, &context));
+    ucp_config_release(config);
+    return context;
+}
+
+static ucp_worker_h create_ucp_worker(ucp_context_h context)
+{
+    ucp_worker_params_t worker_params;
+    ucp_worker_h worker;
+
+    worker_params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE |
+                                UCP_WORKER_PARAM_FIELD_NAME;
+    worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
+    worker_params.name        = "test_worker";
+    UCX_CHECK(ucp_worker_create(context, &worker_params, &worker));
+    return worker;
+}
+
+static void send_worker_address(int receiver_rank, ucp_worker_h worker)
+{
+    ucp_worker_attr_t worker_attr;
+
+    worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_ADDRESS;
+    UCX_CHECK(ucp_worker_query(worker, &worker_attr));
+
+    MPI_Send(&worker_attr.address_length, sizeof(worker_attr.address_length),
+             MPI_BYTE, receiver_rank, MPI_TAG_WORKER_ADDRESS_LENGTH,
+             MPI_COMM_WORLD);
+
+    MPI_Send(worker_attr.address, worker_attr.address_length, MPI_BYTE,
+             receiver_rank, MPI_TAG_WORKER_ADDRESS, MPI_COMM_WORLD);
+
+    ucp_worker_release_address(worker, worker_attr.address);
+}
+
+static void *recv_worker_address(int sender_rank)
+{
+    size_t worker_address_length;
+    void *worker_address;
+
+    MPI_Recv(&worker_address_length, sizeof(worker_address_length), MPI_BYTE,
+             sender_rank, MPI_TAG_WORKER_ADDRESS_LENGTH, MPI_COMM_WORLD,
+             MPI_STATUS_IGNORE);
+
+    worker_address = malloc(worker_address_length);
+    if (worker_address == NULL) {
+        fprintf(stderr, "malloc worker address failed\n");
+        exit(EXIT_FAILURE);
+    }
+
+    MPI_Recv(worker_address, worker_address_length, MPI_BYTE, sender_rank,
+             MPI_TAG_WORKER_ADDRESS, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+    return worker_address;
+}
+
+static ucp_ep_h create_ucp_ep(ucp_worker_h worker)
+{
+    int rank;
+    void *worker_address;
+    ucp_ep_params_t ep_params;
+    ucp_ep_h ep;
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (rank == 0) {
+        send_worker_address(1, worker);
+        worker_address = recv_worker_address(1);
+    } else {
+        worker_address = recv_worker_address(0);
+        send_worker_address(0, worker);
+    }
+
+    ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
+    ep_params.address    = (ucp_address_t*)worker_address;
+
+    UCX_CHECK(ucp_ep_create(worker, &ep_params, &ep));
+    free(worker_address);
+    return ep;
+}
+
+static void destroy_ucp_ep(ucp_ep_h ep)
+{
+    ucp_request_param_t request_param;
+
+    request_param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
+    request_param.flags        = UCP_EP_CLOSE_FLAG_FORCE;
+    ucp_ep_close_nbx(ep, &request_param);
+}
+
+static ucp_mem_h
+create_ucp_mem(void *buffer, size_t size, ucp_context_h context)
+{
+    ucp_mem_map_params_t mem_map_params;
+    ucp_mem_h mem;
+
+    mem_map_params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                                UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+    mem_map_params.address    = buffer;
+    mem_map_params.length     = size;
+    UCX_CHECK(ucp_mem_map(context, &mem_map_params, &mem));
+    return mem;
+}
+
+ucp_t create_ucp()
+{
+    ucp_t ucp;
+    ucp.context = create_ucp_context();
+    ucp.worker  = create_ucp_worker(ucp.context);
+    ucp.ep      = create_ucp_ep(ucp.worker);
+    return ucp;
+}
+
+void destroy_ucp(ucp_t ucp)
+{
+    destroy_ucp_ep(ucp.ep);
+    ucp_worker_destroy(ucp.worker);
+    ucp_cleanup(ucp.context);
+}
+
+ucp_mem_h
+send_rkey(int peer_rank, void *buffer, size_t size, ucp_context_h context)
+{
+    ucp_memh_buffer_release_params_t memh_buffer_release_params = {};
+    uint64_t local_address;
+    ucp_mem_h mem;
+    void *packed_rkey;
+    size_t packed_rkey_size;
+
+    local_address = (uint64_t)buffer;
+    MPI_Send(&local_address, sizeof(local_address), MPI_BYTE, peer_rank,
+             MPI_TAG_ADDRESS, MPI_COMM_WORLD);
+
+    mem = create_ucp_mem(buffer, size, context);
+    UCX_CHECK(ucp_rkey_pack(context, mem, &packed_rkey, &packed_rkey_size));
+
+    MPI_Send(&packed_rkey_size, sizeof(packed_rkey_size), MPI_BYTE, peer_rank,
+             MPI_TAG_PACKED_RKEY_SIZE, MPI_COMM_WORLD);
+
+    MPI_Send(packed_rkey, packed_rkey_size, MPI_BYTE, peer_rank,
+             MPI_TAG_PACKED_RKEY, MPI_COMM_WORLD);
+
+    ucp_memh_buffer_release(packed_rkey, &memh_buffer_release_params);
+    return mem;
+}
+
+rkey_t recv_rkey(int peer_rank, ucp_ep_h ep)
+{
+    rkey_t rkey;
+    size_t packed_rkey_size;
+    void *packed_rkey;
+
+    MPI_Recv(&rkey.remote_address, sizeof(rkey.remote_address), MPI_BYTE,
+             peer_rank, MPI_TAG_ADDRESS, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+    MPI_Recv(&packed_rkey_size, sizeof(packed_rkey_size), MPI_BYTE, peer_rank,
+             MPI_TAG_PACKED_RKEY_SIZE, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+    packed_rkey = malloc(packed_rkey_size);
+    if (packed_rkey == NULL) {
+        fprintf(stderr, "malloc packed rkey failed\n");
+        exit(EXIT_FAILURE);
+    }
+
+    MPI_Recv(packed_rkey, packed_rkey_size, MPI_BYTE, peer_rank,
+             MPI_TAG_PACKED_RKEY, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+    UCX_CHECK(ucp_ep_rkey_unpack(ep, packed_rkey, &rkey.rkey));
+    free(packed_rkey);
+
+    return rkey;
+}

--- a/test/mpi/test_ucp.h
+++ b/test/mpi/test_ucp.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef TEST_UCP_H
+#define TEST_UCP_H
+
+#include "ucp/api/ucp.h"
+
+typedef struct {
+    ucp_context_h context;
+    ucp_worker_h  worker;
+    ucp_ep_h      ep;
+} ucp_t;
+
+
+typedef struct {
+    ucp_rkey_h rkey;
+    uint64_t   remote_address;
+} rkey_t;
+
+
+ucp_t create_ucp();
+
+
+void destroy_ucp(ucp_t);
+
+
+ucp_mem_h send_rkey(int, void*, size_t, ucp_context_h);
+
+
+rkey_t recv_rkey(int, ucp_ep_h);
+
+#endif

--- a/test/mpi/test_ucp_rkey_destroy.c
+++ b/test/mpi/test_ucp_rkey_destroy.c
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "test_cuda_check_def.h"
+#include "test_mpi_tags_def.h"
+#include "test_ucp.h"
+#include "test_ucx_check_def.h"
+
+#include <cuda.h>
+#include <mpi.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define MPI_COMM_SIZE 2
+#define SIZE          (1024 * 1024 * 1024)
+
+static int rank0(ucp_context_h ucp_context)
+{
+    CUdeviceptr ptr;
+    ucp_mem_h ucp_mem;
+    size_t free_bytes_before, total_bytes, free_bytes_after, unreleased_memory;
+
+    CUDA_CHECK(cuMemGetInfo(&free_bytes_before, &total_bytes));
+    CUDA_CHECK(cuMemAlloc(&ptr, SIZE));
+
+    ucp_mem = send_rkey(1, (void*)ptr, SIZE, ucp_context);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    UCX_CHECK(ucp_mem_unmap(ucp_context, ucp_mem));
+    CUDA_CHECK(cuMemFree(ptr));
+    CUDA_CHECK(cuCtxSynchronize());
+
+    CUDA_CHECK(cuMemGetInfo(&free_bytes_after, &total_bytes));
+    unreleased_memory = free_bytes_before - free_bytes_after;
+    fprintf(stdout, "Unreleased memory: %zu bytes: %s\n", unreleased_memory,
+            (unreleased_memory == 0) ? "PASS" : "FAIL");
+    return (unreleased_memory == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+static void rank1(ucp_ep_h ucp_ep)
+{
+    rkey_t rkey;
+    void *ptr;
+
+    rkey = recv_rkey(0, ucp_ep);
+
+    UCX_CHECK(ucp_rkey_ptr(rkey.rkey, rkey.remote_address, &ptr));
+    ucp_rkey_destroy(rkey.rkey);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+int main(int argc, char **argv)
+{
+    int comm_size, rank;
+    int cu_dev_count;
+    CUdevice cu_dev;
+    CUcontext cu_ctx;
+    ucp_t ucp;
+    int exit_status;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (comm_size != MPI_COMM_SIZE) {
+        if (rank == 0) {
+            fprintf(stderr, "This test requires exactly %d MPI processes\n",
+                    MPI_COMM_SIZE);
+        }
+        MPI_Finalize();
+        return EXIT_FAILURE;
+    }
+
+    CUDA_CHECK(cuInit(0));
+    CUDA_CHECK(cuDeviceGetCount(&cu_dev_count));
+    CUDA_CHECK(cuDeviceGet(&cu_dev, rank % cu_dev_count));
+    CUDA_CHECK(cuDevicePrimaryCtxRetain(&cu_ctx, cu_dev));
+    CUDA_CHECK(cuCtxSetCurrent(cu_ctx));
+
+    ucp = create_ucp();
+
+    if (rank == 0) {
+        exit_status = rank0(ucp.context);
+    } else {
+        rank1(ucp.ep);
+    }
+
+    MPI_Bcast(&exit_status, 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+    destroy_ucp(ucp);
+
+    CUDA_CHECK(cuCtxPopCurrent(NULL));
+    CUDA_CHECK(cuDevicePrimaryCtxRelease(cu_dev));
+
+    MPI_Finalize();
+    return exit_status;
+}

--- a/test/mpi/test_ucx_check_def.h
+++ b/test/mpi/test_ucx_check_def.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef TEST_UCX_CHECK_DEF_H
+#define TEST_UCX_CHECK_DEF_H
+
+#include "test_lib_check_def.h"
+
+#include "ucs/type/status.h"
+
+#define UCX_CHECK(_func) \
+    LIB_CHECK(ucs_status_t, _func, UCS_OK, ucs_status_string)
+
+#endif


### PR DESCRIPTION
## What?
Added UCT API uct_md_mem_elem_release to be able to release resources allocated during uct_md_mem_elem_pack.

Unregistered the CUDA IPC memory handle that was registered when unpacking the remote memory key, getting local pointer to remote memory, packing memory element.

## Why?
cuda_ipc maps remote address, opening interprocess handle. It's not possible to release the memory without closing all opened interprocess handles.

## How?
Cherry-picked https://github.com/openucx/ucx/pull/11288 and https://github.com/openucx/ucx/pull/11730
