### PR TITLE
UCT/CUDA_COPY: Fix reachability between interfaces

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -76,6 +76,7 @@ Manjunath Gorentla Venkata <manjugv@gmail.com>
 Manu Shantharam <manu.shantharam@amd.com>
 Marek Schimara <Marek.Schimara@bull.net>
 Mark Allen <markalle@us.ibm.com>
+Mason Pitt <bradley.b.pitt@gmail.com>
 Matthew Baker <bakermb@ornl.gov>
 Michael Braverman <michaelbr@nvidia.com>
 Michal Shalev <mshalev@nvidia.com>

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -554,11 +554,30 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
             continue;
         }
 
+        /* Filter out MDs which access memory of another process, and therefore
+         * need an rkey, such as cuda_ipc. Using them is a protocol choice which
+         * the user can disable. */
         if (!context->config.ext.memtype_copy_enable &&
-            (md_attr->flags & UCT_MD_FLAG_MEMTYPE_COPY) &&
+            ucs_test_all_flags(md_attr->flags, UCT_MD_FLAG_MEMTYPE_COPY |
+                                               UCT_MD_FLAG_NEED_RKEY) &&
             (md_attr->access_mem_types & ~UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
             ucs_trace(UCT_TL_RESOURCE_DESC_FMT
                       " : disabled to avoid memory type copies",
+                      UCT_TL_RESOURCE_DESC_ARG(resource));
+            continue;
+        }
+
+        /* A memory type copy MD which does not need an rkey, such as cuda_copy,
+         * copies within the local address space, so it can only reach the same
+         * worker: memory type endpoints and loopback endpoints. Reaching
+         * another worker of the same process would make the peers select
+         * different rendezvous schemes, because a packed rkey does not describe
+         * the system device of the remote buffer. */
+        if ((md_attr->flags & UCT_MD_FLAG_MEMTYPE_COPY) &&
+            !(md_attr->flags & UCT_MD_FLAG_NEED_RKEY) &&
+            (address->uuid != worker->uuid)) {
+            ucs_trace(UCT_TL_RESOURCE_DESC_FMT
+                      " : memory type copy can only reach the same worker",
                       UCT_TL_RESOURCE_DESC_ARG(resource));
             continue;
         }

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -554,9 +554,9 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
             continue;
         }
 
