### PR TITLE
UCT/GDAKI: Revert check for HCA reachability like rc_mlx5 - v1.22.x (…

### DIFF
--- a/src/uct/ib/mlx5/gdaki/gdaki.c
+++ b/src/uct/ib/mlx5/gdaki/gdaki.c
@@ -1065,7 +1065,7 @@ static uct_rc_iface_ops_t uct_rc_gdaki_internal_ops = {
             .ep_query               = (uct_ep_query_func_t)ucs_empty_function_return_unsupported,
             .ep_invalidate          = (uct_ep_invalidate_func_t)ucs_empty_function_return_unsupported,
             .ep_connect_to_ep_v2    = uct_rc_gdaki_ep_connect_to_ep_v2,
-            .iface_is_reachable_v2  = uct_ib_iface_is_reachable_v2,
+            .iface_is_reachable_v2  = (uct_iface_is_reachable_v2_func_t)ucs_empty_function_return_one_int,
             .ep_is_connected        = uct_rc_gdaki_ep_is_connected,
             .ep_get_device_ep       = uct_rc_gdaki_ep_get_device_ep,
         },

--- a/test/gtest/uct/test_uct_iface.cc
+++ b/test/gtest/uct/test_uct_iface.cc
@@ -98,4 +98,3 @@ UCS_TEST_P(test_uct_iface, is_reachable)
 }
 
 UCT_INSTANTIATE_TEST_CASE(test_uct_iface)
-_UCT_INSTANTIATE_TEST_CASE(test_uct_iface, rc_gda)


### PR DESCRIPTION
## What?
Revert #11801 

## Why?
Reachability check of ib can be wrong for gda
