### PR TITLE
UCT/CUDA: Propagate system device lookup errors

### DIFF
--- a/src/uct/cuda/base/cuda_iface.c
+++ b/src/uct/cuda/base/cuda_iface.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019. ALL RIGHTS RESERVED.
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2019-2026. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -33,7 +33,10 @@ uct_cuda_base_query_devices_common(
             return status;
         }
 
-        sys_device = uct_cuda_get_sys_dev(cuda_device);
+        status = uct_cuda_get_sys_dev(cuda_device, &sys_device);
+        if (status != UCS_OK) {
+            return status;
+        }
     } else {
         ucs_debug("set cuda sys_device to `unknown` as no context is"
                   " currently active");

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -32,7 +32,8 @@ uct_cuda_base_query_md_resources(uct_component_t *component,
      * topology is always aware of all GPUs. */
     status = uct_cuda_enum_gpus(NULL, NULL);
     if (status != UCS_OK) {
-        ucs_diag("failed to enumerate all gpus: %s", ucs_status_string(status));
+        ucs_error("failed to enumerate GPUs: %s", ucs_status_string(status));
+        return status;
     }
 
     status = UCT_CUDADRV_FUNC(cuDeviceGetCount(&num_gpus), UCS_LOG_LEVEL_DIAG);
@@ -44,11 +45,13 @@ uct_cuda_base_query_md_resources(uct_component_t *component,
         status = UCT_CUDADRV_FUNC(cuDeviceGet(&cuda_device, i),
                                   UCS_LOG_LEVEL_DIAG);
         if (status != UCS_OK) {
-            continue;
+            return status;
         }
 
         status = uct_cuda_get_sys_dev(cuda_device, &sys_dev);
         if (status != UCS_OK) {
+            ucs_error("failed to get system device for GPU%d: %s", cuda_device,
+                      ucs_status_string(status));
             return status;
         }
 

--- a/src/uct/cuda/base/cuda_md.c
+++ b/src/uct/cuda/base/cuda_md.c
@@ -47,9 +47,9 @@ uct_cuda_base_query_md_resources(uct_component_t *component,
             continue;
         }
 
-        sys_dev = uct_cuda_get_sys_dev(cuda_device);
-        if (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) {
-            continue;
+        status = uct_cuda_get_sys_dev(cuda_device, &sys_dev);
+        if (status != UCS_OK) {
+            return status;
         }
 
         ucs_snprintf_safe(device_name, sizeof(device_name), "GPU%d",

--- a/src/uct/cuda/base/cuda_util.c
+++ b/src/uct/cuda/base/cuda_util.c
@@ -47,35 +47,39 @@ ucs_status_t uct_cuda_find_device_by_bus_id(const ucs_sys_bus_id_t *bus_id,
     return UCS_OK;
 }
 
-ucs_sys_device_t uct_cuda_get_sys_dev(CUdevice cuda_device)
+ucs_status_t uct_cuda_get_sys_dev_and_bus_id(CUdevice cuda_device,
+                                             ucs_sys_device_t *sys_dev_p,
+                                             ucs_sys_bus_id_t *bus_id_p)
 {
-    ucs_sys_device_t sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+    ucs_sys_device_t sys_dev;
     ucs_sys_bus_id_t bus_id;
-    CUresult cu_err;
     int attrib;
     ucs_status_t status;
 
     /* PCI domain id */
-    cu_err = cuDeviceGetAttribute(&attrib, CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID,
-                                  cuda_device);
-    if (cu_err != CUDA_SUCCESS) {
-        goto err;
+    status = UCT_CUDADRV_FUNC_LOG_DEBUG(
+            cuDeviceGetAttribute(&attrib, CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID,
+                                 cuda_device));
+    if (status != UCS_OK) {
+        return status;
     }
     bus_id.domain = (uint16_t)attrib;
 
     /* PCI bus id */
-    cu_err = cuDeviceGetAttribute(&attrib, CU_DEVICE_ATTRIBUTE_PCI_BUS_ID,
-                                  cuda_device);
-    if (cu_err != CUDA_SUCCESS) {
-        goto err;
+    status = UCT_CUDADRV_FUNC_LOG_DEBUG(
+            cuDeviceGetAttribute(&attrib, CU_DEVICE_ATTRIBUTE_PCI_BUS_ID,
+                                 cuda_device));
+    if (status != UCS_OK) {
+        return status;
     }
     bus_id.bus = (uint8_t)attrib;
 
     /* PCI slot id */
-    cu_err = cuDeviceGetAttribute(&attrib, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID,
-                                  cuda_device);
-    if (cu_err != CUDA_SUCCESS) {
-        goto err;
+    status = UCT_CUDADRV_FUNC_LOG_DEBUG(
+            cuDeviceGetAttribute(&attrib, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID,
+                                 cuda_device));
+    if (status != UCS_OK) {
+        return status;
     }
     bus_id.slot = (uint8_t)attrib;
 
@@ -85,23 +89,31 @@ ucs_sys_device_t uct_cuda_get_sys_dev(CUdevice cuda_device)
     status = ucs_topo_find_device_by_bus_id_and_user_value(
             &bus_id, (uintptr_t)cuda_device, &sys_dev);
     if (status != UCS_OK) {
-        goto err;
+        return status;
     }
 
     status = ucs_topo_sys_device_set_class(sys_dev, UCS_TOPO_DEVICE_CLASS_ACC);
     if (status != UCS_OK) {
-        goto err;
+        return status;
     }
 
     status = ucs_topo_sys_device_enable_aux_path(sys_dev);
     if (status != UCS_OK) {
-        goto err;
+        return status;
     }
 
-    return sys_dev;
+    *sys_dev_p = sys_dev;
+    if (bus_id_p != NULL) {
+        *bus_id_p = bus_id;
+    }
 
-err:
-    return UCS_SYS_DEVICE_ID_UNKNOWN;
+    return UCS_OK;
+}
+
+ucs_status_t
+uct_cuda_get_sys_dev(CUdevice cuda_device, ucs_sys_device_t *sys_dev_p)
+{
+    return uct_cuda_get_sys_dev_and_bus_id(cuda_device, sys_dev_p, NULL);
 }
 
 CUdevice uct_cuda_get_cuda_device(ucs_sys_device_t sys_dev)
@@ -148,9 +160,9 @@ uct_cuda_enum_gpus_internal(ucs_sys_device_t *sys_devs, unsigned *count_p)
                 return status;
             }
 
-            sys_dev = uct_cuda_get_sys_dev(cuda_dev);
-            if (sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) {
-                return UCS_ERR_NO_DEVICE;
+            status = uct_cuda_get_sys_dev(cuda_dev, &sys_dev);
+            if (status != UCS_OK) {
+                return status;
             }
 
             sys_devs[cuda_idx] = sys_dev;

--- a/src/uct/cuda/base/cuda_util.h
+++ b/src/uct/cuda/base/cuda_util.h
@@ -51,13 +51,29 @@ const char *uct_cuda_cu_get_error_string(CUresult result);
 
 
 /**
+ * Get the system device and PCI bus id from the CUDA device.
+ *
+ * @param [in]  cuda_device CUDA device.
+ * @param [out] sys_dev_p   System device corresponding to the CUDA device.
+ * @param [out] bus_id_p    If non-NULL, PCI bus id of the CUDA device.
+ *
+ * @return UCS_OK on success, or an error code otherwise.
+ */
+ucs_status_t uct_cuda_get_sys_dev_and_bus_id(CUdevice cuda_device,
+                                             ucs_sys_device_t *sys_dev_p,
+                                             ucs_sys_bus_id_t *bus_id_p);
+
+
+/**
  * Get the system device from the CUDA device.
  *
  * @param [in]  cuda_device CUDA device.
+ * @param [out] sys_dev_p   System device corresponding to the CUDA device.
  *
- * @return System device corresponding to the CUDA device.
+ * @return UCS_OK on success, or an error code otherwise.
  */
-ucs_sys_device_t uct_cuda_get_sys_dev(CUdevice cuda_device);
+ucs_status_t
+uct_cuda_get_sys_dev(CUdevice cuda_device, ucs_sys_device_t *sys_dev_p);
 
 
 /**

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -725,8 +725,9 @@ uct_cuda_copy_md_query_attributes(const uct_cuda_copy_md_t *md,
             if (pref_loc == CU_DEVICE_CPU) {
                 mem_info->sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
             } else {
-                mem_info->sys_dev = uct_cuda_get_sys_dev(pref_loc);
-                if (mem_info->sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) {
+                mem_info->sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+                status = uct_cuda_get_sys_dev(pref_loc, &mem_info->sys_dev);
+                if (status != UCS_OK) {
                     ucs_diag("cu_device %d (for address %p...%p) unrecognized",
                              pref_loc, address,
                              UCS_PTR_BYTE_OFFSET(address, length));
@@ -755,9 +756,9 @@ uct_cuda_copy_md_query_attributes(const uct_cuda_copy_md_t *md,
         goto out_default_range;
     }
 
-    mem_info->sys_dev = uct_cuda_get_sys_dev(cuda_device);
-    if (mem_info->sys_dev == UCS_SYS_DEVICE_ID_UNKNOWN) {
-        return UCS_ERR_NO_DEVICE;
+    status = uct_cuda_get_sys_dev(cuda_device, &mem_info->sys_dev);
+    if (status != UCS_OK) {
+        return status;
     }
 
     uct_cuda_copy_md_sync_memops_get_address_range(md, (CUdeviceptr)address,

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -722,10 +722,8 @@ uct_cuda_copy_md_query_attributes(const uct_cuda_copy_md_t *md,
                                    cuda_device;
             }
 
-            if (pref_loc == CU_DEVICE_CPU) {
-                mem_info->sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
-            } else {
-                mem_info->sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+            mem_info->sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+            if (pref_loc != CU_DEVICE_CPU) {
                 status = uct_cuda_get_sys_dev(pref_loc, &mem_info->sys_dev);
                 if (status != UCS_OK) {
                     ucs_diag("cu_device %d (for address %p...%p) unrecognized",

--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -931,7 +931,11 @@ uct_rc_gdaki_iface_query(uct_iface_h tl_iface, uct_iface_attr_t *iface_attr)
     iface_attr->cap.put.min_zcopy = 0;
     iface_attr->cap.put.max_zcopy =
             uct_ib_iface_port_attr(&iface->super.super.super)->max_msg_sz;
-    iface_attr->ctl_device    = uct_cuda_get_sys_dev(iface->cuda_dev);
+    status = uct_cuda_get_sys_dev(iface->cuda_dev, &iface_attr->ctl_device);
+    if (status != UCS_OK) {
+        return status;
+    }
+
     iface_attr->dev_num_paths = 1;
 
     return UCS_OK;
@@ -1270,7 +1274,8 @@ static int uct_gdaki_dev_matrix_score(const void *pa, const void *pb, void *arg)
 }
 
 static ucs_status_t
-uct_gdaki_get_cuda_sys_dev(int cuda_idx, ucs_sys_device_t *sys_dev_p)
+uct_gdaki_get_cuda_sys_dev_and_bus_id(int cuda_idx, ucs_sys_device_t *sys_dev_p,
+                                      ucs_sys_bus_id_t *bus_id_p)
 {
     ucs_status_t status;
     CUdevice cuda_dev;
@@ -1280,8 +1285,7 @@ uct_gdaki_get_cuda_sys_dev(int cuda_idx, ucs_sys_device_t *sys_dev_p)
         return status;
     }
 
-    *sys_dev_p = uct_cuda_get_sys_dev(cuda_dev);
-    return UCS_OK;
+    return uct_cuda_get_sys_dev_and_bus_id(cuda_dev, sys_dev_p, bus_id_p);
 }
 
 static ucs_status_t
@@ -1306,12 +1310,8 @@ uct_gdaki_enum_gpus(uct_gdaki_gpu_info_t *gpus, unsigned *count_p)
 
     cuda_gpu_count = 0;
     for (cuda_idx = 0; cuda_idx < cuda_dev_count; cuda_idx++) {
-        status = uct_gdaki_get_cuda_sys_dev(cuda_idx, &sys_dev);
-        if (status != UCS_OK) {
-            return status;
-        }
-
-        status = ucs_topo_get_device_bus_id(sys_dev, &bus_id);
+        status = uct_gdaki_get_cuda_sys_dev_and_bus_id(cuda_idx, &sys_dev,
+                                                       &bus_id);
         if (status != UCS_OK) {
             return status;
         }

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2024. ALL RIGHTS RESERVED.
+ * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2024-2026. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -152,8 +152,8 @@ protected:
                unpack_rkey(unpack_params);
 
                // No context and some valid sys_dev is provided
-               ucs_sys_device_t sys_dev = uct_cuda_get_sys_dev(0);
-               unpack_params.sys_device = sys_dev;
+               EXPECT_UCS_OK(
+                       uct_cuda_get_sys_dev(0, &unpack_params.sys_device));
                unpack_rkey(unpack_params);
            } catch (...) {
                thread_exception = std::current_exception();


### PR DESCRIPTION
## What?
- Propagate CUDA system-device lookup failures instead of converting them to `UCS_SYS_DEVICE_ID_UNKNOWN`.
- Propagate errors instead of ignoring them when initializing CUDA devices.
- Return the `bus_id` from `uct_cuda_get_sys_dev` to avoid calling another getter right after.

## Why?
Failure during these functions may cause unexpected results,
This strict error handling is required to ensure that the NVML based registration is done only after a device registration is fully complete by the CUDA driver, to avoid duplicate registration of the same device.
(Another NVML cleanup PR to follow).
