### PR TITLE
UCP/PROTO: Reload proto_select after nested config allocation

### DIFF
--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2246,7 +2246,7 @@ out:
 
 static void
 ucp_worker_dump_rkey_config_key(ucs_string_buffer_t *log_strb,
-                                ucp_rkey_config_key_t *key)
+                                const ucp_rkey_config_key_t *key)
 {
     ucs_string_buffer_appendf(
             log_strb,
@@ -2265,6 +2265,7 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
     const ucp_ep_config_t *ep_config = &ucs_array_elem(&worker->ep_config,
                                                        key->ep_cfg_index);
     ucp_worker_cfg_index_t rkey_cfg_index;
+    ucp_proto_select_short_t put_short;
     ucp_rkey_config_t *rkey_config;
     ucp_lane_index_t lane;
     ucs_status_t status;
@@ -2349,10 +2350,14 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
         ucp_proto_select_short_init(worker, &rkey_config->proto_select,
                                     key->ep_cfg_index, rkey_cfg_index,
                                     UCP_OP_ID_PUT, UCP_PROTO_FLAG_PUT_SHORT,
-                                    &rkey_config->put_short);
+                                    &put_short);
     } else {
-        ucp_proto_select_short_disable(&rkey_config->put_short);
+        ucp_proto_select_short_disable(&put_short);
     }
