### PR TITLE
UCS/RCACHE: Merge adjacent regions

### DIFF
--- a/src/ucs/memory/rcache.c
+++ b/src/ucs/memory/rcache.c
@@ -24,6 +24,7 @@
 #include <ucs/type/rwlock.h>
 #include <ucs/vfs/base/vfs_obj.h>
 #include <ucm/api/ucm.h>
+#include <ucm/util/sys.h>
 
 #include "rcache.h"
 #include "rcache_int.h"
@@ -110,6 +111,12 @@ ucs_config_field_t ucs_config_rcache_table[] = {
      ucs_offsetof(ucs_rcache_config_t, max_unreleased),
      UCS_CONFIG_TYPE_MEMUNITS},
 
+    {"RCACHE_MAX_ADJACENT_SIZE", "1G",
+     "Maximal size of a registration cache region created by merging directly\n"
+     "adjacent regions. A value of 0 disables merging adjacent regions.",
+     ucs_offsetof(ucs_rcache_config_t, max_adjacent_size),
+     UCS_CONFIG_TYPE_MEMUNITS},
+
     {"RCACHE_PURGE_ON_FORK", "y",
      "Purge registration cache upon fork",
      ucs_offsetof(ucs_rcache_config_t, purge_on_fork), UCS_CONFIG_TYPE_BOOL},
@@ -180,6 +187,7 @@ void ucs_rcache_set_default_params(ucs_rcache_params_t *rcache_params)
     rcache_params->max_regions        = UCS_MEMUNITS_INF;
     rcache_params->max_size           = UCS_MEMUNITS_INF;
     rcache_params->max_unreleased     = UCS_MEMUNITS_INF;
