### PR TITLE
UCP/CORE: Reorder fields in ucp_tl_md_t - v1.22.x

### DIFF
--- a/src/ucp/core/ucp_context.h
+++ b/src/ucp/core/ucp_context.h
@@ -362,14 +362,14 @@ typedef struct ucp_tl_md {
     uct_md_resource_desc_t rsc;
 
     /**
-     * Memory domain attributes
-     */
-    uct_md_attr_v2_t       attr;
-
-    /**
      * Flags mask parameter for @ref uct_md_mkey_pack_v2
      */
     unsigned               pack_flags_mask;
+
+    /**
+     * Memory domain attributes
+     */
+    uct_md_attr_v2_t       attr;
 
     /**
      * Global VA memory handle


### PR DESCRIPTION
## What?
Reorder fields in ucp_tl_md_t. The reorder shrinks the size of ucp_tl_md_t from 600 bytes to 592.

## Why?
b6b853165 increased the size of uct_md_attr_v2_t, which increased the size of ucp_tl_md_t. This caused a perf degradation which is fixed by this commit.

backport of #11784