+
+    /* Protocol selection above can add rkey configurations, which reallocates
+     * the array and invalidates 'rkey_config' */
+    ucs_array_elem(&worker->rkey_config, rkey_cfg_index).put_short = put_short;
 
     return UCS_OK;
 

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -751,7 +751,6 @@ void ucp_proto_select_short_init(ucp_worker_h worker,
     const ucp_proto_threshold_elem_t *thresh;
     ucp_proto_select_param_t select_param;
     const ucp_proto_single_priv_t *spriv;
-    ucp_proto_select_t *proto_select;
     ucp_memory_info_t mem_info;
     ssize_t max_short_signed;
     const uint32_t *op_attribute;

--- a/src/ucp/proto/proto_select.c
+++ b/src/ucp/proto/proto_select.c
@@ -193,6 +193,7 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
                                 ucp_proto_select_init_protocols_t *proto_init)
 {
     UCS_STRING_BUFFER_ONSTACK(strb, UCP_PROTO_CONFIG_STR_MAX);
+    ucp_rkey_config_key_t rkey_config_key;
     ucp_proto_init_params_t init_params;
 
     ucs_assert(ep_cfg_index != UCP_WORKER_CFG_INDEX_NULL);
@@ -208,14 +209,15 @@ ucp_proto_select_init_protocols(ucp_worker_h worker,
     if (rkey_cfg_index == UCP_WORKER_CFG_INDEX_NULL) {
         init_params.rkey_config_key = NULL;
     } else {
-        init_params.rkey_config_key =
-                &ucs_array_elem(&worker->rkey_config, rkey_cfg_index).key;
+        /* Copy the key: probes may add rkey configs and reallocate the array */
+        rkey_config_key             = ucs_array_elem(&worker->rkey_config,
+                                                     rkey_cfg_index).key;
+        init_params.rkey_config_key = &rkey_config_key;
 
         /* rkey configuration must be for the same ep */
-        ucs_assertv_always(
-                init_params.rkey_config_key->ep_cfg_index == ep_cfg_index,
-                "rkey->ep_cfg_index=%d ep_cfg_index=%d",
-                init_params.rkey_config_key->ep_cfg_index, ep_cfg_index);
+        ucs_assertv_always(rkey_config_key.ep_cfg_index == ep_cfg_index,
+                           "rkey->ep_cfg_index=%d ep_cfg_index=%d",
+                           rkey_config_key.ep_cfg_index, ep_cfg_index);
     }
 
     ucs_array_init_dynamic(&proto_init->protocols);
@@ -564,6 +566,16 @@ ucp_proto_select_lookup_slow(ucp_worker_h worker,
         return NULL;
     }
 
+    /* Protocol initialization can add endpoint or remote key configurations,
+     * which reallocates the worker configuration arrays and invalidates
+     * 'proto_select'. Resolve it again from the configuration indexes.
+     */
+    if (rkey_cfg_index == UCP_WORKER_CFG_INDEX_NULL) {
+        proto_select = ucp_ep_config_proto_select(worker, ep_cfg_index);
+    } else {
+        proto_select = ucp_rkey_config_proto_select(worker, rkey_cfg_index);
+    }
+
     /* Add to hash after initializing the temp element, since calling
      * ucp_proto_select_elem_init() can recursively modify the hash. For
      * example, RNDV_RECV may probe RTR, which models its peer side by
@@ -739,6 +751,7 @@ void ucp_proto_select_short_init(ucp_worker_h worker,
     const ucp_proto_threshold_elem_t *thresh;
     ucp_proto_select_param_t select_param;
     const ucp_proto_single_priv_t *spriv;
+    ucp_proto_select_t *proto_select;
     ucp_memory_info_t mem_info;
     ssize_t max_short_signed;
     const uint32_t *op_attribute;
@@ -766,6 +779,13 @@ void ucp_proto_select_short_init(ucp_worker_h worker,
         if (thresh == NULL) {
             /* no protocol for contig/host */
             goto out_disable;
+        }
+
+        /* lookup may add a configuration and reallocate the array */
+        if (rkey_cfg_index == UCP_WORKER_CFG_INDEX_NULL) {
+            proto_select = ucp_ep_config_proto_select(worker, ep_cfg_index);
+        } else {
+            proto_select = ucp_rkey_config_proto_select(worker, rkey_cfg_index);
         }
 
         ucs_assert(thresh->proto_config.proto != NULL);
@@ -864,22 +884,21 @@ ucp_proto_select_get(ucp_worker_h worker, ucp_worker_cfg_index_t ep_cfg_index,
 
     if (rkey_cfg_index == UCP_WORKER_CFG_INDEX_NULL) {
         *new_rkey_cfg_index = UCP_WORKER_CFG_INDEX_NULL;
-        return &ucs_array_elem(&worker->ep_config, ep_cfg_index).proto_select;
-    } else {
-        rkey_config_key =
-                ucs_array_elem(&worker->rkey_config, rkey_cfg_index).key;
-
-        rkey_config_key.ep_cfg_index = ep_cfg_index;
-        status = ucp_worker_rkey_config_get(worker, &rkey_config_key, NULL,
-                                            new_rkey_cfg_index);
-        if (status != UCS_OK) {
-            ucs_error("failed to switch to new rkey");
-            return NULL;
-        }
-
-        return &ucs_array_elem(&worker->rkey_config, *new_rkey_cfg_index)
-                        .proto_select;
+        return ucp_ep_config_proto_select(worker, ep_cfg_index);
     }
+
+    rkey_config_key =
+            ucs_array_elem(&worker->rkey_config, rkey_cfg_index).key;
+
+    rkey_config_key.ep_cfg_index = ep_cfg_index;
+    status = ucp_worker_rkey_config_get(worker, &rkey_config_key, NULL,
+                                        new_rkey_cfg_index);
+    if (status != UCS_OK) {
+        ucs_error("failed to switch to new rkey");
+        return NULL;
+    }
+
+    return ucp_rkey_config_proto_select(worker, *new_rkey_cfg_index);
 }
 
 void ucp_proto_config_query(ucp_worker_h worker,

--- a/src/ucp/proto/proto_select.inl
+++ b/src/ucp/proto/proto_select.inl
@@ -73,6 +73,21 @@ ucp_proto_select_op_flags(const ucp_proto_select_param_t *select_param)
     return select_param->op_id_flags & ~(UCP_PROTO_SELECT_OP_FLAGS_BASE - 1);
 }
 
+static UCS_F_ALWAYS_INLINE ucp_proto_select_t *
+ucp_ep_config_proto_select(ucp_worker_h worker,
+                           ucp_worker_cfg_index_t ep_cfg_index)
+{
+    return &ucs_array_elem(&worker->ep_config, ep_cfg_index).proto_select;
+}
+
+static UCS_F_ALWAYS_INLINE ucp_proto_select_t *
+ucp_rkey_config_proto_select(ucp_worker_h worker,
+                             ucp_worker_cfg_index_t rkey_cfg_index)
+{
+    ucs_assert(rkey_cfg_index != UCP_WORKER_CFG_INDEX_NULL);
+    return &ucs_array_elem(&worker->rkey_config, rkey_cfg_index).proto_select;
+}
+
 static UCS_F_ALWAYS_INLINE const ucp_proto_threshold_elem_t*
 ucp_proto_select_lookup(ucp_worker_h worker, ucp_proto_select_t *proto_select,
                         ucp_worker_cfg_index_t ep_cfg_index,
@@ -101,6 +116,15 @@ ucp_proto_select_lookup(ucp_worker_h worker, ucp_proto_select_t *proto_select,
                                                        &key.param);
             if (ucs_unlikely(select_elem == NULL)) {
                 return NULL;
+            }
+
+            /* lookup_slow may add a configuration and reallocate the array */
+            if (rkey_cfg_index == UCP_WORKER_CFG_INDEX_NULL) {
+                proto_select = ucp_ep_config_proto_select(worker,
+                                                          ep_cfg_index);
+            } else {
+                proto_select = ucp_rkey_config_proto_select(worker,
+                                                            rkey_cfg_index);
             }
         }
 

--- a/src/ucp/rndv/rndv_ppln.c
+++ b/src/ucp/rndv/rndv_ppln.c
@@ -99,8 +99,7 @@ ucp_proto_rndv_ppln_probe(const ucp_proto_init_params_t *init_params)
 
     select_elem = ucp_proto_select_lookup_slow(worker, proto_select, 1,
                                                init_params->ep_cfg_index,
-                                               init_params->rkey_cfg_index,
-                                               &sel_param);
+                                               rkey_cfg_index, &sel_param);
     if (select_elem == NULL) {
         return;
     }

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -185,6 +185,8 @@ protected:
         static_cast<void>(ucp_proto_select_lookup_slow(
                 worker(), proto_select, 1, ep_cfg_index, rkey_cfg_index,
                 &select_param));