+    rcache_params->max_adjacent_size  = UCS_GBYTE;
 }
 
 void ucs_rcache_set_params(ucs_rcache_params_t *rcache_params,
@@ -191,6 +199,7 @@ void ucs_rcache_set_params(ucs_rcache_params_t *rcache_params,
     rcache_params->max_regions        = rcache_config->max_regions;
     rcache_params->max_size           = rcache_config->max_size;
     rcache_params->max_unreleased     = rcache_config->max_unreleased;
+    rcache_params->max_adjacent_size  = rcache_config->max_adjacent_size;
     rcache_params->flags              = !rcache_config->purge_on_fork ? 0 :
                                         UCS_RCACHE_FLAG_PURGE_ON_FORK;
 }
@@ -361,6 +370,55 @@ static void ucs_rcache_find_regions(ucs_rcache_t *rcache, ucs_pgt_addr_t from,
     ucs_trace("%s: find regions in 0x%lx..0x%lx", rcache->name, from, to);
     ucs_pgtable_search_range(&rcache->pgtable, from, to,
                              ucs_rcache_region_collect_callback, list);
+}
+
+typedef struct {
+    ucs_pgt_addr_t request_start;
+    ucs_pgt_addr_t request_end;
+    ucs_pgt_addr_t start;
+    ucs_pgt_addr_t end;
+    int            prot;
+    int            found;
+} ucs_rcache_vma_info_t;
+
+static int ucs_rcache_get_vma_cb(void *arg, void *address, size_t length,
+                                 int prot, const char *path)
+{
+    ucs_rcache_vma_info_t *info = arg;
+    ucs_pgt_addr_t start        = (uintptr_t)address;
+    ucs_pgt_addr_t end          = start + length;
+
+    if (info->request_start >= end) {
+        return 0;
+    }
+
+    if ((info->request_start >= start) && (info->request_end <= end)) {
+        info->start = start;
+        info->end   = end;
+        info->prot  = prot;
+        info->found = 1;
+    }
+
+    return 1;
+}
+
+static int ucs_rcache_get_vma(ucs_pgt_addr_t start, ucs_pgt_addr_t end,
+                              int prot, ucs_pgt_addr_t *vma_start_p,
+                              ucs_pgt_addr_t *vma_end_p)
+{
+    ucs_rcache_vma_info_t info = {
+        .request_start = start,
+        .request_end   = end
+    };
+
+    ucm_parse_proc_self_maps(ucs_rcache_get_vma_cb, &info);
+    if (!info.found || !ucs_test_all_flags(info.prot, prot)) {
+        return 0;
+    }
+
+    *vma_start_p = info.start;
+    *vma_end_p   = info.end;
+    return 1;
 }
 
 static ucs_rcache_distribution_t *
@@ -818,39 +876,19 @@ ucs_rcache_check_overlap_one(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
 }
 
 /* Lock must be held */
-static ucs_status_t
-ucs_rcache_check_overlap(ucs_rcache_t *rcache, void *arg, ucs_pgt_addr_t *start,
-                         ucs_pgt_addr_t *end, size_t *alignment, int *prot,
-                         int *merged, ucs_rcache_region_t **region_p)
+static void
+ucs_rcache_merge_overlaps(ucs_rcache_t *rcache, void *arg,
+                          ucs_pgt_addr_t *start, ucs_pgt_addr_t *end,
+                          size_t *alignment, int *prot, int *merged)
 {
     ucs_rcache_region_t *region, *tmp;
     ucs_pgt_addr_t old_start, old_end;
     ucs_list_link_t region_list;
     ucs_status_t status;
 
-    ucs_trace_func("rcache=%s, *start=0x%lx, *end=0x%lx", rcache->name, *start,
-                   *end);
-
-    ucs_rcache_check_inv_queue(rcache, 0);
-    /* coverity[double_unlock] */
-    ucs_rcache_check_gc_list(rcache, 1);
-
     ucs_list_head_init(&region_list);
     ucs_rcache_find_regions(rcache, *start, *end - 1, &region_list);
 
-    if (!ucs_list_is_empty(&region_list)) {
-        region = ucs_list_next(&region_list, ucs_rcache_region_t, tmp_list);
-        if (ucs_list_is_only(&region_list, &region->tmp_list) &&
-            (*start >= region->super.start) && (*end <= region->super.end) &&
-            ucs_rcache_region_test(region, *prot, *alignment)) {
-            /* Found a region which contains the given address range */
-            ucs_rcache_region_hold(rcache, region);
-            *region_p = region;
-            return UCS_ERR_ALREADY_EXISTS;
-        }
-    }
-
-    /* TODO check if any of the regions is locked */
     do {
         old_start = *start;
         old_end   = *end;
@@ -872,9 +910,211 @@ ucs_rcache_check_overlap(ucs_rcache_t *rcache, void *arg, ucs_pgt_addr_t *start,
          * in turn, can result in even more overlapping regions.
          */
         ucs_list_head_init(&region_list);
-        ucs_rcache_find_regions(rcache, *start, old_start - 1, &region_list);
-        ucs_rcache_find_regions(rcache, old_end, *end - 1, &region_list);
+        if (*start < old_start) {
+            ucs_rcache_find_regions(rcache, *start, old_start - 1,
+                                    &region_list);
+        }
+
+        if (*end > old_end) {
+            ucs_rcache_find_regions(rcache, old_end, *end - 1, &region_list);
+        }
     } while (!ucs_list_is_empty(&region_list));
+}
+
+static int
+ucs_rcache_can_merge_adjacent(ucs_rcache_t *rcache,
+                              ucs_rcache_region_t *region,
+                              ucs_pgt_addr_t start, ucs_pgt_addr_t end,
+                              size_t alignment, int prot,
+                              ucs_pgt_addr_t vma_start,
+                              ucs_pgt_addr_t vma_end)
+{
+    size_t merged_alignment = ucs_max(alignment, region->alignment);
+    ucs_pgt_addr_t merged_start, merged_end;
+
+    if (((region->super.end != start) && (region->super.start != end)) ||
+        (region->prot != prot)) {
+        return 0;
+    }
+
+    merged_start = ucs_align_down_pow2(ucs_min(start, region->super.start),
+                                       merged_alignment);
+    merged_end   = ucs_max(end, region->super.end);
+    if (merged_end > (UCS_PGT_ADDR_MAX - (merged_alignment - 1))) {
+        return 0;
+    }
+
+    merged_end = ucs_align_up_pow2(merged_end, merged_alignment);
+    return (merged_start >= vma_start) && (merged_end <= vma_end) &&
+           ((merged_end - merged_start) <=
+            rcache->params.max_adjacent_size);
+}
+
+static size_t
+ucs_rcache_adjacent_target_size(size_t size, size_t alignment, size_t max_size)
+{
+    size_t target_size = alignment;
+
+    max_size = ucs_align_down_pow2(max_size, alignment);
+    ucs_assert(size <= max_size);
+
+    while (target_size < size) {
+        if (target_size > (max_size / 2)) {
+            return max_size;
+        }
+
+        target_size *= 2;
+    }
+
+    return target_size;
+}
+
+static void
+ucs_rcache_expand_adjacent(ucs_rcache_t *rcache, ucs_pgt_addr_t *start,
+                           ucs_pgt_addr_t *end, size_t alignment,
+                           ucs_pgt_addr_t vma_start, ucs_pgt_addr_t vma_end,
+                           int merged_left, int merged_right)
+{
+    size_t current_size = *end - *start;
+    size_t target_size;
+    size_t extra;
+    size_t grow;
+    int grow_right;
+
+    vma_start   = ucs_align_up_pow2(vma_start, alignment);
+    vma_end     = ucs_align_down_pow2(vma_end, alignment);
+    target_size = ucs_rcache_adjacent_target_size(
+            current_size, alignment, rcache->params.max_adjacent_size);
+    target_size = ucs_min(target_size, vma_end - vma_start);
+    if (target_size <= current_size) {
+        return;
+    }
+
+    if (merged_left && merged_right) {
+        grow_right = (vma_end - *end) >= (*start - vma_start);
+    } else {
+        grow_right = merged_right;
+    }
+
+    extra = target_size - current_size;
+    if (grow_right) {
+        grow  = ucs_min(extra, vma_end - *end);
+        *end += grow;
+        extra -= grow;
+        *start -= extra;
+    } else {
+        grow    = ucs_min(extra, *start - vma_start);
+        *start -= grow;
+        extra  -= grow;
+        *end   += extra;
+    }
+}
+
+static int
+ucs_rcache_merge_adjacent(ucs_rcache_t *rcache, void *arg,
+                          ucs_pgt_addr_t *start, ucs_pgt_addr_t *end,
+                          size_t *alignment, int *prot)
+{
+    ucs_pgt_addr_t adjacent_start = *start;
+    ucs_pgt_addr_t adjacent_end   = *end;
+    ucs_pgt_addr_t vma_start, vma_end;
+    ucs_pgt_region_t *pgt_region;
+    ucs_rcache_region_t *left  = NULL;
+    ucs_rcache_region_t *right = NULL;
+    ucs_status_t status;
+    int merged_left  = 0;
+    int merged_right = 0;
+
+    if (rcache->params.max_adjacent_size == 0) {
+        return 0;
+    }
+
+    if (adjacent_start > 0) {
+        pgt_region = ucs_pgtable_lookup(&rcache->pgtable,
+                                        adjacent_start - 1);
+        if ((pgt_region != NULL) && (pgt_region->end == adjacent_start)) {
+            left = ucs_derived_of(pgt_region, ucs_rcache_region_t);
+        }
+    }
+
+    if (adjacent_end < UCS_PGT_ADDR_MAX) {
+        pgt_region = ucs_pgtable_lookup(&rcache->pgtable, adjacent_end);
+        if ((pgt_region != NULL) && (pgt_region->start == adjacent_end)) {
+            right = ucs_derived_of(pgt_region, ucs_rcache_region_t);
+        }
+    }
+
+    if ((left == NULL) && (right == NULL)) {
+        return 0;
+    }
+
+    if (!ucs_rcache_get_vma(adjacent_start, adjacent_end, *prot, &vma_start,
+                            &vma_end)) {
+        return 0;
+    }
+
+    if ((left != NULL) &&
+        ucs_rcache_can_merge_adjacent(rcache, left, *start, *end, *alignment,
+                                      *prot, vma_start, vma_end)) {
+        status = ucs_rcache_check_overlap_one(rcache, start, end, alignment,
+                                              prot, arg, left);
+        merged_left = status == UCS_OK;
+    }
+
+    if ((right != NULL) &&
+        ucs_rcache_can_merge_adjacent(rcache, right, *start, *end, *alignment,
+                                      *prot, vma_start, vma_end)) {
+        status = ucs_rcache_check_overlap_one(rcache, start, end, alignment,
+                                              prot, arg, right);
+        merged_right = status == UCS_OK;
+    }
+
+    if (!merged_left && !merged_right) {
+        return 0;
+    }
+
+    *start = ucs_align_down_pow2(*start, *alignment);
+    *end   = ucs_align_up_pow2(*end, *alignment);
+    ucs_rcache_expand_adjacent(rcache, start, end, *alignment, vma_start,
+                               vma_end, merged_left, merged_right);
+    return 1;
+}
+
+/* Lock must be held */
+static ucs_status_t
+ucs_rcache_check_overlap(ucs_rcache_t *rcache, void *arg, ucs_pgt_addr_t *start,
+                         ucs_pgt_addr_t *end, size_t *alignment, int *prot,
+                         int *merged, ucs_rcache_region_t **region_p)
+{
+    ucs_pgt_region_t *pgt_region;
+    ucs_rcache_region_t *region;
+
+    ucs_trace_func("rcache=%s, *start=0x%lx, *end=0x%lx", rcache->name, *start,
+                   *end);
+
+    ucs_rcache_check_inv_queue(rcache, 0);
+    /* coverity[double_unlock] */
+    ucs_rcache_check_gc_list(rcache, 1);
+
+    pgt_region = ucs_pgtable_lookup(&rcache->pgtable, *start);
+    if (pgt_region != NULL) {
+        region = ucs_derived_of(pgt_region, ucs_rcache_region_t);
+        if ((*end <= region->super.end) &&
+            ucs_rcache_region_test(region, *prot, *alignment)) {
+            /* Found a region which contains the given address range */
+            ucs_rcache_region_hold(rcache, region);
+            *region_p = region;
+            return UCS_ERR_ALREADY_EXISTS;
+        }
+    }
+
+    ucs_rcache_merge_overlaps(rcache, arg, start, end, alignment, prot,
+                              merged);
+    if (ucs_rcache_merge_adjacent(rcache, arg, start, end, alignment, prot)) {
+        *merged = 1;
+        ucs_rcache_merge_overlaps(rcache, arg, start, end, alignment, prot,
+                                  merged);
+    }
 
     return UCS_OK;
 }

--- a/src/ucs/memory/rcache.h
+++ b/src/ucs/memory/rcache.h
@@ -155,6 +155,8 @@ struct ucs_rcache_params {
     unsigned long          max_regions;         /**< Maximal number of regions */
     size_t                 max_size;            /**< Maximal total size of regions */
     size_t                 max_unreleased;      /**< Threshold for triggering a cleanup */
+    size_t                 max_adjacent_size;   /**< Maximal adjacent merged region
+                                                     size */
 };
 
 
@@ -167,6 +169,8 @@ struct ucs_rcache_config {
     unsigned long max_regions;    /**< Maximal number of rcache regions */
     size_t        max_size;       /**< Maximal size of mapped memory */
     size_t        max_unreleased; /**< Threshold for triggering a cleanup */
+    size_t        max_adjacent_size; /**< Maximal size of a region created by
+                                          merging adjacent regions */
     int           purge_on_fork;  /**< Enable/disable rcache purge on fork */
 };
 

--- a/src/uct/sm/mm/xpmem/mm_xpmem.c
+++ b/src/uct/sm/mm/xpmem/mm_xpmem.c
@@ -256,6 +256,7 @@ uct_xpmem_rmem_add(xpmem_segid_t xsegid, uct_xpmem_remote_mem_t **rmem_p)
     rcache_params.flags              = UCS_RCACHE_FLAG_NO_PFN_CHECK;
     rcache_params.max_regions        = ULONG_MAX;
     rcache_params.max_size           = SIZE_MAX;
+    rcache_params.max_adjacent_size  = 0;
 
     status = ucs_rcache_create(&rcache_params, "xpmem_remote_mem",
                                ucs_stats_get_root(), &rmem->rcache);

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -19,14 +19,12 @@ extern "C" {
 static ucs_rcache_params_t
 get_default_rcache_params(void *context, const ucs_rcache_ops_t *ops)
 {
-    ucs_rcache_params_t params = {sizeof(ucs_rcache_region_t),
-                                  UCM_EVENT_VM_UNMAPPED,
-                                  1000,
-                                  ops,
-                                  context,
-                                  0,
-                                  ULONG_MAX,
-                                  SIZE_MAX};
+    ucs_rcache_params_t params;
+    ucs_rcache_set_default_params(&params);
+    params.ucm_events        = UCM_EVENT_VM_UNMAPPED;
+    params.ops               = ops;
+    params.context           = context;
+    params.max_unreleased    = 0;
 
     return params;
 }
@@ -74,7 +72,9 @@ protected:
         uint32_t            id;
     };
 
-    test_rcache() : m_reg_count(0), m_ptr(NULL), m_comp_count(0)
+    test_rcache(bool lock_memory = true) : m_reg_count(0), m_reg_bytes(0),
+                                           m_ptr(NULL), m_comp_count(0),
+                                           m_lock_memory(lock_memory)
     {
     }
 
@@ -129,20 +129,26 @@ protected:
             return UCS_ERR_IO_ERROR;
         }
 
-        mlock((const void*)region->super.super.start,
-              region->super.super.end - region->super.super.start);
+        if (m_lock_memory) {
+            mlock((const void*)region->super.super.start,
+                  region->super.super.end - region->super.super.start);
+        }
         EXPECT_NE(uint32_t(MAGIC), region->magic);
         region->magic = MAGIC;
         region->id    = ucs_atomic_fadd32(&next_id, 1);
 
         ucs_atomic_add32(&m_reg_count, +1);
+        ucs_atomic_add64(&m_reg_bytes, region->super.super.end -
+                                      region->super.super.start);
         return UCS_OK;
     }
 
     virtual void mem_dereg(region *region)
     {
-        munlock((const void*)region->super.super.start,
-                region->super.super.end - region->super.super.start);
+        if (m_lock_memory) {
+            munlock((const void*)region->super.super.start,
+                    region->super.super.end - region->super.super.start);
+        }
         EXPECT_EQ(uint32_t(MAGIC), region->magic);
         region->magic = 0;
         uint32_t prev = ucs_atomic_fsub32(&m_reg_count, 1);
@@ -177,6 +183,29 @@ protected:
         return ptr;
     }
 