-        /* Filter out MDs which access memory of another process, and therefore
-         * need an rkey, such as cuda_ipc. Using them is a protocol choice which
-         * the user can disable. */
+        /* A memory type copy MD which needs an rkey, such as cuda_ipc,
+         * copies non-host memory of another process. Using it is a protocol
+         * choice which the user can disable by UCX_MEMTYPE_COPY_ENABLE. */
         if (!context->config.ext.memtype_copy_enable &&
             ucs_test_all_flags(md_attr->flags, UCT_MD_FLAG_MEMTYPE_COPY |
                                                UCT_MD_FLAG_NEED_RKEY) &&
@@ -567,12 +567,12 @@ static UCS_F_NOINLINE ucs_status_t ucp_wireup_select_transport(
             continue;
         }
 
-        /* A memory type copy MD which does not need an rkey, such as cuda_copy,
-         * copies within the local address space, so it can only reach the same
-         * worker: memory type endpoints and loopback endpoints. Reaching
-         * another worker of the same process would make the peers select
-         * different rendezvous schemes, because a packed rkey does not describe
-         * the system device of the remote buffer. */
+        /* A memory type copy MD which does not need an rkey, such as
+         * cuda_copy, copies within the local address space, so it can only
+         * reach the same worker, i.e. memory type and loopback endpoints.
+         * A packed rkey does not describe the system device of the remote
+         * buffer, so reaching even another worker of the same process would
+         * make the peers select different rendezvous protocols. */
         if ((md_attr->flags & UCT_MD_FLAG_MEMTYPE_COPY) &&
             !(md_attr->flags & UCT_MD_FLAG_NEED_RKEY) &&
             (address->uuid != worker->uuid)) {

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.c
@@ -14,9 +14,12 @@
 #include <uct/cuda/base/cuda_iface.h>
 #include <uct/cuda/base/cuda_md.h>
 #include <ucs/type/class.h>
+#include <ucs/type/init_once.h>
 #include <ucs/sys/string.h>
 #include <ucs/async/eventfd.h>
 #include <ucs/arch/cpu.h>
+
+#include <unistd.h>
 
 
 #define UCT_CUDA_COPY_IFACE_OVERHEAD 0
@@ -54,6 +57,19 @@ static ucs_config_field_t uct_cuda_copy_iface_config_table[] = {
 
     {NULL}
 };
+
+
+static uct_cuda_copy_iface_addr_t uct_cuda_copy_iface_get_uuid(void)
+{
+    static ucs_init_once_t init_once = UCS_INIT_ONCE_INITIALIZER;
+    static uct_cuda_copy_iface_addr_t uuid;
+
+    UCS_INIT_ONCE(&init_once) {
+        uuid = ucs_generate_uuid((uintptr_t)getpid());
+    }
+
+    return uuid;
+}
 
 /* Forward declaration for the delete function */
 static void UCS_CLASS_DELETE_FUNC_NAME(uct_cuda_copy_iface_t)(uct_iface_t*);
@@ -338,7 +354,7 @@ static UCS_CLASS_INIT_FUNC(uct_cuda_copy_iface_t, uct_md_h md, uct_worker_h work
         return status;
     }
 
-    self->id                           = ucs_generate_uuid((uintptr_t)self);
+    self->id                           = uct_cuda_copy_iface_get_uuid();
     self->config.bw                    = config->bw;
     self->super.ops                    = &uct_cuda_iface_ops;
     self->super.config.max_events      = config->max_cuda_events;

--- a/src/uct/cuda/cuda_copy/cuda_copy_iface.h
+++ b/src/uct/cuda/cuda_copy/cuda_copy_iface.h
@@ -60,7 +60,7 @@ typedef struct {
 
 typedef struct uct_cuda_copy_iface {
     uct_cuda_iface_t            super;
-    /* used to store uuid and check iface reachability */
+    /* process-wide uuid used to check iface reachability */
     uct_cuda_copy_iface_addr_t  id;
     /* config parameters to control cuda copy transport */
     struct {

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -119,7 +119,8 @@ uct_cuda_copy_md_query(uct_md_h uct_md, uct_md_attr_v2_t *md_attr)
     uct_cuda_copy_md_t *md = ucs_derived_of(uct_md, uct_cuda_copy_md_t);
 
     uct_md_base_md_query(md_attr);
-    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC;
+    md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC |
+                                UCT_MD_FLAG_MEMTYPE_COPY;
     md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
                                 UCS_BIT(UCS_MEMORY_TYPE_CUDA) |
                                 UCS_BIT(UCS_MEMORY_TYPE_CUDA_MANAGED);

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -88,21 +88,6 @@ protected:
         return false;
     }
 
-    bool has_tl(const char *tl_name)
-    {
-        ucp_context_h context = this->context();
-        ucp_rsc_index_t rsc_index;
-
-        for (rsc_index = 0; rsc_index < context->num_tls; ++rsc_index) {
-            if (!std::strcmp(context->tl_rscs[rsc_index].tl_rsc.tl_name,
-                             tl_name)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     void require_cuda_memory()
     {
         if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
@@ -823,7 +808,7 @@ UCS_TEST_P(test_ucp_proto, memtype_copy_disable_keeps_staging_ep,
            "MEMTYPE_COPY_ENABLE=n")
 {
     require_cuda_memory();
-    if (!has_tl("cuda_copy")) {
+    if (!has_resource(sender(), "cuda_copy")) {
         UCS_TEST_SKIP_R("cuda_copy transport is not available");
     }
 

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -88,6 +88,21 @@ protected:
         return false;
     }
 
+    bool has_tl(const char *tl_name)
+    {
+        ucp_context_h context = this->context();
+        ucp_rsc_index_t rsc_index;
+
+        for (rsc_index = 0; rsc_index < context->num_tls; ++rsc_index) {
+            if (!std::strcmp(context->tl_rscs[rsc_index].tl_rsc.tl_name,
+                             tl_name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     void require_cuda_memory()
     {
         if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_CUDA)) {
@@ -799,6 +814,20 @@ UCS_TEST_P(test_ucp_proto, dt_iter_mem_reg)
 
         test_dt_iter_mem_reg(mem_type, buffer_size, md_map);
     }
+}
+
+/* cuda_copy is a memory type copy MD, but unlike cuda_ipc it copies within the
+ * local address space and is what memory type staging is built on. Disabling
+ * memory type copies must not remove it from wireup. */
+UCS_TEST_P(test_ucp_proto, memtype_copy_disable_keeps_staging_ep,
+           "MEMTYPE_COPY_ENABLE=n")
+{
+    require_cuda_memory();
+    if (!has_tl("cuda_copy")) {
+        UCS_TEST_SKIP_R("cuda_copy transport is not available");
+    }
+
+    EXPECT_NE(nullptr, worker()->mem_type_ep[UCS_MEMORY_TYPE_CUDA]);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_proto)

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -2205,8 +2205,10 @@ public:
         attrs   = ucp_worker_iface_get_attr(worker, rsc_index);
         has_cm  = ucp_ep_init_flags_has_cm(ep_init_flags);
 
+        /* Keep in sync with ucp_wireup_select_transport() */
         if (!context->config.ext.memtype_copy_enable &&
-            (md_attr->flags & UCT_MD_FLAG_MEMTYPE_COPY) &&
+            ucs_test_all_flags(md_attr->flags, UCT_MD_FLAG_MEMTYPE_COPY |
+                                               UCT_MD_FLAG_NEED_RKEY) &&
             (md_attr->access_mem_types & ~UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
             return 0;
         }

--- a/test/gtest/uct/test_flush.cc
+++ b/test/gtest/uct/test_flush.cc
@@ -251,7 +251,7 @@ public:
     }
 
     void test_flush_put_zcopy(flush_func_t flush) {
-        const auto access_mem_types = sender().md_attr().access_mem_types;
+        const auto access_mem_types = sender().xfer_mem_types();
 
         ASSERT_NE(access_mem_types, 0);
         ucs_memory_type_t mem_type = (ucs_memory_type_t)ucs_ffs64(

--- a/test/gtest/uct/test_p2p_mix.cc
+++ b/test/gtest/uct/test_p2p_mix.cc
@@ -189,7 +189,7 @@ void uct_p2p_mix_test::run(unsigned count, size_t offset, size_t size_cap,
     if (m_avail_send_funcs.size() == 0) {
         UCS_TEST_SKIP_R("unsupported");
     }
-    if (!(sender().md_attr().access_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
+    if (!(sender().xfer_mem_types() & UCS_BIT(UCS_MEMORY_TYPE_HOST))) {
         UCS_TEST_SKIP_R("skipping on non-host memory");
     }
 

--- a/test/gtest/uct/test_p2p_rma.cc
+++ b/test/gtest/uct/test_p2p_rma.cc
@@ -153,7 +153,7 @@ UCS_TEST_SKIP_COND_P(test_p2p_rma_madvise, madvise,
                      /* Allocate with mmap to avoid pinning other heap memory */
                      "IB_ALLOC?=mmap")
 {
-    const auto access_mem_types = sender().md_attr().access_mem_types;
+    const auto access_mem_types = sender().xfer_mem_types();
 
     ASSERT_NE(access_mem_types, 0);
     const ucs_memory_type_t mem_type = (ucs_memory_type_t)ucs_ffs64(

--- a/test/gtest/uct/test_stats.cc
+++ b/test/gtest/uct/test_stats.cc
@@ -97,11 +97,12 @@ public:
 
     void init_bufs(size_t min, size_t max)
     {
-        size_t size = ucs_max(min, ucs_min(64ul, max));
+        size_t size        = ucs_max(min, ucs_min(64ul, max));
+        uint64_t mem_types = sender().xfer_mem_types();
         uint8_t mem_type_index;
 
-        ucs_assert(sender().md_attr().access_mem_types != 0);
-        mem_type_index = ucs_ffs64(sender().md_attr().access_mem_types);
+        ucs_assert(mem_types != 0);
+        mem_type_index = ucs_ffs64(mem_types);
 
         lbuf = new mapped_buffer(size, 0, sender(), 0, (ucs_memory_type_t)mem_type_index);
         rbuf = new mapped_buffer(size, 0, receiver(), 0, (ucs_memory_type_t)mem_type_index);

--- a/test/gtest/uct/test_uct_ep.cc
+++ b/test/gtest/uct/test_uct_ep.cc
@@ -209,7 +209,8 @@ UCS_TEST_P(test_uct_ep, is_connected)
     /* The following transports are always connected to remote side on the same
      * process/machine, so we modify remote id to simulate no-connection
      * scenario. */
-    if (has_cma() || has_cuda_ipc() || has_transport("knem")) {
+    if (has_cma() || has_cuda_ipc() || has_transport("knem") ||
+        has_transport("cuda_copy")) {
         modify_remote_id(has_cuda_ipc() ? *m_receiver : *e);
     }
 

--- a/test/gtest/uct/test_uct_iface.cc
+++ b/test/gtest/uct/test_uct_iface.cc
@@ -16,6 +16,9 @@ protected:
     {
         uct_test::init();
         m_entities.push_back(uct_test::create_entity(0));
+        if (has_transport("cuda_copy")) {
+            m_entities.push_back(uct_test::create_entity(0));
+        }
     }
 
     entity &get_entity()
@@ -28,7 +31,9 @@ protected:
 
 void test_uct_iface::test_is_reachable()
 {
-    const auto &iface_attr = get_entity().iface_attr();
+    /* Use a separate cuda_copy iface; other transports keep the self-check. */
+    entity &remote         = *m_entities.back();
+    const auto &iface_attr = remote.iface_attr();
     auto iface             = get_entity().iface();
     uct_iface_is_reachable_params_t params;
     ucs_status_t status;
@@ -50,11 +55,12 @@ void test_uct_iface::test_is_reachable()
     params.iface_addr         = (uct_iface_addr_t*)&iface_addr[0];
     params.iface_addr_length  = iface_attr.iface_addr_len;
 
-    status = uct_iface_get_device_address(iface,
+    status = uct_iface_get_device_address(remote.iface(),
                                           (uct_device_addr_t*)&dev_addr[0]);
     ASSERT_UCS_OK(status);
 
-    status = uct_iface_get_address(iface, (uct_iface_addr_t*)&iface_addr[0]);
+    status = uct_iface_get_address(remote.iface(),
+                                   (uct_iface_addr_t*)&iface_addr[0]);
     ASSERT_UCS_OK(status);
 
     bool is_reachable = uct_iface_is_reachable_v2(iface, &params);

--- a/test/gtest/uct/test_uct_perf.cc
+++ b/test/gtest/uct/test_uct_perf.cc
@@ -259,17 +259,18 @@ class test_uct_loopback_cuda : public test_uct_perf {
 public:
     const std::vector<std::vector<ucs_memory_type_t>> mem_type_pairs() {
         std::vector<std::vector<ucs_memory_type_t>> result;
-        std::vector<ucs_memory_type_t> input = {UCS_MEMORY_TYPE_HOST,
-                                                UCS_MEMORY_TYPE_CUDA};
 
         /* gdr_copy test supports from host to GPU mem case only */
         if (has_transport("gdr_copy")) {
-            result.push_back(input);
+            result.push_back({UCS_MEMORY_TYPE_HOST, UCS_MEMORY_TYPE_CUDA});
         } else if (has_transport("cuda_ipc")) {
             /* cuda_ipc test only supports GPU-GPU case */
             result.push_back({UCS_MEMORY_TYPE_CUDA, UCS_MEMORY_TYPE_CUDA});
         } else {
-            result = ucs::make_pairs(input);
+            /* cuda_copy does not support host-host memory copy */
+            result.push_back({UCS_MEMORY_TYPE_HOST, UCS_MEMORY_TYPE_CUDA});
+            result.push_back({UCS_MEMORY_TYPE_CUDA, UCS_MEMORY_TYPE_HOST});
+            result.push_back({UCS_MEMORY_TYPE_CUDA, UCS_MEMORY_TYPE_CUDA});
         }
 
         return result;

--- a/test/gtest/uct/uct_p2p_test.cc
+++ b/test/gtest/uct/uct_p2p_test.cc
@@ -148,13 +148,15 @@ void uct_p2p_test::test_xfer_print(O& os, send_func_t send, size_t length,
 void uct_p2p_test::test_xfer_multi(send_func_t send, size_t min_length,
                                    size_t max_length, unsigned flags)
 {
+    const uint64_t access_mem_types = sender().xfer_mem_types();
+
     for (auto mem_type : mem_buffer::supported_mem_types()) {
         /* test mem type if md supports mem type
          * (or) if HOST MD can register mem type
          */
-        if (!((sender().md_attr().access_mem_types & UCS_BIT(mem_type)) ||
-            ((sender().md_attr().access_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST)) &&
-		sender().md_attr().reg_mem_types & UCS_BIT(mem_type)))) {
+        if (!((access_mem_types & UCS_BIT(mem_type)) ||
+              ((access_mem_types & UCS_BIT(UCS_MEMORY_TYPE_HOST)) &&
+               (sender().md_attr().reg_mem_types & UCS_BIT(mem_type))))) {
             continue;
         }
         if (mem_type == UCS_MEMORY_TYPE_CUDA) {

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1142,6 +1142,17 @@ const uct_md_attr_v2_t& uct_test::entity::md_attr() const {
     return m_md_attr;
 }
 
+uint64_t uct_test::entity::xfer_mem_types() const {
+    uint64_t mem_types = md_attr().access_mem_types;
+
+    /* Memory-type copy MDs do not support host-to-host transfers. */
+    if (md_attr().flags & UCT_MD_FLAG_MEMTYPE_COPY) {
+        mem_types &= ~UCS_BIT(UCS_MEMORY_TYPE_HOST);
+    }
+
+    return mem_types;
+}
+
 uct_worker_h uct_test::entity::worker() const {
     return m_worker;
 }

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -167,6 +167,8 @@ protected:
 
         const uct_md_attr_v2_t& md_attr() const;
 
+        uint64_t xfer_mem_types() const;
+
         uct_worker_h worker() const;
 
         uct_cm_h cm() const;


### PR DESCRIPTION
### What?
Allow different `cuda_copy` interfaces in the same process to reach each other.

### Why?
Each interface had its own UUID, so interfaces in the same process were treated as unreachable.

### How?
Use one process-wide UUID for all `cuda_copy` interfaces and update the reachability test to use two separate interfaces.