+        proto_select = &ucs_array_elem(&worker()->rkey_config,
+                                       rkey_cfg_index).proto_select;
 
         frag_key.param             = select_param;
         frag_key.param.op_id_flags = UCP_OP_ID_RNDV_RECV |


### PR DESCRIPTION
## What?

Nested protocol selection can reallocate worker config arrays and then use a stale `proto_select` / `rkey_config` pointer (UAF). Reload those pointers from the config indexes after the nested call returns.

## Why?

`worker->rkey_config` and `worker->ep_config` are growable worker arrays (not `ucp_ep_t`). Nested RTS probe can append an rkey config (`ucp_worker_add_rkey_config()`), realloc `worker->rkey_config[]`, and delayed-free the old buffer while `ucp_proto_select_lookup_slow` still holds `&rkey_config->proto_select`. The heap khash survives but the wrapper does not, so `proto_select->hash` can read as `NULL`.

This crash is the rkey array. The outer lookup uses `&ep_config->proto_select` in `worker->ep_config[]`, which is not grown here. The same realloc path exists for `ep_config[]` if a nested call adds an endpoint config.

```
ucp_proto_select_short_init
  ucp_proto_select_lookup_slow              /* outer: &ep_config->proto_select */
    ucp_proto_select_elem_init
      ucp_proto_select_init_protocols
        ucp_proto_rndv_rts_probe
          ucp_proto_rndv_ctrl_probe
            ucp_proto_rndv_ctrl_select_remote_proto
              rkey_config = &ucs_array_elem(...)   /* pointer taken */
              ucp_proto_select_lookup_slow         /* inner: &rkey_config->proto_select */
                kh_get(proto_select->hash)         /* still valid */
                ucp_proto_select_elem_init
                  /* add_rkey_config → worker->rkey_config[] realloc */
                kh_get(proto_select->hash)         /* UAF, hash == NULL */
```

## How?

Re-fetch `proto_select` (and other pointers into those arrays) after functions that can grow/realloc the worker config arrays.