+    void test_merge_adjacent(bool first_is_lower)
+    {
+        const size_t size = ucs_get_page_size();
+        void *mem         = alloc_pages(2 * size, PROT_READ | PROT_WRITE);
+        void *lower       = mem;
+        void *upper       = UCS_PTR_BYTE_OFFSET(mem, size);
+        void *first       = first_is_lower ? lower : upper;
+        void *second      = first_is_lower ? upper : lower;
+        region *region1, *region2, *region1_2;
+        region1 = get(first, size);
+        region2 = get(second, size);
+        EXPECT_NE(region1, region2);
+        EXPECT_EQ((uintptr_t)mem, region2->super.super.start);
+        EXPECT_EQ((uintptr_t)mem + (2 * size), region2->super.super.end);
+        region1_2 = get(first, size);
+        EXPECT_EQ(region2, region1_2);
+
+        put(region1_2);
+        put(region1);
+        put(region2);
+        munmap(mem, 2 * size);
+    }
+
     static void completion_cb(void *arg)
     {
         test_rcache *test = (test_rcache*)arg;
@@ -187,9 +216,11 @@ protected:
     static const uint32_t MAGIC = 0x05e905e9;
     static volatile uint32_t next_id;
     volatile uint32_t m_reg_count;
+    volatile uint64_t m_reg_bytes;
     ucs::handle<ucs_rcache_t*> m_rcache;
     void * volatile m_ptr;
     size_t m_comp_count;
+    const bool m_lock_memory;
 
 private:
 
@@ -218,6 +249,13 @@ private:
     {
         reinterpret_cast<test_rcache*>(context)->dump_region(
                         ucs_derived_of(r, struct region), buf, max);
+    }
+};
+
+class test_rcache_adjacent : public test_rcache {
+protected:
+    test_rcache_adjacent() : test_rcache(false)
+    {
     }
 };
 
