### PR TITLE
GTEST/UCS: Increase rwlock test sleep to avoid CI races

### DIFF
--- a/test/gtest/ucs/test_type.cc
+++ b/test/gtest/ucs/test_type.cc
@@ -310,6 +310,51 @@ UCS_TEST_F(test_rwlock, shared_state) {
     ucs_rw_spinlock_cleanup(&lock);
 }
 
+UCS_TEST_F(test_rwlock, publish) {
+    /* One writer and two readers looping in parallel. The writer stores seq
+     * then payloada and readers load payload then seq. Seeing the new payload
+     * is allowed only if seq was stored too.
+     */
+    const int niters       = 10000000;
+    ucs_rw_spinlock_t lock = UCS_RWLOCK_STATIC_INITIALIZER;
+    int seq                = 0;
+    int payload            = 0;
+    std::vector<std::thread> threads;
+
+    threads.reserve(3);
+    threads.emplace_back([&]() {
+        for (int n = 0; n < niters; ++n) {
+            ucs_rw_spinlock_write_lock(&lock);
+            seq++;
+            ucs_compiler_fence();
+            payload = seq;
+            ucs_rw_spinlock_write_unlock(&lock);
+        }
+    });
+    for (int i = 0; i < 2; ++i) {
+        threads.emplace_back([&]() {
+            for (int n = 0; n < niters; ++n) {
+                ucs_rw_spinlock_read_lock(&lock);
+                int p = payload;
+                ucs_compiler_fence();
+                int s = seq;
+                ucs_rw_spinlock_read_unlock(&lock);
+
+                EXPECT_EQ(s, p);
+                EXPECT_LE(s, niters);
+            }
+        });
+    }
+
+    for (auto &t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(niters, seq);
+    EXPECT_EQ(niters, payload);
+    ucs_rw_spinlock_cleanup(&lock);
+}
+
 typedef struct {
     int64_t counter[128];
 } data_t;

--- a/test/gtest/ucs/test_type.cc
+++ b/test/gtest/ucs/test_type.cc
@@ -312,7 +312,7 @@ UCS_TEST_F(test_rwlock, shared_state) {
 
 UCS_TEST_F(test_rwlock, publish) {
     /* One writer and two readers looping in parallel. The writer stores seq
-     * then payloada and readers load payload then seq. Seeing the new payload
+     * then payload and readers load payload then seq. Seeing the new payload
      * is allowed only if seq was stored too.
      */
     const int niters       = 10000000;

--- a/test/gtest/ucs/test_type.cc
+++ b/test/gtest/ucs/test_type.cc
@@ -149,7 +149,7 @@ protected:
 
     void sleep()
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
     void measure_one(int iter_count, int thread_count, int writers,


### PR DESCRIPTION
## What?
Fix flacky test, apparently under load the write thread could end-up being running after the normally subsequent reader thread.

Also added optional visibility-based test exercising the memory acquire/release aspect of the read and write lock. 

```
2026-08-20T09:37:28.4719473Z [       OK ] test_rwlock.memory_barriers (30905 ms)
2026-08-20T09:37:28.4719957Z [ RUN      ] test_rwlock.lock <> <>
2026-08-20T09:37:28.4756001Z /scrap/azure/agent-05/AZP_WORKSPACE/1/s/contrib/../test/gtest/ucs/test_type.cc:230: Failure
2026-08-20T09:37:28.4756701Z Value of: read_taken
2026-08-20T09:37:28.4757094Z   Actual: true
2026-08-20T09:37:28.4757452Z Expected: false
2026-08-20T09:37:28.4768151Z [  FAILED  ] test_rwlock.lock, where TypeParam =  and GetParam() =  (5 ms)
2026-08-20T09:37:28.4768938Z [----------] 2 tests from test_rwlock (30910 ms total)
