### PR TITLE
CI: Replace Blue Ocean with pipeline-overview URL

### DIFF
--- a/.ci/jenkins/Jenkinsfile.dispatcher
+++ b/.ci/jenkins/Jenkinsfile.dispatcher
@@ -1,0 +1,70 @@
+#!/usr/bin/groovy
+
+/**
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2026. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+
+@Library('blossom-github-lib@master')
+import ipp.blossom.*
+
+def githubHelper = null
+withCredentials([usernamePassword(credentialsId: 'github-token', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+  githubHelper = GithubHelper.getInstance("${GIT_PASSWORD}", VARIABLE_FROM_POST)
+}
+
+// Abort previous dispatcher runs for the same PR
+def currentPrNumber = githubHelper.getPRNumber()?.toString()
+if (currentPrNumber) {
+  def slurper = new groovy.json.JsonSlurper()
+  try {
+    Jenkins.instance.getItemByFullName(env.JOB_NAME).builds.findAll {
+      it.isBuilding() && it.number < currentBuild.number
+    }.each { b ->
+      def gd = b.getAction(hudson.model.ParametersAction)?.getParameters()?.find { it.name == 'VARIABLE_FROM_POST' }?.value
+      def otherPr = gd ? slurper.parseText(gd)?.issue?.number?.toString() : null
+      if (otherPr == currentPrNumber) {
+        echo "Aborting dispatcher #${b.number} for same PR #${currentPrNumber}"
+        b.doStop()
+      }
+    }
+  } catch(Exception e) {
+    echo "Could not abort previous dispatchers: ${e.message}"
+  }
+}
+
+def sha = githubHelper.getMergedSHA()
+def pipelineOverviewUrl = "${env.BUILD_URL}pipeline-overview/"
+
+githubHelper.updateCommitStatus(pipelineOverviewUrl, "Blossom CI started", GitHubCommitState.PENDING)
+currentBuild.description = githubHelper.getBuildDescription()
+
+def jobs = [
+  'ucx-codestyle-oss',
+  'ucx-static-checks-oss',
+  'ucx-coverity-oss',
+  'ucx-build-oss',
+  'ucx-build-static-oss',
+  'ucx-test-oss',
+  'ucx-test-gpu-oss',
+  'ucx-test-dl-gpu-oss',
+]
+
+try {
+  def fanout = [:]
+  for (def j in jobs) {
+    def jobName = "UCX-OSS/${j}"
+    fanout[jobName] = {
+      build job: jobName, parameters: [
+        string(name: 'sha1', value: sha),
+        string(name: 'githubData', value: VARIABLE_FROM_POST),
+      ], propagate: false, wait: true
+    }
+  }
+  parallel fanout
+  githubHelper.updateCommitStatus(pipelineOverviewUrl, "Blossom CI passed", GitHubCommitState.SUCCESS)
+} catch(Exception ex) {
+  println ex
+  githubHelper.updateCommitStatus(pipelineOverviewUrl, "Blossom CI failed", GitHubCommitState.FAILURE)
+  throw ex
+}

--- a/.ci/jenkins/Jenkinsfile.github
+++ b/.ci/jenkins/Jenkinsfile.github
@@ -12,16 +12,15 @@ def matrix = new com.mellanox.cicd.Matrix()
 import ipp.blossom.*
 
 def githubHelper = null
-def blueOceanUrl = ""
+def pipelineOverviewUrl = ""
 
 if (params.githubData) {
   withCredentials([usernamePassword(credentialsId: 'github-token', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
     githubHelper = GithubHelper.getInstance("${GIT_PASSWORD}", params.githubData)
   }
 
-  def blueOceanJobPath = env.JOB_NAME.replace('/', '%2F')
-  blueOceanUrl = "${JENKINS_URL}blue/organizations/jenkins/${blueOceanJobPath}/detail/${env.JOB_BASE_NAME}/${env.BUILD_NUMBER}/pipeline/"
-  githubHelper.updateCommitStatus(blueOceanUrl, "CI started", GitHubCommitState.PENDING, env.JOB_BASE_NAME)
+  pipelineOverviewUrl = "${env.BUILD_URL}pipeline-overview/"
+  githubHelper.updateCommitStatus(pipelineOverviewUrl, "CI started", GitHubCommitState.PENDING, env.JOB_BASE_NAME)
   currentBuild.description = githubHelper.getBuildDescription()
 }
 
@@ -34,7 +33,7 @@ try {
 } finally {
   if (params.githubData) {
     githubHelper.updateCommitStatus(
-      blueOceanUrl,
+      pipelineOverviewUrl,
       "CI completed",
       currentBuild.resultIsBetterOrEqualTo('SUCCESS') ? GitHubCommitState.SUCCESS : GitHubCommitState.FAILURE,
       env.JOB_BASE_NAME

--- a/.ci/jenkins/proj_jjb_oss.yaml
+++ b/.ci/jenkins/proj_jjb_oss.yaml
@@ -74,10 +74,9 @@
       }}
 
       def sha = githubHelper.getMergedSHA()
-      def blueOceanJobPath = env.JOB_NAME.replace('/', '%2F')
-      def blueOceanUrl = "${{JENKINS_URL}}blue/organizations/jenkins/${{blueOceanJobPath}}/detail/${{env.JOB_BASE_NAME}}/${{env.BUILD_NUMBER}}/pipeline/"
+      def pipelineOverviewUrl = "${{env.BUILD_URL}}pipeline-overview/"
 
-      githubHelper.updateCommitStatus(blueOceanUrl, "Blossom CI started", GitHubCommitState.PENDING)
+      githubHelper.updateCommitStatus(pipelineOverviewUrl, "Blossom CI started", GitHubCommitState.PENDING)
       currentBuild.description = githubHelper.getBuildDescription()
 
       def jobs = [
@@ -103,10 +102,10 @@
           }}
         }}
         parallel fanout
-        githubHelper.updateCommitStatus(blueOceanUrl, "Blossom CI passed", GitHubCommitState.SUCCESS)
+        githubHelper.updateCommitStatus(pipelineOverviewUrl, "Blossom CI passed", GitHubCommitState.SUCCESS)
       }} catch(Exception ex) {{
         println ex
-        githubHelper.updateCommitStatus(blueOceanUrl, "Blossom CI failed", GitHubCommitState.FAILURE)
+        githubHelper.updateCommitStatus(pipelineOverviewUrl, "Blossom CI failed", GitHubCommitState.FAILURE)
         throw ex
       }}
 

--- a/.ci/jenkins/proj_jjb_oss.yaml
+++ b/.ci/jenkins/proj_jjb_oss.yaml
@@ -44,70 +44,17 @@
           name: "VARIABLE_FROM_POST"
           default: ""
           description: "Raw GitHub webhook payload (Blossom)"
-    dsl: |
-      @Library('blossom-github-lib@master')
-      import ipp.blossom.*
-
-      def githubHelper = null
-      withCredentials([usernamePassword(credentialsId: 'github-token', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {{
-        githubHelper = GithubHelper.getInstance("${{GIT_PASSWORD}}", VARIABLE_FROM_POST)
-      }}
-
-      // Abort previous dispatcher runs for the same PR
-      def currentPrNumber = githubHelper.getPRNumber()?.toString()
-      if (currentPrNumber) {{
-        def slurper = new groovy.json.JsonSlurper()
-        try {{
-          Jenkins.instance.getItemByFullName(env.JOB_NAME).builds.findAll {{
-            it.isBuilding() && it.number < currentBuild.number
-          }}.each {{ b ->
-            def gd = b.getAction(hudson.model.ParametersAction)?.getParameters()?.find {{ it.name == 'VARIABLE_FROM_POST' }}?.value
-            def otherPr = gd ? slurper.parseText(gd)?.issue?.number?.toString() : null
-            if (otherPr == currentPrNumber) {{
-              echo "Aborting dispatcher #${{b.number}} for same PR #${{currentPrNumber}}"
-              b.doStop()
-            }}
-          }}
-        }} catch(Exception e) {{
-          echo "Could not abort previous dispatchers: ${{e.message}}"
-        }}
-      }}
-
-      def sha = githubHelper.getMergedSHA()
-      def pipelineOverviewUrl = "${{env.BUILD_URL}}pipeline-overview/"
-
-      githubHelper.updateCommitStatus(pipelineOverviewUrl, "Blossom CI started", GitHubCommitState.PENDING)
-      currentBuild.description = githubHelper.getBuildDescription()
-
-      def jobs = [
-        'ucx-codestyle-oss',
-        'ucx-static-checks-oss',
-        'ucx-coverity-oss',
-        'ucx-build-oss',
-        'ucx-build-static-oss',
-        'ucx-test-oss',
-        'ucx-test-gpu-oss',
-        'ucx-test-dl-gpu-oss',
-      ]
-
-      try {{
-        def fanout = [:]
-        for (def j in jobs) {{
-          def jobName = "UCX-OSS/${{j}}"
-          fanout[jobName] = {{
-            build job: jobName, parameters: [
-              string(name: 'sha1', value: sha),
-              string(name: 'githubData', value: VARIABLE_FROM_POST),
-            ], propagate: false, wait: true
-          }}
-        }}
-        parallel fanout
-        githubHelper.updateCommitStatus(pipelineOverviewUrl, "Blossom CI passed", GitHubCommitState.SUCCESS)
-      }} catch(Exception ex) {{
-        println ex
-        githubHelper.updateCommitStatus(pipelineOverviewUrl, "Blossom CI failed", GitHubCommitState.FAILURE)
-        throw ex
-      }}
+    pipeline-scm:
+      scm:
+        - git:
+            url: "https://github.com/openucx/ucx.git"
+            branches: [ 'master' ]
+            shallow-clone: true
+            depth: 100
+            refspec: "+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/*"
+            browser: githubweb
+            browser-url: "https://github.com/openucx/ucx"
+      script-path: ".ci/jenkins/Jenkinsfile.dispatcher"
 
 - job-template:
     name: "{jjb_proj}"

--- a/AUTHORS
+++ b/AUTHORS
@@ -88,6 +88,7 @@ Netanel Yosephian <netanelyo@mellanox.com>
 Nicolas 'Pixel' Noble <nicolas@nobis-crew.org>
 Nicolas Morey <nmorey@suse.com>
 Nir Wolfer <nwolfer@nvidia.com>
+Noam Tsemah <ntsemah@nvidia.com>
 Ofir Farjon <ofarjon@nvidia.com>
 Olly Perks <olly.perks@arm.com>
 Or Balayla <obalayla@nvidia.com>


### PR DESCRIPTION
## What?
Replace GitHub commit status links to point to Jenkins' pipeline-overview page instead of Blue Ocean UI.

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
