### PR TITLE
API/UCP/UCT: Add per-endpoint traffic class

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -268,7 +268,8 @@ enum ucp_ep_params_field {
     /**< Connection request field */
     UCP_EP_PARAM_FIELD_CONN_REQUEST      = UCS_BIT(6),
     UCP_EP_PARAM_FIELD_NAME              = UCS_BIT(7), /**< Endpoint name */
-    UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR   = UCS_BIT(8)  /**< Local socket Address */
+    UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR   = UCS_BIT(8), /**< Local socket addr */
+    UCP_EP_PARAM_FIELD_TRAFFIC_CLASS     = UCS_BIT(9)  /**< Traffic class */
 };
 
 

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -268,7 +268,7 @@ enum ucp_ep_params_field {
     /**< Connection request field */
     UCP_EP_PARAM_FIELD_CONN_REQUEST      = UCS_BIT(6),
     UCP_EP_PARAM_FIELD_NAME              = UCS_BIT(7), /**< Endpoint name */
-    UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR   = UCS_BIT(8), /**< Local socket addr */
+    UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR   = UCS_BIT(8), /**< Local socket Address */
     UCP_EP_PARAM_FIELD_TRAFFIC_CLASS     = UCS_BIT(9)  /**< Traffic class */
 };
 

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -788,6 +788,23 @@ typedef struct ucp_ep_params {
      */
     ucs_sock_addr_t         local_sockaddr;
 
+    /**
+     * Traffic class for this endpoint, as a full 8-bit Type of Service value:
+     * a 6-bit Differentiated Services Code Point (DSCP) followed by 2 ECN
+     * bits. On InfiniBand it is used as the GRH Traffic Class; on RoCEv2 its
+     * upper 6 bits are used as the DSCP field of the IP header. It overrides
+     * the transport's default traffic class for this endpoint only, using the
+     * same format.
+     *
+     * Currently implemented by the RC transport over mlx5 devices with DEVX
+     * enabled, including the GGA and GDAKI transports which are based on it.
+     * Transports which do not support it, such as DC, ignore this value and
+     * keep using their default traffic class.
+     *
+     * This setting is optional. To enable it, the corresponding @ref
+     * UCP_EP_PARAM_FIELD_TRAFFIC_CLASS bit in the field mask must be set.
+     */
+    uint8_t                 traffic_class;
 } ucp_ep_params_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -374,7 +374,10 @@ typedef enum {
     UCT_EP_CONNECT_TO_EP_PARAM_FIELD_DEVICE_ADDR_LENGTH = UCS_BIT(0),
 
     /** Endpoint address length */
-    UCT_EP_CONNECT_TO_EP_PARAM_FIELD_EP_ADDR_LENGTH     = UCS_BIT(1)
+    UCT_EP_CONNECT_TO_EP_PARAM_FIELD_EP_ADDR_LENGTH     = UCS_BIT(1),
+
+    /** Traffic class */
+    UCT_EP_CONNECT_TO_EP_PARAM_FIELD_TRAFFIC_CLASS      = UCS_BIT(2)
 } uct_ep_connect_to_ep_param_field_t;
 
 
@@ -729,6 +732,25 @@ typedef struct uct_ep_connect_to_ep_params {
      * default minimal length according to the address buffer contents.
      */
     size_t                        ep_addr_length;
+
+    /**
+     * Traffic class for this endpoint, as a full 8-bit Type of Service value:
+     * a 6-bit Differentiated Services Code Point (DSCP) followed by 2 ECN
+     * bits. On InfiniBand it is used as the GRH Traffic Class; on RoCEv2 its
+     * upper 6 bits are used as the DSCP field of the IP header. It overrides
+     * the interface's default traffic class for this endpoint only, using the
+     * same format.
+     *
+     * Currently implemented by the RC transport over mlx5 devices with DEVX
+     * enabled, including the GGA and GDAKI transports which are based on it.
+     * Transports which do not support it, such as DC, ignore this value and
+     * keep using their default traffic class.
+     *
+     * This setting is optional. To enable it, the corresponding @ref
+     * UCT_EP_CONNECT_TO_EP_PARAM_FIELD_TRAFFIC_CLASS bit in the field mask
+     * must be set.
+     */
+    uint8_t                       traffic_class;
 } uct_ep_connect_to_ep_params_t;
 
 


### PR DESCRIPTION
## What

Add an optional **per-endpoint traffic class** to the UCP and UCT (v2) APIs:

* UCP: `ucp_ep_params_t::ep_traffic_class`, enabled by
  `UCP_EP_PARAM_FIELD_EP_TRAFFIC_CLASS`
* UCT: `uct_ep_connect_to_ep_params_t::ep_traffic_class`, enabled by
  `UCT_EP_CONNECT_TO_EP_PARAM_FIELD_EP_TRAFFIC_CLASS`

This PR contains **only the API definitions**. The implementation follows in a
separate PR (see "Follow-up" below).

## Why this cannot be done with the existing configuration

UCX already supports a traffic class, but only as an **interface-wide**
setting (`UCX_IB_TRAFFIC_CLASS`), programmed into every QP created on that
interface. It is a single value per process/interface.

The use case requires **several different values simultaneously within the same
process and the same interface**: endpoints belonging to different logical
groups must be tagged differently so the fabric can arbitrate between their
flows.

Concretely, for collective-communication QoS: a UCC team (≈ an MPI
communicator) is created with a priority, and every UCX endpoint opened for
that team must carry the corresponding traffic class, while endpoints of other
teams — on the same worker and the same device — keep a different one. A
higher-priority collective is then simply run on a higher-priority team.

This is a **per-connection property, known only by the caller at connect
time**. It cannot be derived from any existing parameter, and an environment
variable cannot express it, since one process needs multiple distinct values at
the same time. Hence the API addition.

The value is deliberately kept opaque and fabric-interpreted, matching what UCX
already does with the interface-wide setting: on RoCEv2 it ends up as the IP
DSCP code point, on IB as the GRH traffic class. No new semantics are
introduced — the same field UCX already programs simply becomes settable per
endpoint. Actual arbitration must still be configured on the fabric
(PFC/ETS/DSCP-to-priority mapping); UCX only carries the value.

## Backward compatibility

**Wire compatibility — unchanged.** Nothing is added to the wire protocol. The
traffic class is *not* packed into UCX addresses and *not* exchanged in wireup
messages; it is applied locally, by each side, to its own QP context at connect
time. An old peer and a new peer interoperate with a bit-identical wire format.

Each side applies its own value to its own QP, with no negotiation. If only one
side sets it, that side's outgoing packets carry its traffic class and the peer
keeps the existing default — a partial QoS effect, but no protocol breakage.
This mirrors the existing behavior of the interface-wide setting.

**ABI compatibility — preserved.** Both new fields are appended at the **end**
of their respective structures, so no existing field offset changes.

**Behavioral compatibility — none by default.** The feature is strictly opt-in
through `field_mask`. When the bit is not set, the code path is unchanged and
falls back to the existing interface-wide value, so current applications are
bit-for-bit unaffected.

## Follow-up

Implementation PR: #11618 (UCP endpoint plumbing + RC mlx5 DEVX QP
programming), rebased on top of this one once merged.