### PR TITLE
TEST/GTEST: Avoid munmap of reused FIXED address holes

### DIFF
--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -8,6 +8,7 @@
 
 #include <ucs/async/async.h>
 #include <ucs/sys/math.h>
+#include <ucs/sys/ptr_arith.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/string.h>
 #include <ucs/config/global_opts.h>
@@ -699,7 +700,9 @@ uint16_t get_port() {
     return port;
 }
 
-mmap_fixed_address::mmap_fixed_address(size_t length) : m_length(length) {
+mmap_fixed_address::mmap_fixed_address(size_t length) :
+    m_length(ucs_align_up(length, ucs_get_page_size()))
+{
     m_ptr = mmap(NULL, m_length, PROT_READ | PROT_WRITE,
                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (m_ptr == MAP_FAILED) {
@@ -707,9 +710,33 @@ mmap_fixed_address::mmap_fixed_address(size_t length) : m_length(length) {
     }
 }
 
-mmap_fixed_address::~mmap_fixed_address() {
-    if (m_ptr != NULL) {
-        munmap(m_ptr, m_length);
+void mmap_fixed_address::mark_unmapped(void *address, size_t length)
+{
+    if (length > 0) {
+        m_holes[(char*)address] = (char*)address + length;
+    }
+}
+
+mmap_fixed_address::~mmap_fixed_address()
+{
+    char *start, *region_end;
+
+    if (m_ptr == NULL) {
+        return;
+    }
+
+    /* Unmap mapped spans between holes; skip holes that may have been reused */
+    start      = (char*)m_ptr;
+    region_end = (char*)UCS_PTR_BYTE_OFFSET(m_ptr, m_length);
+    for (const auto &hole : m_holes) {
+        if (hole.first > start) {
+            munmap(start, hole.first - start);
+        }
+        start = hole.second;
+    }
+
+    if (region_end > start) {
+        munmap(start, region_end - start);
     }
 }
 

--- a/test/gtest/common/test_helpers.cc
+++ b/test/gtest/common/test_helpers.cc
@@ -713,30 +713,31 @@ mmap_fixed_address::mmap_fixed_address(size_t length) :
 void mmap_fixed_address::mark_unmapped(void *address, size_t length)
 {
     if (length > 0) {
-        m_holes[(char*)address] = (char*)address + length;
+        m_holes[address] = length;
     }
 }
 
 mmap_fixed_address::~mmap_fixed_address()
 {
-    char *start, *region_end;
+    void *start, *end;
 
-    if (m_ptr == NULL) {
+    if (m_ptr == nullptr) {
         return;
     }
 
     /* Unmap mapped spans between holes; skip holes that may have been reused */
-    start      = (char*)m_ptr;
-    region_end = (char*)UCS_PTR_BYTE_OFFSET(m_ptr, m_length);
+    start = m_ptr;
+    end   = UCS_PTR_BYTE_OFFSET(m_ptr, m_length);
     for (const auto &hole : m_holes) {
         if (hole.first > start) {
-            munmap(start, hole.first - start);
+            munmap(start, UCS_PTR_BYTE_DIFF(start, hole.first));
         }
-        start = hole.second;
+
+        start = UCS_PTR_BYTE_OFFSET(hole.first, hole.second);
     }
 
-    if (region_end > start) {
-        munmap(start, region_end - start);
+    if (end > start) {
+        munmap(start, UCS_PTR_BYTE_DIFF(start, end));
     }
 }
 

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -368,7 +368,7 @@ public:
     mmap_fixed_address(size_t length);
     ~mmap_fixed_address();
     void* operator*() const { return m_ptr; }
-    void detach() { m_ptr = NULL; }
+    void detach() { m_ptr = nullptr; }
 
     /* Report a sub-range which was already unmapped by the caller. Such a range
      * must not be unmapped again on destruction, since an unrelated mapping may
@@ -378,8 +378,8 @@ public:
 private:
     void *m_ptr;
     size_t m_length;
-    /* Holes [start, end) already released inside the reservation */
-    std::map<char*, char*> m_holes;
+    /* Holes already released inside the reservation: start -> length */
+    std::map<void*, size_t> m_holes;
 };
 
 

--- a/test/gtest/common/test_helpers.h
+++ b/test/gtest/common/test_helpers.h
@@ -30,6 +30,7 @@
 #include <initializer_list>
 #include <algorithm>
 #include <set>
+#include <map>
 #include <unordered_map>
 #include <sys/socket.h>
 #include <dirent.h>
@@ -369,9 +370,16 @@ public:
     void* operator*() const { return m_ptr; }
     void detach() { m_ptr = NULL; }
 
+    /* Report a sub-range which was already unmapped by the caller. Such a range
+     * must not be unmapped again on destruction, since an unrelated mapping may
+     * have been placed there in the meanwhile */
+    void mark_unmapped(void *address, size_t length);
+
 private:
     void *m_ptr;
     size_t m_length;
+    /* Holes [start, end) already released inside the reservation */
+    std::map<char*, char*> m_holes;
 };
 
 

--- a/test/gtest/uct/test_mem.cc
+++ b/test/gtest/uct/test_mem.cc
@@ -204,6 +204,9 @@ UCS_TEST_P(test_mem, md_fixed) {
                     memset(uct_mem.address, 'c', uct_mem.length);
                     EXPECT_EQ(*(char*)curr_addr, 'c');
                     status = uct_mem_free(&uct_mem);
+                    if (status == UCS_OK) {
+                        p_addr.mark_unmapped(uct_mem.address, uct_mem.length);
+                    }
                 } else {
                     EXPECT_EQ(status, UCS_ERR_NO_MEMORY);
                 }
@@ -262,6 +265,8 @@ UCS_TEST_P(test_mem, mmap_fixed) {
             if (status != UCS_OK) {
                 UCS_TEST_ABORT("uct_mem_free failed to release memory region");
             }
+
+            p_addr.mark_unmapped(uct_mem.address, uct_mem.length);
         } else {
             EXPECT_EQ(status, UCS_ERR_NO_MEMORY);
         }


### PR DESCRIPTION
## What?
Track already-freed FIXED sub-ranges in `ucs::mmap_fixed_address` and unmap only the remaining spans on destruction.

## Why?
`test_mem.mmap_fixed` and `test_mem.md_fixed` punch holes in the reservation; unrelated mappings can reuse them. A full-range `munmap` then tears those mappings down and can crash later (e.g. in `pthread_create` during `test_mem.md_alloc`).

## How?
Add `mark_unmapped()`, record holes in a map, and `munmap` only the mapped gaps between them.

Typical stacktrace:
```
[ RUN      ] alloc_methods/test_mem.mmap_fixed/3 <4>
[       OK ] alloc_methods/test_mem.mmap_fixed/3 (2 ms)
[ RUN      ] alloc_methods/test_mem.md_alloc/3 <4>
[swx-rdmz-ucx-gpu-02:65846:0:65846] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x7fa1c55352d0)
==== backtrace (tid:  65846) ====
 0  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(ucs_handle_error+0x2ec) [0x7fa1dd0d22ac]
 1  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(+0x4348b) [0x7fa1dd0d248b]
 2  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(+0x436f4) [0x7fa1dd0d26f4]
 3  /usr/lib/x86_64-linux-gnu/libc.so.6(+0x45320) [0x7fa1d5899320]
 4  /usr/lib/x86_64-linux-gnu/libc.so.6(pthread_create+0x208) [0x7fa1d58f0db8]
 5  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(ucs_pthread_create+0x78) [0x7fa1dd0eace8]
 6  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(+0x240e8) [0x7fa1dd0b30e8]
 7  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(+0x24841) [0x7fa1dd0b3841]
 8  /__w/1/s/build-test/src/ucs/.libs/libucs.so.0(ucs_async_set_event_handler+0x1d2) [0x7fa1dd0b0122]
 9  /__w/1/s/build-test/src/uct/ib/.libs/libuct_ib.so.0(uct_ib_device_init+0x30e) [0x7fa1dcdc300e]
10  /__w/1/s/build-test/src/uct/ib/.libs/libuct_ib.so.0(uct_ib_md_open_common+0x12b) [0x7fa1dcdceddb]
11  /__w/1/s/build-test/src/uct/ib/mlx5/.libs/libuct_ib_mlx5.so.0(uct_ib_mlx5_devx_md_open_common+0x86a) [0x7fa1dcd2800a]