@@ -405,6 +443,172 @@ UCS_MT_TEST_F(test_rcache, merge, 6) {
     put(region3);
 
     munmap(mem, size1 + pad + size2);
+}
+
+UCS_TEST_F(test_rcache_adjacent, merge_adjacent_after) {
+    test_merge_adjacent(true);
+}
+
+UCS_TEST_F(test_rcache_adjacent, merge_adjacent_before) {
+    test_merge_adjacent(false);
+}
+
+UCS_MT_TEST_F(test_rcache_adjacent, merge_adjacent_mt, 6)
+{
+    const size_t size = ucs_get_page_size();
+    region *lower_region, *upper_region, *lower_region_2;
+    void *upper;
+
+    if (barrier()) {
+        m_ptr = alloc_pages(2 * size, PROT_READ | PROT_WRITE);
+    }
+    barrier();
+
+    upper        = UCS_PTR_BYTE_OFFSET(m_ptr, size);
+    lower_region = get(m_ptr, size);
+    barrier();
+
+    upper_region = get(upper, size);
+    barrier();
+
+    lower_region_2 = get(m_ptr, size);
+    EXPECT_EQ(upper_region, lower_region_2);
+
+    put(lower_region_2);
+    put(lower_region);
+    put(upper_region);
+    if (barrier()) {
+        munmap(m_ptr, 2 * size);
+    }
+    barrier();
+}
+
+UCS_TEST_F(test_rcache_adjacent, merge_adjacent_chain)
+{
+    static const size_t num_regions = 16;
+    const size_t page_size          = ucs_get_page_size();
+    const size_t total_size         = num_regions * page_size;
+    std::vector<region*> regions;
+    std::set<region*> unique_regions;
+    void *mem;
+    region *merged;
+    size_t index;
+
+    mem = alloc_pages(total_size, PROT_READ | PROT_WRITE);
+    for (index = 0; index < num_regions; ++index) {
+        merged = get(UCS_PTR_BYTE_OFFSET(mem, index * page_size), page_size);
+        regions.push_back(merged);
+        unique_regions.insert(merged);
+    }
+
+    EXPECT_EQ(5ul, unique_regions.size());
+    EXPECT_EQ((2 * num_regions - 1) * page_size, m_reg_bytes);
+
+    merged = get(mem, total_size);
+    EXPECT_EQ(regions.back(), merged);
+    put(merged);
+
+    for (auto region : regions) {
+        put(region);
+    }
+
+    munmap(mem, total_size);
+}
+
+UCS_TEST_F(test_rcache_adjacent, do_not_merge_adjacent_when_disabled)
+{
+    const size_t size = ucs_get_page_size();
+    void *mem         = alloc_pages(2 * size, PROT_READ | PROT_WRITE);
+    void *upper       = UCS_PTR_BYTE_OFFSET(mem, size);
+    region *lower_region, *upper_region;
+    m_rcache->params.max_adjacent_size = 0;
+    lower_region = get(mem, size);
+    upper_region = get(upper, size);
+    EXPECT_NE(lower_region, upper_region);
+    EXPECT_EQ((uintptr_t)mem, lower_region->super.super.start);
+    EXPECT_EQ((uintptr_t)upper, upper_region->super.super.start);
+    put(lower_region);
+    put(upper_region);
+    munmap(mem, 2 * size);
+}
+
+UCS_TEST_F(test_rcache_adjacent, do_not_merge_adjacent_protection) {
+    const size_t size = ucs_get_page_size();
+    void *mem         = alloc_pages(2 * size, PROT_READ | PROT_WRITE);
+    void *upper       = UCS_PTR_BYTE_OFFSET(mem, size);
+    region *region1, *region2, *region1_2;
+    region1 = get(mem, size, PROT_READ);
+    region2 = get(upper, size, PROT_WRITE);
+    EXPECT_EQ((uintptr_t)upper, region2->super.super.start);
+    EXPECT_EQ((uintptr_t)upper + size, region2->super.super.end);
+    EXPECT_EQ(PROT_WRITE, region2->super.prot);
+    region1_2 = get(mem, size, PROT_READ);
+    EXPECT_EQ(region1, region1_2);
+    put(region1_2);
+    put(region1);
+    put(region2);
+    munmap(mem, 2 * size);
+}
+
+UCS_TEST_F(test_rcache, merge_different_protection_after_alignment)
+{
+    const size_t page_size = ucs_get_page_size();
+    const size_t alignment = 2 * page_size;
+    const size_t size      = 4 * page_size;
+    region *read_region, *write_region, *merged, *read_region_2;
+    void *mem = NULL;
+
+    ASSERT_EQ(0, posix_memalign(&mem, alignment, size));
+    memset(mem, 0, size);
+
+    read_region  = get(mem, page_size, PROT_READ);
+    write_region = get(UCS_PTR_BYTE_OFFSET(mem, 2 * page_size), page_size,
+                       PROT_WRITE, alignment);
+    merged       = get(UCS_PTR_BYTE_OFFSET(mem, page_size), page_size,
+                       PROT_WRITE, size);
+
+    EXPECT_EQ((uintptr_t)mem, merged->super.super.start);
+    EXPECT_EQ((uintptr_t)mem + size, merged->super.super.end);
+    EXPECT_EQ(PROT_READ | PROT_WRITE, merged->super.prot);
+
+    read_region_2 = get(mem, page_size, PROT_READ);
+    EXPECT_EQ(merged, read_region_2);
+
+    put(read_region_2);
+    put(read_region);
+    put(write_region);
+    put(merged);
+    free(mem);
+}
+
+UCS_TEST_F(test_rcache_adjacent, do_not_merge_separate_adjacent_mappings)
+{
+    const size_t size = ucs_get_page_size();
+    void *mem         = alloc_pages(2 * size, PROT_NONE);
+    void *upper       = UCS_PTR_BYTE_OFFSET(mem, size);
+    void *lower_mapping, *upper_mapping;
+    region *lower_region, *upper_region;
+    int fd;
+    ASSERT_EQ(0, munmap(mem, 2 * size));
+    fd = open("/dev/zero", O_RDWR);
+    ASSERT_GE(fd, 0);
+
+    lower_mapping = mmap(mem, size, PROT_READ | PROT_WRITE,
+                         MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_EQ(mem, lower_mapping);
+    upper_mapping = mmap(upper, size, PROT_READ | PROT_WRITE,
+                         MAP_FIXED | MAP_PRIVATE, fd, 0);
+    close(fd);
+    ASSERT_EQ(upper, upper_mapping);
+
+    lower_region = get(lower_mapping, size);
+    upper_region = get(upper_mapping, size);
+    EXPECT_NE(lower_region, upper_region);
+
+    put(lower_region);
+    put(upper_region);
+    munmap(lower_mapping, size);
+    munmap(upper_mapping, size);
 }
 
 UCS_TEST_F(test_rcache, merge_aligned)
@@ -1014,15 +1218,16 @@ UCS_TEST_F(test_rcache_stats, merge) {
 
 UCS_TEST_F(test_rcache_stats, hits_slow) {
     static const size_t size1 = 1024 * 1024;
-    region *r1, *r2;
+    region *r1, *r2, *neighbor;
     void *mem1, *mem2;
 
     mem1 = alloc_pages(size1, PROT_READ|PROT_WRITE);
     r1 = get(mem1, size1);
     put(r1);
 
-    mem2 = alloc_pages(size1, PROT_READ|PROT_WRITE);
-    r1 = get(mem2, size1);
+    mem2     = alloc_pages(2 * size1, PROT_READ | PROT_WRITE);
+    r1       = get(mem2, size1, PROT_READ);
+    neighbor = get(UCS_PTR_BYTE_OFFSET(mem2, size1), size1, PROT_WRITE);
 
     /* generate unmap event under lock, to roce using invalidation queue */
     ucs_rw_spinlock_read_lock(&m_rcache->pgt_lock);
@@ -1031,20 +1236,21 @@ UCS_TEST_F(test_rcache_stats, hits_slow) {
 
     EXPECT_EQ(1, get_counter(UCS_RCACHE_UNMAPS));
 
-    EXPECT_EQ(2, get_counter(UCS_RCACHE_GETS));
+    EXPECT_EQ(3, get_counter(UCS_RCACHE_GETS));
     EXPECT_EQ(1, get_counter(UCS_RCACHE_PUTS));
-    EXPECT_EQ(2, get_counter(UCS_RCACHE_MISSES));
+    EXPECT_EQ(3, get_counter(UCS_RCACHE_MISSES));
     EXPECT_EQ(0, get_counter(UCS_RCACHE_UNMAP_INVALIDATES));
     EXPECT_EQ(0, get_counter(UCS_RCACHE_DEREGS));
     /* it should produce a slow hit because there is
      * a pending unmap event
      */
-    r2 = get(mem2, size1);
+    r2 = get(mem2, size1, PROT_READ);
     EXPECT_EQ(1, get_counter(UCS_RCACHE_HITS_SLOW));
+    EXPECT_EQ(0, get_counter(UCS_RCACHE_MERGES));
 
-    EXPECT_EQ(3, get_counter(UCS_RCACHE_GETS));
+    EXPECT_EQ(4, get_counter(UCS_RCACHE_GETS));
     EXPECT_EQ(1, get_counter(UCS_RCACHE_PUTS));
-    EXPECT_EQ(2, get_counter(UCS_RCACHE_MISSES));
+    EXPECT_EQ(3, get_counter(UCS_RCACHE_MISSES));
     EXPECT_EQ(1, get_counter(UCS_RCACHE_UNMAPS));
     /* unmap event processed */
     EXPECT_EQ(1, get_counter(UCS_RCACHE_UNMAP_INVALIDATES));
@@ -1052,7 +1258,8 @@ UCS_TEST_F(test_rcache_stats, hits_slow) {
 
     put(r1);
     put(r2);
-    munmap(mem2, size1);
+    put(neighbor);
+    munmap(mem2, 2 * size1);
 }
 #endif
 

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -591,7 +591,9 @@ UCS_TEST_F(test_rcache_adjacent, do_not_merge_separate_adjacent_mappings)
     int fd;
     ASSERT_EQ(0, munmap(mem, 2 * size));
     fd = open("/dev/zero", O_RDWR);
-    ASSERT_GE(fd, 0);
+    if (fd < 0) {
+        UCS_TEST_ABORT("failed to open /dev/zero");
+    }
 
     lower_mapping = mmap(mem, size, PROT_READ | PROT_WRITE,
                          MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);

--- a/test/gtest/ucs/test_rcache.cc
+++ b/test/gtest/ucs/test_rcache.cc
@@ -488,13 +488,16 @@ UCS_TEST_F(test_rcache_adjacent, merge_adjacent_chain)
     static const size_t num_regions = 16;
     const size_t page_size          = ucs_get_page_size();
     const size_t total_size         = num_regions * page_size;
+    const size_t mapping_size       = total_size + (2 * page_size);
     std::vector<region*> regions;
     std::set<region*> unique_regions;
-    void *mem;
+    void *mapping, *mem;
     region *merged;
     size_t index;
 
-    mem = alloc_pages(total_size, PROT_READ | PROT_WRITE);
+    mapping = alloc_pages(mapping_size, PROT_NONE);
+    mem     = UCS_PTR_BYTE_OFFSET(mapping, page_size);
+    ASSERT_EQ(0, mprotect(mem, total_size, PROT_READ | PROT_WRITE));
     for (index = 0; index < num_regions; ++index) {
         merged = get(UCS_PTR_BYTE_OFFSET(mem, index * page_size), page_size);
         regions.push_back(merged);
@@ -512,7 +515,7 @@ UCS_TEST_F(test_rcache_adjacent, merge_adjacent_chain)
         put(region);
     }
 
-    munmap(mem, total_size);
+    munmap(mapping, mapping_size);
 }
 
 UCS_TEST_F(test_rcache_adjacent, do_not_merge_adjacent_when_disabled)


### PR DESCRIPTION
## What?

Merge directly adjacent registration-cache regions when they have matching
protection and belong to one compatible virtual-memory range. Bound the merged
range with a configurable maximum size.

## Why?

Consecutive registrations can create one cached region per adjacent buffer,
even when one registration can cover the combined address range. At high
scale, these redundant regions can exhaust device registration resources.

Naively re-registering the exact union on every adjacent request would make a
sequential first-touch chain quadratic. The merge policy therefore needs both
an amortization strategy and explicit safety bounds.

## How?

- Preserve the direct containing-region lookup on the slow path.
- Discover only immediate left and right neighbors after exact overlap
  processing.
- Require matching protection and compatible contiguous memory mappings for a
  pure adjacency merge.
- Grow successful adjacent merges geometrically, within the mapping boundary,
  to amortize sequential first-touch registration.
- Limit the resulting region with `RCACHE_MAX_ADJACENT_SIZE`; setting it to
  zero disables adjacent merging.
- Keep existing overlap and alignment semantics, including protection
  expansion when alignment creates a real overlap.
