### PR TITLE
UCT/IB/MLX5: Track RC send PSN with path MTU

### DIFF
--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -532,6 +532,7 @@ uct_gga_mlx5_ep_connect_to_ep_v2(uct_ep_h tl_ep,
         return status;
     }
 
+    uct_rc_mlx5_txwq_set_path_mtu(&ep->super.tx.wq, path_mtu);
     ep->super.super.atomic_mr_offset = 0;
     ep->super.super.flags           |= UCT_RC_EP_FLAG_CONNECTED;
     ep->super.super.flush_rkey       =

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -696,7 +696,7 @@ void uct_ib_mlx5_txwq_reset(uct_ib_mlx5_txwq_t *txwq)
     txwq->curr           = txwq->qstart;
     txwq->sw_pi          = 0;
     txwq->prev_sw_pi     = UINT16_MAX;
-    txwq->next_first_psn = 0;
+    txwq->next_wqe_psn   = 0;
     txwq->path_mtu_mask  = 0;
     txwq->path_mtu_shift = 0;
 #if UCS_ENABLE_ASSERT
@@ -716,14 +716,13 @@ void uct_ib_mlx5_init_wq_buf(uct_ib_mlx5_txwq_t *txwq)
 }
 
 static void
-uct_ib_mlx5_txwq_vfs_show_next_first_psn(void *obj,
-                                         ucs_string_buffer_t *strb,
-                                         void *arg_ptr, uint64_t arg_u64)
+uct_ib_mlx5_txwq_vfs_show_next_wqe_psn(void *obj, ucs_string_buffer_t *strb,
+                                       void *arg_ptr, uint64_t arg_u64)
 {
     uct_ib_mlx5_txwq_t *txwq = arg_ptr;
 
     ucs_string_buffer_appendf(
-            strb, "%u\n", uct_ib_mlx5_txwq_get_next_first_psn(txwq));
+            strb, "%u\n", uct_ib_mlx5_txwq_get_next_wqe_psn(txwq));
 }
 
 void uct_ib_mlx5_txwq_vfs_populate(uct_ib_mlx5_txwq_t *txwq, void *parent_obj)
@@ -736,8 +735,8 @@ void uct_ib_mlx5_txwq_vfs_populate(uct_ib_mlx5_txwq_t *txwq, void *parent_obj)
     ucs_vfs_obj_add_ro_file(parent_obj, ucs_vfs_show_primitive,
                             &txwq->prev_sw_pi, UCS_VFS_TYPE_U16, "prev_sw_pi");
     ucs_vfs_obj_add_ro_file(parent_obj,
-                            uct_ib_mlx5_txwq_vfs_show_next_first_psn, txwq, 0,
-                            "next_first_psn");
+                            uct_ib_mlx5_txwq_vfs_show_next_wqe_psn, txwq, 0,
+                            "next_wqe_psn");
     ucs_vfs_obj_add_ro_file(parent_obj, ucs_vfs_show_primitive, &txwq->qstart,
                             UCS_VFS_TYPE_POINTER, "qstart");
     ucs_vfs_obj_add_ro_file(parent_obj, ucs_vfs_show_primitive, &txwq->qend,

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -697,6 +697,7 @@ void uct_ib_mlx5_txwq_reset(uct_ib_mlx5_txwq_t *txwq)
     txwq->sw_pi          = 0;
     txwq->prev_sw_pi     = UINT16_MAX;
     txwq->next_first_psn = 0;
+    txwq->path_mtu_mask  = 0;
     txwq->path_mtu_shift = 0;
 #if UCS_ENABLE_ASSERT
     txwq->hw_ci          = 0xFFFF;

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -715,7 +715,6 @@ void uct_ib_mlx5_init_wq_buf(uct_ib_mlx5_txwq_t *txwq)
     uct_ib_mlx5_set_ctrl_qpn_ds(uct_ib_mlx5_txwq_get_wqe(txwq, 0xffff), 0, 1);
 }
 
-
 static void
 uct_ib_mlx5_txwq_vfs_show_next_first_psn(void *obj,
                                          ucs_string_buffer_t *strb,
@@ -726,7 +725,6 @@ uct_ib_mlx5_txwq_vfs_show_next_first_psn(void *obj,
     ucs_string_buffer_appendf(
             strb, "%u\n", uct_ib_mlx5_txwq_get_next_first_psn(txwq));
 }
-
 
 void uct_ib_mlx5_txwq_vfs_populate(uct_ib_mlx5_txwq_t *txwq, void *parent_obj)
 {

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -697,7 +697,6 @@ void uct_ib_mlx5_txwq_reset(uct_ib_mlx5_txwq_t *txwq)
     txwq->sw_pi           = 0;
     txwq->prev_sw_pi      = UINT16_MAX;
     txwq->next_first_psn  = 0;
-    txwq->path_mtu_mask   = 0;
     txwq->path_mtu_shift  = 0;
 #if UCS_ENABLE_ASSERT
     txwq->hw_ci      = 0xFFFF;

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -693,9 +693,12 @@ void uct_ib_mlx5_devx_uar_cleanup(uct_ib_mlx5_devx_uar_t *uar)
 
 void uct_ib_mlx5_txwq_reset(uct_ib_mlx5_txwq_t *txwq)
 {
-    txwq->curr       = txwq->qstart;
-    txwq->sw_pi      = 0;
-    txwq->prev_sw_pi = UINT16_MAX;
+    txwq->curr            = txwq->qstart;
+    txwq->sw_pi           = 0;
+    txwq->prev_sw_pi      = UINT16_MAX;
+    txwq->next_first_psn  = 0;
+    txwq->path_mtu_mask   = 0;
+    txwq->path_mtu_shift  = 0;
 #if UCS_ENABLE_ASSERT
     txwq->hw_ci      = 0xFFFF;
     txwq->flags      = 0;
@@ -721,6 +724,9 @@ void uct_ib_mlx5_txwq_vfs_populate(uct_ib_mlx5_txwq_t *txwq, void *parent_obj)
                             UCS_VFS_TYPE_U16, "sw_pi");
     ucs_vfs_obj_add_ro_file(parent_obj, ucs_vfs_show_primitive,
                             &txwq->prev_sw_pi, UCS_VFS_TYPE_U16, "prev_sw_pi");
+    ucs_vfs_obj_add_ro_file(parent_obj, ucs_vfs_show_primitive,
+                            &txwq->next_first_psn, UCS_VFS_TYPE_U32,
+                            "next_first_psn");
     ucs_vfs_obj_add_ro_file(parent_obj, ucs_vfs_show_primitive, &txwq->qstart,
                             UCS_VFS_TYPE_POINTER, "qstart");
     ucs_vfs_obj_add_ro_file(parent_obj, ucs_vfs_show_primitive, &txwq->qend,

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -693,14 +693,14 @@ void uct_ib_mlx5_devx_uar_cleanup(uct_ib_mlx5_devx_uar_t *uar)
 
 void uct_ib_mlx5_txwq_reset(uct_ib_mlx5_txwq_t *txwq)
 {
-    txwq->curr            = txwq->qstart;
-    txwq->sw_pi           = 0;
-    txwq->prev_sw_pi      = UINT16_MAX;
-    txwq->next_first_psn  = 0;
-    txwq->path_mtu_shift  = 0;
+    txwq->curr           = txwq->qstart;
+    txwq->sw_pi          = 0;
+    txwq->prev_sw_pi     = UINT16_MAX;
+    txwq->next_first_psn = 0;
+    txwq->path_mtu_shift = 0;
 #if UCS_ENABLE_ASSERT
-    txwq->hw_ci      = 0xFFFF;
-    txwq->flags      = 0;
+    txwq->hw_ci          = 0xFFFF;
+    txwq->flags          = 0;
 #endif
     uct_ib_fence_info_init(&txwq->fi);
 }

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -715,6 +715,19 @@ void uct_ib_mlx5_init_wq_buf(uct_ib_mlx5_txwq_t *txwq)
     uct_ib_mlx5_set_ctrl_qpn_ds(uct_ib_mlx5_txwq_get_wqe(txwq, 0xffff), 0, 1);
 }
 
+
+static void
+uct_ib_mlx5_txwq_vfs_show_next_first_psn(void *obj,
+                                         ucs_string_buffer_t *strb,
+                                         void *arg_ptr, uint64_t arg_u64)
+{
+    uct_ib_mlx5_txwq_t *txwq = arg_ptr;
+
+    ucs_string_buffer_appendf(
+            strb, "%u\n", uct_ib_mlx5_txwq_get_next_first_psn(txwq));
+}
+
+
 void uct_ib_mlx5_txwq_vfs_populate(uct_ib_mlx5_txwq_t *txwq, void *parent_obj)
 {
     ucs_vfs_obj_add_ro_file(parent_obj, ucs_vfs_show_primitive,
@@ -724,8 +737,8 @@ void uct_ib_mlx5_txwq_vfs_populate(uct_ib_mlx5_txwq_t *txwq, void *parent_obj)
                             UCS_VFS_TYPE_U16, "sw_pi");
     ucs_vfs_obj_add_ro_file(parent_obj, ucs_vfs_show_primitive,
                             &txwq->prev_sw_pi, UCS_VFS_TYPE_U16, "prev_sw_pi");
-    ucs_vfs_obj_add_ro_file(parent_obj, ucs_vfs_show_primitive,
-                            &txwq->next_first_psn, UCS_VFS_TYPE_U32,
+    ucs_vfs_obj_add_ro_file(parent_obj,
+                            uct_ib_mlx5_txwq_vfs_show_next_first_psn, txwq, 0,
                             "next_first_psn");
     ucs_vfs_obj_add_ro_file(parent_obj, ucs_vfs_show_primitive, &txwq->qstart,
                             UCS_VFS_TYPE_POINTER, "qstart");

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -686,7 +686,8 @@ typedef struct uct_ib_mlx5_txwq {
     uct_ib_mlx5_qp_t            super;
     uint16_t                    sw_pi;      /* PI for next WQE */
     uint16_t                    prev_sw_pi; /* PI where last WQE *started*  */
-    uint32_t                    next_first_psn; /* Free-running PSN counter */
+    uint32_t                    next_wqe_psn; /* 1st PSN of the next WQE to be
+                                                posted */
     uct_ib_mlx5_mmio_reg_t      *reg;
     void                        *curr;
     volatile uint32_t           *dbrec;
@@ -705,9 +706,9 @@ typedef struct uct_ib_mlx5_txwq {
 
 
 static UCS_F_ALWAYS_INLINE uint32_t
-uct_ib_mlx5_txwq_get_next_first_psn(const uct_ib_mlx5_txwq_t *txwq)
+uct_ib_mlx5_txwq_get_next_wqe_psn(const uct_ib_mlx5_txwq_t *txwq)
 {
-    return txwq->next_first_psn & UCS_MASK(24);
+    return txwq->next_wqe_psn & UCS_MASK(24);
 }
 
 

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -694,7 +694,6 @@ typedef struct uct_ib_mlx5_txwq {
     void                        *qend;
     uint16_t                    bb_max;
     uint16_t                    sig_pi;     /* PI for last signaled WQE */
-    uint16_t                    path_mtu_mask;  /* Path MTU in bytes - 1 */
     uint8_t                     path_mtu_shift; /* log2(path MTU in bytes) */
 #if UCS_ENABLE_ASSERT
     uint16_t                    hw_ci; /* First BB index of last completed WQE */

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -694,6 +694,7 @@ typedef struct uct_ib_mlx5_txwq {
     void                        *qend;
     uint16_t                    bb_max;
     uint16_t                    sig_pi;     /* PI for last signaled WQE */
+    uint16_t                    path_mtu_mask;  /* Path MTU in bytes - 1 */
     uint8_t                     path_mtu_shift; /* log2(path MTU in bytes) */
 #if UCS_ENABLE_ASSERT
     uint16_t                    hw_ci; /* First BB index of last completed WQE */

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -686,6 +686,9 @@ typedef struct uct_ib_mlx5_txwq {
     uct_ib_mlx5_qp_t            super;
     uint16_t                    sw_pi;      /* PI for next WQE */
     uint16_t                    prev_sw_pi; /* PI where last WQE *started*  */
+    uint32_t                    next_first_psn; /* First PSN of next WQE */
+    uint16_t                    path_mtu_mask;  /* Path MTU in bytes - 1 */
+    uint8_t                     path_mtu_shift; /* log2(path MTU in bytes) */
     uct_ib_mlx5_mmio_reg_t      *reg;
     void                        *curr;
     volatile uint32_t           *dbrec;

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -686,7 +686,7 @@ typedef struct uct_ib_mlx5_txwq {
     uct_ib_mlx5_qp_t            super;
     uint16_t                    sw_pi;      /* PI for next WQE */
     uint16_t                    prev_sw_pi; /* PI where last WQE *started*  */
-    uint32_t                    next_first_psn; /* First PSN of next WQE */
+    uint32_t                    next_first_psn; /* Free-running PSN counter */
     uct_ib_mlx5_mmio_reg_t      *reg;
     void                        *curr;
     volatile uint32_t           *dbrec;
@@ -702,6 +702,13 @@ typedef struct uct_ib_mlx5_txwq {
 #endif
     uct_ib_fence_info_t         fi;
 } uct_ib_mlx5_txwq_t;
+
+
+static UCS_F_ALWAYS_INLINE uint32_t
+uct_ib_mlx5_txwq_get_next_first_psn(const uct_ib_mlx5_txwq_t *txwq)
+{
+    return txwq->next_first_psn & UCS_MASK(24);
+}
 
 
 /* Receive work-queue */

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -687,8 +687,6 @@ typedef struct uct_ib_mlx5_txwq {
     uint16_t                    sw_pi;      /* PI for next WQE */
     uint16_t                    prev_sw_pi; /* PI where last WQE *started*  */
     uint32_t                    next_first_psn; /* First PSN of next WQE */
-    uint16_t                    path_mtu_mask;  /* Path MTU in bytes - 1 */
-    uint8_t                     path_mtu_shift; /* log2(path MTU in bytes) */
     uct_ib_mlx5_mmio_reg_t      *reg;
     void                        *curr;
     volatile uint32_t           *dbrec;
@@ -696,6 +694,8 @@ typedef struct uct_ib_mlx5_txwq {
     void                        *qend;
     uint16_t                    bb_max;
     uint16_t                    sig_pi;     /* PI for last signaled WQE */
+    uint16_t                    path_mtu_mask;  /* Path MTU in bytes - 1 */
+    uint8_t                     path_mtu_shift; /* log2(path MTU in bytes) */
 #if UCS_ENABLE_ASSERT
     uint16_t                    hw_ci; /* First BB index of last completed WQE */
     uint8_t                     flags; /* Debug flags */

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -541,15 +541,6 @@ size_t uct_ib_mlx5_set_data_seg_iov_length(uct_ib_mlx5_txwq_t *txwq,
 }
 
 
-static UCS_F_ALWAYS_INLINE
-size_t uct_ib_mlx5_set_data_seg_iov(uct_ib_mlx5_txwq_t *txwq,
-                                    struct mlx5_wqe_data_seg *dptr,
-                                    const uct_iov_t *iov, size_t iovcnt)
-{
-    return uct_ib_mlx5_set_data_seg_iov_length(txwq, dptr, iov, iovcnt, NULL);
-}
-
-
 static UCS_F_ALWAYS_INLINE void uct_ib_mlx5_bf_copy_bb(void * restrict dst,
                                                        void * restrict src)
 {

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -507,12 +507,15 @@ uct_ib_mlx5_set_data_seg(struct mlx5_wqe_data_seg *dptr,
 
 
 static UCS_F_ALWAYS_INLINE
-size_t uct_ib_mlx5_set_data_seg_iov(uct_ib_mlx5_txwq_t *txwq,
-                                    struct mlx5_wqe_data_seg *dptr,
-                                    const uct_iov_t *iov, size_t iovcnt)
+size_t uct_ib_mlx5_set_data_seg_iov_length(uct_ib_mlx5_txwq_t *txwq,
+                                           struct mlx5_wqe_data_seg *dptr,
+                                           const uct_iov_t *iov, size_t iovcnt,
+                                           size_t *iov_length_p)
 {
-    size_t wqe_size = 0;
+    size_t iov_length = 0;
+    size_t wqe_size   = 0;
     size_t iov_it;
+    size_t length;
 
     for (iov_it = 0; iov_it < iovcnt; ++iov_it) {
         if (!iov[iov_it].length) { /* Skip zero length WQE*/
@@ -522,14 +525,28 @@ size_t uct_ib_mlx5_set_data_seg_iov(uct_ib_mlx5_txwq_t *txwq,
 
         /* place data into the buffer */
         dptr = uct_ib_mlx5_txwq_wrap_any(txwq, dptr);
-        uct_ib_mlx5_set_data_seg(dptr, iov[iov_it].buffer,
-                                 uct_iov_get_length(iov + iov_it),
+        length = uct_iov_get_length(iov + iov_it);
+        uct_ib_mlx5_set_data_seg(dptr, iov[iov_it].buffer, length,
                                  uct_ib_memh_get_lkey(iov[iov_it].memh));
-        wqe_size += sizeof(*dptr);
+        iov_length += length;
+        wqe_size   += sizeof(*dptr);
         ++dptr;
     }
 
+    if (iov_length_p != NULL) {
+        *iov_length_p = iov_length;
+    }
+
     return wqe_size;
+}
+
+
+static UCS_F_ALWAYS_INLINE
+size_t uct_ib_mlx5_set_data_seg_iov(uct_ib_mlx5_txwq_t *txwq,
+                                    struct mlx5_wqe_data_seg *dptr,
+                                    const uct_iov_t *iov, size_t iovcnt)
+{
+    return uct_ib_mlx5_set_data_seg_iov_length(txwq, dptr, iov, iovcnt, NULL);
 }
 
 

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -507,10 +507,10 @@ uct_ib_mlx5_set_data_seg(struct mlx5_wqe_data_seg *dptr,
 
 
 static UCS_F_ALWAYS_INLINE
-size_t uct_ib_mlx5_set_data_seg_iov_length(uct_ib_mlx5_txwq_t *txwq,
-                                           struct mlx5_wqe_data_seg *dptr,
-                                           const uct_iov_t *iov, size_t iovcnt,
-                                           size_t *iov_length_p)
+size_t uct_ib_mlx5_set_data_seg_iov(uct_ib_mlx5_txwq_t *txwq,
+                                    struct mlx5_wqe_data_seg *dptr,
+                                    const uct_iov_t *iov, size_t iovcnt,
+                                    size_t *iov_length_p)
 {
     size_t iov_length = 0;
     size_t wqe_size   = 0;

--- a/src/uct/ib/mlx5/rc/rc_mlx5.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.h
@@ -213,6 +213,9 @@ ucs_status_t uct_rc_mlx5_iface_create_qp(uct_rc_mlx5_iface_common_t *iface,
                                          uct_ib_mlx5_txwq_t *txwq,
                                          uct_ib_mlx5_qp_attr_t *attr);
 
+void uct_rc_mlx5_txwq_set_path_mtu(uct_ib_mlx5_txwq_t *txwq,
+                                    enum ibv_mtu path_mtu);
+
 ucs_status_t
 uct_rc_mlx5_ep_connect_qp(uct_rc_mlx5_iface_common_t *iface,
                           uct_ib_mlx5_qp_t *qp, uint32_t qp_num,

--- a/src/uct/ib/mlx5/rc/rc_mlx5.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.h
@@ -214,7 +214,7 @@ ucs_status_t uct_rc_mlx5_iface_create_qp(uct_rc_mlx5_iface_common_t *iface,
                                          uct_ib_mlx5_qp_attr_t *attr);
 
 void uct_rc_mlx5_txwq_set_path_mtu(uct_ib_mlx5_txwq_t *txwq,
-                                    enum ibv_mtu path_mtu);
+                                   enum ibv_mtu path_mtu);
 
 ucs_status_t
 uct_rc_mlx5_ep_connect_qp(uct_rc_mlx5_iface_common_t *iface,

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -479,8 +479,7 @@ uct_rc_mlx5_num_packets(const uct_ib_mlx5_txwq_t *txwq,
 static UCS_F_ALWAYS_INLINE void
 uct_rc_mlx5_txwq_add_psn(uct_ib_mlx5_txwq_t *txwq, uint32_t num_packets)
 {
-    txwq->next_first_psn =
-            (txwq->next_first_psn + num_packets) & UCS_MASK(24);
+    txwq->next_first_psn += num_packets;
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -467,7 +467,7 @@ uct_rc_mlx5_txwq_add_psn(uct_ib_mlx5_txwq_t *txwq, int qp_type,
                          uint32_t num_packets)
 {
     if (qp_type == IBV_QPT_RC) {
-        txwq->next_first_psn += num_packets;
+        txwq->next_wqe_psn += num_packets;
     }
 }
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -479,12 +479,11 @@ static UCS_F_ALWAYS_INLINE void
 uct_rc_mlx5_txwq_update_psn(uct_ib_mlx5_txwq_t *txwq, int qp_type,
                             size_t message_length)
 {
-    if (qp_type != IBV_QPT_RC) {
-        return;
+    if (qp_type == IBV_QPT_RC) {
+        uct_rc_mlx5_txwq_add_psn(txwq, qp_type,
+                                 uct_rc_mlx5_num_packets(txwq,
+                                                        message_length));
     }
-
-    uct_rc_mlx5_txwq_add_psn(txwq, qp_type,
-                             uct_rc_mlx5_num_packets(txwq, message_length));
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -900,7 +900,7 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
         /* Data segment with payload */
         dptr             = (struct mlx5_wqe_data_seg *)((char *)inl + inl_seg_size);
         wqe_size         = ctrl_av_size + inl_seg_size +
-                           uct_ib_mlx5_set_data_seg_iov_length(
+                           uct_ib_mlx5_set_data_seg_iov(
                                    txwq, dptr, iov, iovcnt, &iov_length);
         opmod            = 0;
         message_length   = iov_length + sizeof(*rch) + am_hdr_len;
@@ -918,7 +918,7 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
         inl->byte_count  = htonl(sizeof(struct ibv_tmh) | MLX5_INLINE_SEG);
         dptr             = uct_ib_mlx5_txwq_wrap_exact(txwq, (char *)inl + inl_seg_size);
         wqe_size         = ctrl_av_size + inl_seg_size +
-                           uct_ib_mlx5_set_data_seg_iov_length(
+                           uct_ib_mlx5_set_data_seg_iov(
                                    txwq, dptr, iov, iovcnt, &iov_length);
         opmod            = 0;
         message_length   = iov_length + sizeof(struct ibv_tmh);
@@ -939,7 +939,7 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
 
         /* Data segment */
         wqe_size = ctrl_av_size + sizeof(*raddr) +
-                   uct_ib_mlx5_set_data_seg_iov_length(
+                   uct_ib_mlx5_set_data_seg_iov(
                            txwq, (void*)(raddr + 1), iov, iovcnt,
                            &message_length);
         opmod    = 0;

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -461,7 +461,6 @@ uct_rc_mlx5_txwq_set_path_mtu(uct_ib_mlx5_txwq_t *txwq,
     ucs_assert(mtu <= UINT16_MAX);
     ucs_assert(ucs_is_pow2(mtu));
 
-    txwq->path_mtu_mask  = mtu - 1;
     txwq->path_mtu_shift = ucs_ilog2(mtu);
 }
 
@@ -469,11 +468,14 @@ static UCS_F_ALWAYS_INLINE uint32_t
 uct_rc_mlx5_num_packets(const uct_ib_mlx5_txwq_t *txwq,
                         size_t message_length)
 {
+    uint32_t num_packets;
+
     ucs_assert(txwq->path_mtu_shift > 0);
 
-    return ucs_max((size_t)1,
-                   (message_length + txwq->path_mtu_mask) >>
-                           txwq->path_mtu_shift);
+    num_packets = (message_length + UCS_MASK(txwq->path_mtu_shift)) >>
+                  txwq->path_mtu_shift;
+    ucs_assert(num_packets > 0);
+    return num_packets;
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -453,6 +453,45 @@ uct_rc_mlx5_ep_fm_cq_update(uct_rc_mlx5_iface_common_t *iface,
 }
 
 static UCS_F_ALWAYS_INLINE void
+uct_rc_mlx5_txwq_set_path_mtu(uct_ib_mlx5_txwq_t *txwq,
+                              enum ibv_mtu path_mtu)
+{
+    size_t mtu = uct_ib_mtu_value(path_mtu);
+
+    ucs_assert(mtu <= UINT16_MAX);
+    ucs_assert(ucs_is_pow2(mtu));
+
+    txwq->path_mtu_mask  = mtu - 1;
+    txwq->path_mtu_shift = ucs_ilog2(mtu);
+}
+
+static UCS_F_ALWAYS_INLINE uint32_t
+uct_rc_mlx5_num_packets(const uct_ib_mlx5_txwq_t *txwq,
+                        size_t message_length)
+{
+    ucs_assert(txwq->path_mtu_shift > 0);
+
+    return ucs_max((size_t)1,
+                   (message_length + txwq->path_mtu_mask) >>
+                           txwq->path_mtu_shift);
+}
+
+static UCS_F_ALWAYS_INLINE void
+uct_rc_mlx5_txwq_add_psn(uct_ib_mlx5_txwq_t *txwq, uint32_t num_packets)
+{
+    txwq->next_first_psn =
+            (txwq->next_first_psn + num_packets) & UCS_MASK(24);
+}
+
+static UCS_F_ALWAYS_INLINE void
+uct_rc_mlx5_txwq_update_psn(uct_ib_mlx5_txwq_t *txwq,
+                            size_t message_length)
+{
+    uct_rc_mlx5_txwq_add_psn(txwq,
+                             uct_rc_mlx5_num_packets(txwq, message_length));
+}
+
+static UCS_F_ALWAYS_INLINE void
 uct_rc_mlx5_common_post_send(uct_rc_mlx5_iface_common_t *iface, int qp_type,
                              uct_rc_txqp_t *txqp, uct_ib_mlx5_txwq_t *txwq,
                              uint8_t opcode, uint8_t opmod, uint8_t fm_ce_se,
@@ -532,6 +571,9 @@ static UCS_F_ALWAYS_INLINE void uct_rc_mlx5_txqp_inline_iov_post(
     uct_rc_mlx5_common_post_send(iface, qp_type, txqp, txwq, MLX5_OPCODE_SEND,
                                  0, fm_ce_se, dci_channel, wqe_size, 0,
                                  INT_MAX, NULL);
+    if (qp_type == IBV_QPT_RC) {
+        uct_rc_mlx5_txwq_add_psn(txwq, 1);
+    }
 }
 
 /*
@@ -627,6 +669,10 @@ uct_rc_mlx5_txqp_inline_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
     uct_rc_mlx5_common_post_send(iface, qp_type, txqp, txwq, opcode, 0, fm_ce_se,
                                  dci_channel, wqe_size, imm_val_be,
                                  max_log_sge, NULL);
+    if ((qp_type == IBV_QPT_RC) && (opcode != MLX5_OPCODE_NOP)) {
+        /* Inline short operations always fit in one RC packet. */
+        uct_rc_mlx5_txwq_add_psn(txwq, 1);
+    }
 }
 
 /*
@@ -810,6 +856,9 @@ uct_rc_mlx5_txqp_dptr_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
                                  (opcode_flags & UCT_RC_MLX5_OPCODE_MASK), opmod,
                                  fm_ce_se, dci_channel, wqe_size, imm_val_be,
                                  max_log_sge, log_sge);
+    if (qp_type == IBV_QPT_RC) {
+        uct_rc_mlx5_txwq_update_psn(txwq, length);
+    }
 }
 
 static UCS_F_ALWAYS_INLINE
@@ -830,6 +879,7 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
     struct mlx5_wqe_inl_data_seg *inl;
     uct_rc_mlx5_hdr_t            *rch;
     unsigned                     wqe_size, inl_seg_size, ctrl_av_size;
+    size_t                       message_length;
     void                         *next_seg;
     uint8_t                      opmod;
 #if HAVE_MLX5_MMO
@@ -868,6 +918,8 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
         wqe_size         = ctrl_av_size + inl_seg_size +
                            uct_ib_mlx5_set_data_seg_iov(txwq, dptr, iov, iovcnt);
         opmod            = 0;
+        message_length   = uct_iov_total_length(iov, iovcnt) + sizeof(*rch) +
+                           am_hdr_len;
 
         ucs_assert(wqe_size <= UCT_IB_MLX5_MAX_SEND_WQE_SIZE);
         break;
@@ -883,6 +935,8 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
         wqe_size         = ctrl_av_size + inl_seg_size +
                            uct_ib_mlx5_set_data_seg_iov(txwq, dptr, iov, iovcnt);
         opmod            = 0;
+        message_length   = uct_iov_total_length(iov, iovcnt) +
+                           sizeof(struct ibv_tmh);
 
         uct_rc_mlx5_fill_tmh((struct ibv_tmh*)(inl + 1), tag, app_ctx,
                              IBV_TMH_EAGER);
@@ -905,6 +959,7 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
                            uct_ib_mlx5_set_data_seg_iov(txwq, (void*)(raddr + 1),
                                                         iov, iovcnt);
         opmod            = 0;
+        message_length   = uct_iov_total_length(iov, iovcnt);
         break;
 
 #if HAVE_MLX5_MMO
@@ -940,6 +995,7 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
 
         wqe_size = sizeof(*ctrl) + sizeof(*dma_seg) + (2 * sizeof(*dptr));
         opmod    = UCT_IB_MLX5_OPMOD_MMO_DMA;
+        message_length = 0;
         break;
 #endif
     default:
@@ -950,6 +1006,9 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
                                  opcode_flags & UCT_RC_MLX5_OPCODE_MASK, opmod,
                                  fm_ce_se, dci_channel, wqe_size, ib_imm_be,
                                  max_log_sge, NULL);
+    if (qp_type == IBV_QPT_RC) {
+        uct_rc_mlx5_txwq_update_psn(txwq, message_length);
+    }
 }
 
 /*
@@ -1099,6 +1158,10 @@ uct_rc_mlx5_txqp_tag_inline_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
     uct_rc_mlx5_common_post_send(iface, qp_type, txqp, txwq, opcode, 0,
                                  fm_ce_se, dci_channel, wqe_size, imm_val_be,
                                  INT_MAX, NULL);
+    if (qp_type == IBV_QPT_RC) {
+        /* Inline tag operations always fit in one RC packet. */
+        uct_rc_mlx5_txwq_add_psn(txwq, 1);
+    }
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -458,8 +458,7 @@ uct_rc_mlx5_num_packets(const uct_ib_mlx5_txwq_t *txwq,
 {
     ucs_assert(txwq->path_mtu_shift > 0);
 
-    return ucs_max(1u, (message_length + txwq->path_mtu_mask) >>
-                       txwq->path_mtu_shift);
+    return (message_length + txwq->path_mtu_mask) >> txwq->path_mtu_shift;
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -845,7 +844,11 @@ uct_rc_mlx5_txqp_dptr_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
                                  (opcode_flags & UCT_RC_MLX5_OPCODE_MASK), opmod,
                                  fm_ce_se, dci_channel, wqe_size, imm_val_be,
                                  max_log_sge, log_sge);
-    uct_rc_mlx5_txwq_update_psn(txwq, qp_type, length);
+    if (length == 0) {
+        uct_rc_mlx5_txwq_add_psn(txwq, qp_type, 1);
+    } else {
+        uct_rc_mlx5_txwq_update_psn(txwq, qp_type, length);
+    }
 }
 
 static UCS_F_ALWAYS_INLINE
@@ -997,7 +1000,11 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
     }
 #endif
 
-    uct_rc_mlx5_txwq_update_psn(txwq, qp_type, message_length);
+    if (message_length == 0) {
+        uct_rc_mlx5_txwq_add_psn(txwq, qp_type, 1);
+    } else {
+        uct_rc_mlx5_txwq_update_psn(txwq, qp_type, message_length);
+    }
 }
 
 /*

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -879,7 +879,7 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
     struct mlx5_wqe_inl_data_seg *inl;
     uct_rc_mlx5_hdr_t            *rch;
     unsigned                     wqe_size, inl_seg_size, ctrl_av_size;
-    size_t                       message_length;
+    size_t                       iov_length, message_length;
     void                         *next_seg;
     uint8_t                      opmod;
 #if HAVE_MLX5_MMO
@@ -902,9 +902,6 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
         inl_seg_size     = ucs_align_up_pow2(sizeof(*inl) + sizeof(*rch) + am_hdr_len,
                                              UCT_IB_MLX5_WQE_SEG_SIZE);
 
-        ucs_assert(uct_iov_total_length(iov, iovcnt) + sizeof(*rch) + am_hdr_len <=
-                   iface->super.super.config.seg_size);
-
         /* Inline segment with AM ID and header */
         inl              = next_seg;
         inl->byte_count  = htonl((sizeof(*rch) + am_hdr_len) | MLX5_INLINE_SEG);
@@ -915,12 +912,13 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
 
         /* Data segment with payload */
         dptr             = (struct mlx5_wqe_data_seg *)((char *)inl + inl_seg_size);
-        wqe_size         = ctrl_av_size + inl_seg_size +
-                           uct_ib_mlx5_set_data_seg_iov(txwq, dptr, iov, iovcnt);
-        opmod            = 0;
-        message_length   = uct_iov_total_length(iov, iovcnt) + sizeof(*rch) +
-                           am_hdr_len;
+        wqe_size       = ctrl_av_size + inl_seg_size +
+                         uct_ib_mlx5_set_data_seg_iov_length(
+                                 txwq, dptr, iov, iovcnt, &iov_length);
+        opmod          = 0;
+        message_length = iov_length + sizeof(*rch) + am_hdr_len;
 
+        ucs_assert(message_length <= iface->super.super.config.seg_size);
         ucs_assert(wqe_size <= UCT_IB_MLX5_MAX_SEND_WQE_SIZE);
         break;
 
@@ -932,11 +930,11 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
         inl              = next_seg;
         inl->byte_count  = htonl(sizeof(struct ibv_tmh) | MLX5_INLINE_SEG);
         dptr             = uct_ib_mlx5_txwq_wrap_exact(txwq, (char *)inl + inl_seg_size);
-        wqe_size         = ctrl_av_size + inl_seg_size +
-                           uct_ib_mlx5_set_data_seg_iov(txwq, dptr, iov, iovcnt);
-        opmod            = 0;
-        message_length   = uct_iov_total_length(iov, iovcnt) +
-                           sizeof(struct ibv_tmh);
+        wqe_size       = ctrl_av_size + inl_seg_size +
+                         uct_ib_mlx5_set_data_seg_iov_length(
+                                 txwq, dptr, iov, iovcnt, &iov_length);
+        opmod          = 0;
+        message_length = iov_length + sizeof(struct ibv_tmh);
 
         uct_rc_mlx5_fill_tmh((struct ibv_tmh*)(inl + 1), tag, app_ctx,
                              IBV_TMH_EAGER);
@@ -949,17 +947,16 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
         /* Fall through */
     case MLX5_OPCODE_RDMA_WRITE:
         /* Set RDMA segment */
-        ucs_assert(uct_iov_total_length(iov, iovcnt) <= UCT_IB_MAX_MESSAGE_SIZE);
-
         raddr            = next_seg;
         uct_ib_mlx5_ep_set_rdma_seg(raddr, remote_addr, rkey);
 
         /* Data segment */
-        wqe_size         = ctrl_av_size + sizeof(*raddr) +
-                           uct_ib_mlx5_set_data_seg_iov(txwq, (void*)(raddr + 1),
-                                                        iov, iovcnt);
-        opmod            = 0;
-        message_length   = uct_iov_total_length(iov, iovcnt);
+        wqe_size       = ctrl_av_size + sizeof(*raddr) +
+                         uct_ib_mlx5_set_data_seg_iov_length(
+                                 txwq, (void*)(raddr + 1), iov, iovcnt,
+                                 &message_length);
+        opmod          = 0;
+        ucs_assert(message_length <= UCT_IB_MAX_MESSAGE_SIZE);
         break;
 
 #if HAVE_MLX5_MMO

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -460,7 +460,7 @@ uct_rc_mlx5_num_packets(const uct_ib_mlx5_txwq_t *txwq,
 
     ucs_assert(txwq->path_mtu_shift > 0);
 
-    num_packets = (message_length + UCS_MASK(txwq->path_mtu_shift)) >>
+    num_packets = (message_length + txwq->path_mtu_mask) >>
                   txwq->path_mtu_shift;
     ucs_assert(num_packets > 0);
     return num_packets;

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -741,6 +741,7 @@ uct_rc_mlx5_txqp_dptr_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
         /* Data segment */
         if (length == 0) {
             wqe_size     = ctrl_av_size + sizeof(*raddr);
+            uct_rc_mlx5_txwq_add_psn(txwq, qp_type, 1);
         } else {
             /* dptr cannot wrap, because ctrl+av could be either 2 or 4 segs */
             dptr         = uct_ib_mlx5_txwq_wrap_none(txwq, raddr + 1);
@@ -844,11 +845,7 @@ uct_rc_mlx5_txqp_dptr_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
                                  (opcode_flags & UCT_RC_MLX5_OPCODE_MASK), opmod,
                                  fm_ce_se, dci_channel, wqe_size, imm_val_be,
                                  max_log_sge, log_sge);
-    if (length == 0) {
-        uct_rc_mlx5_txwq_add_psn(txwq, qp_type, 1);
-    } else {
-        uct_rc_mlx5_txwq_update_psn(txwq, qp_type, length);
-    }
+    uct_rc_mlx5_txwq_update_psn(txwq, qp_type, length);
 }
 
 static UCS_F_ALWAYS_INLINE
@@ -1000,10 +997,11 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
     }
 #endif
 
-    if (message_length == 0) {
-        uct_rc_mlx5_txwq_add_psn(txwq, qp_type, 1);
-    } else {
-        uct_rc_mlx5_txwq_update_psn(txwq, qp_type, message_length);
+    uct_rc_mlx5_txwq_update_psn(txwq, qp_type, message_length);
+    if (opcode_flags == MLX5_OPCODE_RDMA_WRITE) {
+        /* opcode_flags is constant after inlining, so only zero-length
+         * PUT_ZCOPY gets the branchless one-PSN adjustment. */
+        uct_rc_mlx5_txwq_add_psn(txwq, qp_type, !message_length);
     }
 }
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -903,11 +903,11 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
 
         /* Data segment with payload */
         dptr             = (struct mlx5_wqe_data_seg *)((char *)inl + inl_seg_size);
-        wqe_size       = ctrl_av_size + inl_seg_size +
-                         uct_ib_mlx5_set_data_seg_iov_length(
-                                 txwq, dptr, iov, iovcnt, &iov_length);
-        opmod          = 0;
-        message_length = iov_length + sizeof(*rch) + am_hdr_len;
+        wqe_size         = ctrl_av_size + inl_seg_size +
+                           uct_ib_mlx5_set_data_seg_iov_length(
+                                   txwq, dptr, iov, iovcnt, &iov_length);
+        opmod            = 0;
+        message_length   = iov_length + sizeof(*rch) + am_hdr_len;
 
         ucs_assert(message_length <= iface->super.super.config.seg_size);
         ucs_assert(wqe_size <= UCT_IB_MLX5_MAX_SEND_WQE_SIZE);
@@ -921,11 +921,11 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
         inl              = next_seg;
         inl->byte_count  = htonl(sizeof(struct ibv_tmh) | MLX5_INLINE_SEG);
         dptr             = uct_ib_mlx5_txwq_wrap_exact(txwq, (char *)inl + inl_seg_size);
-        wqe_size       = ctrl_av_size + inl_seg_size +
-                         uct_ib_mlx5_set_data_seg_iov_length(
-                                 txwq, dptr, iov, iovcnt, &iov_length);
-        opmod          = 0;
-        message_length = iov_length + sizeof(struct ibv_tmh);
+        wqe_size         = ctrl_av_size + inl_seg_size +
+                           uct_ib_mlx5_set_data_seg_iov_length(
+                                   txwq, dptr, iov, iovcnt, &iov_length);
+        opmod            = 0;
+        message_length   = iov_length + sizeof(struct ibv_tmh);
 
         uct_rc_mlx5_fill_tmh((struct ibv_tmh*)(inl + 1), tag, app_ctx,
                              IBV_TMH_EAGER);
@@ -942,11 +942,11 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
         uct_ib_mlx5_ep_set_rdma_seg(raddr, remote_addr, rkey);
 
         /* Data segment */
-        wqe_size       = ctrl_av_size + sizeof(*raddr) +
-                         uct_ib_mlx5_set_data_seg_iov_length(
-                                 txwq, (void*)(raddr + 1), iov, iovcnt,
-                                 &message_length);
-        opmod          = 0;
+        wqe_size = ctrl_av_size + sizeof(*raddr) +
+                   uct_ib_mlx5_set_data_seg_iov_length(
+                           txwq, (void*)(raddr + 1), iov, iovcnt,
+                           &message_length);
+        opmod    = 0;
         ucs_assert(message_length <= UCT_IB_MAX_MESSAGE_SIZE);
         break;
 
@@ -981,8 +981,9 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
         uct_ib_mlx5_set_data_seg(dptr /* scatter segment */,
                                  dma_dst_buf, iov[0].length, dma_dst_key);
 
-        wqe_size = sizeof(*ctrl) + sizeof(*dma_seg) + (2 * sizeof(*dptr));
-        opmod    = UCT_IB_MLX5_OPMOD_MMO_DMA;
+        wqe_size       = sizeof(*ctrl) + sizeof(*dma_seg) +
+                         (2 * sizeof(*dptr));
+        opmod          = UCT_IB_MLX5_OPMOD_MMO_DMA;
         message_length = 0;
         break;
 #endif

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -452,18 +452,6 @@ uct_rc_mlx5_ep_fm_cq_update(uct_rc_mlx5_iface_common_t *iface,
     return fm_ce_se;
 }
 
-static UCS_F_ALWAYS_INLINE void
-uct_rc_mlx5_txwq_set_path_mtu(uct_ib_mlx5_txwq_t *txwq,
-                              enum ibv_mtu path_mtu)
-{
-    size_t mtu = uct_ib_mtu_value(path_mtu);
-
-    ucs_assert(mtu <= UINT16_MAX);
-    ucs_assert(ucs_is_pow2(mtu));
-
-    txwq->path_mtu_shift = ucs_ilog2(mtu);
-}
-
 static UCS_F_ALWAYS_INLINE uint32_t
 uct_rc_mlx5_num_packets(const uct_ib_mlx5_txwq_t *txwq,
                         size_t message_length)

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -456,14 +456,10 @@ static UCS_F_ALWAYS_INLINE uint32_t
 uct_rc_mlx5_num_packets(const uct_ib_mlx5_txwq_t *txwq,
                         size_t message_length)
 {
-    uint32_t num_packets;
-
     ucs_assert(txwq->path_mtu_shift > 0);
 
-    num_packets = (message_length + txwq->path_mtu_mask) >>
-                  txwq->path_mtu_shift;
-    ucs_assert(num_packets > 0);
-    return num_packets;
+    return ucs_max(1u, (message_length + txwq->path_mtu_mask) >>
+                       txwq->path_mtu_shift);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -995,6 +995,12 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
                                  opcode_flags & UCT_RC_MLX5_OPCODE_MASK, opmod,
                                  fm_ce_se, dci_channel, wqe_size, ib_imm_be,
                                  max_log_sge, NULL);
+#if HAVE_MLX5_MMO
+    if ((opcode_flags & UCT_RC_MLX5_OPCODE_MASK) == MLX5_OPCODE_MMO) {
+        return;
+    }
+#endif
+
     uct_rc_mlx5_txwq_update_psn(txwq, qp_type, message_length);
 }
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -477,16 +477,23 @@ uct_rc_mlx5_num_packets(const uct_ib_mlx5_txwq_t *txwq,
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_rc_mlx5_txwq_add_psn(uct_ib_mlx5_txwq_t *txwq, uint32_t num_packets)
+uct_rc_mlx5_txwq_add_psn(uct_ib_mlx5_txwq_t *txwq, int qp_type,
+                         uint32_t num_packets)
 {
-    txwq->next_first_psn += num_packets;
+    if (qp_type == IBV_QPT_RC) {
+        txwq->next_first_psn += num_packets;
+    }
 }
 
 static UCS_F_ALWAYS_INLINE void
-uct_rc_mlx5_txwq_update_psn(uct_ib_mlx5_txwq_t *txwq,
+uct_rc_mlx5_txwq_update_psn(uct_ib_mlx5_txwq_t *txwq, int qp_type,
                             size_t message_length)
 {
-    uct_rc_mlx5_txwq_add_psn(txwq,
+    if (qp_type != IBV_QPT_RC) {
+        return;
+    }
+
+    uct_rc_mlx5_txwq_add_psn(txwq, qp_type,
                              uct_rc_mlx5_num_packets(txwq, message_length));
 }
 
@@ -570,9 +577,7 @@ static UCS_F_ALWAYS_INLINE void uct_rc_mlx5_txqp_inline_iov_post(
     uct_rc_mlx5_common_post_send(iface, qp_type, txqp, txwq, MLX5_OPCODE_SEND,
                                  0, fm_ce_se, dci_channel, wqe_size, 0,
                                  INT_MAX, NULL);
-    if (qp_type == IBV_QPT_RC) {
-        uct_rc_mlx5_txwq_add_psn(txwq, 1);
-    }
+    uct_rc_mlx5_txwq_add_psn(txwq, qp_type, 1);
 }
 
 /*
@@ -668,9 +673,9 @@ uct_rc_mlx5_txqp_inline_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
     uct_rc_mlx5_common_post_send(iface, qp_type, txqp, txwq, opcode, 0, fm_ce_se,
                                  dci_channel, wqe_size, imm_val_be,
                                  max_log_sge, NULL);
-    if ((qp_type == IBV_QPT_RC) && (opcode != MLX5_OPCODE_NOP)) {
+    if (opcode != MLX5_OPCODE_NOP) {
         /* Inline short operations always fit in one RC packet. */
-        uct_rc_mlx5_txwq_add_psn(txwq, 1);
+        uct_rc_mlx5_txwq_add_psn(txwq, qp_type, 1);
     }
 }
 
@@ -855,9 +860,7 @@ uct_rc_mlx5_txqp_dptr_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
                                  (opcode_flags & UCT_RC_MLX5_OPCODE_MASK), opmod,
                                  fm_ce_se, dci_channel, wqe_size, imm_val_be,
                                  max_log_sge, log_sge);
-    if (qp_type == IBV_QPT_RC) {
-        uct_rc_mlx5_txwq_update_psn(txwq, length);
-    }
+    uct_rc_mlx5_txwq_update_psn(txwq, qp_type, length);
 }
 
 static UCS_F_ALWAYS_INLINE
@@ -1002,9 +1005,7 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
                                  opcode_flags & UCT_RC_MLX5_OPCODE_MASK, opmod,
                                  fm_ce_se, dci_channel, wqe_size, ib_imm_be,
                                  max_log_sge, NULL);
-    if (qp_type == IBV_QPT_RC) {
-        uct_rc_mlx5_txwq_update_psn(txwq, message_length);
-    }
+    uct_rc_mlx5_txwq_update_psn(txwq, qp_type, message_length);
 }
 
 /*
@@ -1154,10 +1155,8 @@ uct_rc_mlx5_txqp_tag_inline_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
     uct_rc_mlx5_common_post_send(iface, qp_type, txqp, txwq, opcode, 0,
                                  fm_ce_se, dci_channel, wqe_size, imm_val_be,
                                  INT_MAX, NULL);
-    if (qp_type == IBV_QPT_RC) {
-        /* Inline tag operations always fit in one RC packet. */
-        uct_rc_mlx5_txwq_add_psn(txwq, 1);
-    }
+    /* Inline tag operations always fit in one RC packet. */
+    uct_rc_mlx5_txwq_add_psn(txwq, qp_type, 1);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -888,6 +888,7 @@ void uct_rc_mlx5_txwq_set_path_mtu(uct_ib_mlx5_txwq_t *txwq,
     ucs_assert(mtu <= UINT16_MAX);
     ucs_assert(ucs_is_pow2(mtu));
 
+    txwq->path_mtu_mask  = mtu - 1;
     txwq->path_mtu_shift = ucs_ilog2(mtu);
 }
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -881,7 +881,7 @@ void uct_rc_mlx5_common_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t
 }
 
 void uct_rc_mlx5_txwq_set_path_mtu(uct_ib_mlx5_txwq_t *txwq,
-                                    enum ibv_mtu path_mtu)
+                                   enum ibv_mtu path_mtu)
 {
     size_t mtu = uct_ib_mtu_value(path_mtu);
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -880,6 +880,17 @@ void uct_rc_mlx5_common_packet_dump(uct_base_iface_t *iface, uct_am_trace_type_t
                           valid_length, buffer, max);
 }
 
+void uct_rc_mlx5_txwq_set_path_mtu(uct_ib_mlx5_txwq_t *txwq,
+                                    enum ibv_mtu path_mtu)
+{
+    size_t mtu = uct_ib_mtu_value(path_mtu);
+
+    ucs_assert(mtu <= UINT16_MAX);
+    ucs_assert(ucs_is_pow2(mtu));
+
+    txwq->path_mtu_shift = ucs_ilog2(mtu);
+}
+
 ucs_status_t
 uct_rc_mlx5_ep_connect_qp(uct_rc_mlx5_iface_common_t *iface,
                           uct_ib_mlx5_qp_t *qp, uint32_t qp_num,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -301,7 +301,7 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
 
     uct_rc_txqp_posted(&ep->super.txqp, &iface->super, res_count, 1);
     uct_ib_mlx5_txwq_ring_doorbell(txwq, ctrl, txwq->sw_pi, 1);
-    uct_rc_mlx5_txwq_add_psn(txwq, num_packets);
+    uct_rc_mlx5_txwq_add_psn(txwq, IBV_QPT_RC, num_packets);
 
     uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp,
                               uct_rc_ep_send_op_completion_handler, comp, sn,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -212,10 +212,10 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
     uct_ib_mlx5_txwq_t *txwq       = &ep->tx.wq;
     size_t total                   = 0;
     struct mlx5_wqe_ctrl_seg *ctrl = NULL;
+    uint32_t num_packets           = 0;
     struct mlx5_wqe_raddr_seg *raddr;
     struct mlx5_wqe_data_seg *dptr;
     size_t wqe_size, i;
-    uint32_t num_packets = 0;
     uint8_t fm_ce_se, fence_flag;
     uint16_t sn, pi, res_count;
     uint64_t addr;

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -215,6 +215,7 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
     struct mlx5_wqe_raddr_seg *raddr;
     struct mlx5_wqe_data_seg *dptr;
     size_t wqe_size, i;
+    uint32_t num_packets = 0;
     uint8_t fm_ce_se, fence_flag;
     uint16_t sn, pi, res_count;
     uint64_t addr;
@@ -288,7 +289,8 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
         curr = UCS_PTR_BYTE_OFFSET(ctrl, MLX5_SEND_WQE_BB);
         curr = uct_ib_mlx5_txwq_wrap_exact(txwq, curr);
         pi++;
-        total += lengths[i];
+        total       += lengths[i];
+        num_packets += uct_rc_mlx5_num_packets(txwq, lengths[i]);
     }
 
     res_count         = pi - 1 - txwq->prev_sw_pi;
@@ -299,6 +301,7 @@ uct_rc_mlx5_base_ep_put_sgl_zcopy(uct_ep_h tl_ep, void * const *buffers,
 
     uct_rc_txqp_posted(&ep->super.txqp, &iface->super, res_count, 1);
     uct_ib_mlx5_txwq_ring_doorbell(txwq, ctrl, txwq->sw_pi, 1);
+    uct_rc_mlx5_txwq_add_psn(txwq, num_packets);
 
     uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp,
                               uct_rc_ep_send_op_completion_handler, comp, sn,
@@ -973,6 +976,7 @@ uct_rc_mlx5_ep_connect_to_ep_v2(uct_ep_h tl_ep,
     if (status != UCS_OK) {
         return status;
     }
+    uct_rc_mlx5_txwq_set_path_mtu(&ep->super.tx.wq, path_mtu);
 
     ep->super.super.atomic_mr_offset = uct_ib_md_atomic_offset(
             rc_addr->atomic_mr_id);

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -988,6 +988,7 @@ uct_rc_mlx5_ep_connect_to_ep_v2(uct_ep_h tl_ep,
     if (status != UCS_OK) {
         return status;
     }
+
     uct_rc_mlx5_txwq_set_path_mtu(&ep->super.tx.wq, path_mtu);
 
     ep->super.super.atomic_mr_offset = uct_ib_md_atomic_offset(

--- a/src/uct/ib/mlx5/ud/ud_mlx5.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.c
@@ -320,9 +320,9 @@ static UCS_F_ALWAYS_INLINE ucs_status_t uct_ud_mlx5_ep_inline_iov_post(
     /* set iov to dptr */
     if (iovcnt > 0) {
         wqe_size  = ucs_align_up_pow2(wqe_size, UCT_IB_MLX5_WQE_SEG_SIZE);
-        wqe_size += uct_ib_mlx5_set_data_seg_iov(&iface->tx.wq,
-                                                 UCS_PTR_BYTE_OFFSET(ctrl, wqe_size),
-                                                 iov, iovcnt);
+        wqe_size += uct_ib_mlx5_set_data_seg_iov_length(
+                &iface->tx.wq, UCS_PTR_BYTE_OFFSET(ctrl, wqe_size), iov,
+                iovcnt, NULL);
     }
 
     uct_ud_mlx5_post_send(iface, ep, 0, ctrl, wqe_size, neth,

--- a/src/uct/ib/mlx5/ud/ud_mlx5.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.c
@@ -320,7 +320,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_t uct_ud_mlx5_ep_inline_iov_post(
     /* set iov to dptr */
     if (iovcnt > 0) {
         wqe_size  = ucs_align_up_pow2(wqe_size, UCT_IB_MLX5_WQE_SEG_SIZE);
-        wqe_size += uct_ib_mlx5_set_data_seg_iov_length(
+        wqe_size += uct_ib_mlx5_set_data_seg_iov(
                 &iface->tx.wq, UCS_PTR_BYTE_OFFSET(ctrl, wqe_size), iov,
                 iovcnt, NULL);
     }

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -144,6 +144,89 @@ UCS_TEST_P(test_rc, fence_am_short_consumed, "RC_FENCE=weak")
 
 UCT_INSTANTIATE_RC_TEST_CASE(test_rc)
 
+#ifdef HAVE_MLX5_DV
+class test_rc_mlx5_psn : public test_rc {
+public:
+    void init() override
+    {
+        uct_test::init();
+
+        modify_config("IB_PATH_MTU", "4096");
+        m_e1 = uct_test::create_entity(0);
+        m_entities.push_back(m_e1);
+
+        check_skip_test();
+
+        modify_config("IB_PATH_MTU", "512");
+        m_e2 = uct_test::create_entity(0);
+        m_entities.push_back(m_e2);
+
+        connect();
+    }
+
+protected:
+    uct_ib_mlx5_txwq_t *txwq()
+    {
+        return &ucs_derived_of(m_e1->ep(0),
+                               uct_rc_mlx5_ep_t)->super.tx.wq;
+    }
+};
+
+UCS_TEST_P(test_rc_mlx5_psn, path_mtu_from_rc_qp)
+{
+    uct_ib_iface_t *local_iface =
+            ucs_derived_of(m_e1->iface(), uct_ib_iface_t);
+    uct_ib_iface_t *peer_iface =
+            ucs_derived_of(m_e2->iface(), uct_ib_iface_t);
+
+    EXPECT_EQ(IBV_MTU_4096, local_iface->config.path_mtu);
+    EXPECT_EQ(IBV_MTU_512, peer_iface->config.path_mtu);
+    EXPECT_EQ(511, txwq()->path_mtu_mask);
+    EXPECT_EQ(9, txwq()->path_mtu_shift);
+}
+
+UCS_TEST_SKIP_COND_P(test_rc_mlx5_psn, next_first_psn,
+                     !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY))
+{
+    static const size_t length = 513;
+    uct_ib_mlx5_txwq_t *wq    = txwq();
+    mapped_buffer sendbuf(length, 0ul, *m_e1);
+    mapped_buffer recvbuf(length, 0ul, *m_e2);
+    uct_completion_t comp;
+    ucs_status_t status;
+
+    EXPECT_EQ(0, wq->next_first_psn);
+
+    ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0));
+    EXPECT_EQ(1, wq->next_first_psn);
+
+    comp.func   = [](uct_completion_t*) {};
+    comp.count  = 1;
+    comp.status = UCS_OK;
+
+    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
+                            sendbuf.memh(), 1);
+    status = uct_ep_put_zcopy(m_e1->ep(0), iov, iovcnt, recvbuf.addr(),
+                              recvbuf.rkey(), &comp);
+    ASSERT_UCS_OK_OR_INPROGRESS(status);
+
+    /* The RC QP uses the peer's 512-byte path MTU, so 513 bytes use 2 PSNs. */
+    EXPECT_EQ(3, wq->next_first_psn);
+
+    if (status == UCS_INPROGRESS) {
+        wait_for_value(&comp.count, 0, true);
+    }
+
+    wq->next_first_psn = UCS_MASK(24);
+    ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0));
+    EXPECT_EQ(0, wq->next_first_psn);
+
+    flush();
+}
+
+_UCT_INSTANTIATE_TEST_CASE(test_rc_mlx5_psn, rc_mlx5)
+#endif
+
 
 class test_rc_max_wr : public test_rc {
 protected:

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -181,7 +181,6 @@ UCS_TEST_P(test_rc_mlx5_psn, path_mtu_from_rc_qp)
 
     EXPECT_EQ(IBV_MTU_4096, local_iface->config.path_mtu);
     EXPECT_EQ(IBV_MTU_512, peer_iface->config.path_mtu);
-    EXPECT_EQ(511, txwq()->path_mtu_mask);
     EXPECT_EQ(9, txwq()->path_mtu_shift);
 }
 

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -192,6 +192,7 @@ UCS_TEST_SKIP_COND_P(test_rc_mlx5_psn, next_wqe_psn,
     uct_ib_mlx5_txwq_t *wq    = txwq();
     mapped_buffer sendbuf(length, 0ul, *m_e1);
     mapped_buffer recvbuf(length, 0ul, *m_e2);
+    uct_iov_t zero_iov = {};
     uct_completion_t comp;
     ucs_status_t status;
 
@@ -212,6 +213,23 @@ UCS_TEST_SKIP_COND_P(test_rc_mlx5_psn, next_wqe_psn,
 
     /* The RC QP uses the peer's 512-byte path MTU, so 513 bytes use 2 PSNs. */
     EXPECT_EQ(3, uct_ib_mlx5_txwq_get_next_wqe_psn(wq));
+
+    if (status == UCS_INPROGRESS) {
+        wait_for_value(&comp.count, 0, true);
+    }
+
+    zero_iov.buffer = sendbuf.ptr();
+    zero_iov.length = 0;
+    zero_iov.memh   = sendbuf.memh();
+    zero_iov.stride = 0;
+    zero_iov.count  = 1;
+    comp.count      = 1;
+    comp.status     = UCS_OK;
+
+    status = uct_ep_put_zcopy(m_e1->ep(0), &zero_iov, 1, recvbuf.addr(),
+                              recvbuf.rkey(), &comp);
+    ASSERT_UCS_OK_OR_INPROGRESS(status);
+    EXPECT_EQ(4, uct_ib_mlx5_txwq_get_next_wqe_psn(wq));
 
     if (status == UCS_INPROGRESS) {
         wait_for_value(&comp.count, 0, true);

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -181,6 +181,7 @@ UCS_TEST_P(test_rc_mlx5_psn, path_mtu_from_rc_qp)
 
     EXPECT_EQ(IBV_MTU_4096, local_iface->config.path_mtu);
     EXPECT_EQ(IBV_MTU_512, peer_iface->config.path_mtu);
+    EXPECT_EQ(511, txwq()->path_mtu_mask);
     EXPECT_EQ(9, txwq()->path_mtu_shift);
 }
 

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -185,7 +185,7 @@ UCS_TEST_P(test_rc_mlx5_psn, path_mtu_from_rc_qp)
     EXPECT_EQ(9, txwq()->path_mtu_shift);
 }
 
-UCS_TEST_SKIP_COND_P(test_rc_mlx5_psn, next_first_psn,
+UCS_TEST_SKIP_COND_P(test_rc_mlx5_psn, next_wqe_psn,
                      !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY))
 {
     static const size_t length = 513;
@@ -195,10 +195,10 @@ UCS_TEST_SKIP_COND_P(test_rc_mlx5_psn, next_first_psn,
     uct_completion_t comp;
     ucs_status_t status;
 
-    EXPECT_EQ(0, uct_ib_mlx5_txwq_get_next_first_psn(wq));
+    EXPECT_EQ(0, uct_ib_mlx5_txwq_get_next_wqe_psn(wq));
 
     ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0));
-    EXPECT_EQ(1, uct_ib_mlx5_txwq_get_next_first_psn(wq));
+    EXPECT_EQ(1, uct_ib_mlx5_txwq_get_next_wqe_psn(wq));
 
     comp.func   = [](uct_completion_t*) {};
     comp.count  = 1;
@@ -211,16 +211,16 @@ UCS_TEST_SKIP_COND_P(test_rc_mlx5_psn, next_first_psn,
     ASSERT_UCS_OK_OR_INPROGRESS(status);
 
     /* The RC QP uses the peer's 512-byte path MTU, so 513 bytes use 2 PSNs. */
-    EXPECT_EQ(3, uct_ib_mlx5_txwq_get_next_first_psn(wq));
+    EXPECT_EQ(3, uct_ib_mlx5_txwq_get_next_wqe_psn(wq));
 
     if (status == UCS_INPROGRESS) {
         wait_for_value(&comp.count, 0, true);
     }
 
-    wq->next_first_psn = UCS_MASK(24);
+    wq->next_wqe_psn = UCS_MASK(24);
     ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0));
-    EXPECT_EQ(UCS_BIT(24), wq->next_first_psn);
-    EXPECT_EQ(0, uct_ib_mlx5_txwq_get_next_first_psn(wq));
+    EXPECT_EQ(UCS_BIT(24), wq->next_wqe_psn);
+    EXPECT_EQ(0, uct_ib_mlx5_txwq_get_next_wqe_psn(wq));
 
     flush();
 }

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -195,10 +195,10 @@ UCS_TEST_SKIP_COND_P(test_rc_mlx5_psn, next_first_psn,
     uct_completion_t comp;
     ucs_status_t status;
 
-    EXPECT_EQ(0, wq->next_first_psn);
+    EXPECT_EQ(0, uct_ib_mlx5_txwq_get_next_first_psn(wq));
 
     ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0));
-    EXPECT_EQ(1, wq->next_first_psn);
+    EXPECT_EQ(1, uct_ib_mlx5_txwq_get_next_first_psn(wq));
 
     comp.func   = [](uct_completion_t*) {};
     comp.count  = 1;
@@ -211,7 +211,7 @@ UCS_TEST_SKIP_COND_P(test_rc_mlx5_psn, next_first_psn,
     ASSERT_UCS_OK_OR_INPROGRESS(status);
 
     /* The RC QP uses the peer's 512-byte path MTU, so 513 bytes use 2 PSNs. */
-    EXPECT_EQ(3, wq->next_first_psn);
+    EXPECT_EQ(3, uct_ib_mlx5_txwq_get_next_first_psn(wq));
 
     if (status == UCS_INPROGRESS) {
         wait_for_value(&comp.count, 0, true);
@@ -219,7 +219,8 @@ UCS_TEST_SKIP_COND_P(test_rc_mlx5_psn, next_first_psn,
 
     wq->next_first_psn = UCS_MASK(24);
     ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(0), 0, 0, NULL, 0));
-    EXPECT_EQ(0, wq->next_first_psn);
+    EXPECT_EQ(UCS_BIT(24), wq->next_first_psn);
+    EXPECT_EQ(0, uct_ib_mlx5_txwq_get_next_first_psn(wq));
 
     flush();
 }


### PR DESCRIPTION
## What?
Track the PSN that will be used by the next RC mlx5 send WQE.

Cache the path MTU programmed on the connected RC QP and use it to advance the tracked PSN for RC send operations.

## Why?
Follow-up RC recovery logic needs a stable mapping from posted WQEs to their first packet sequence number. Using the interface MTU can miscount packets when the connected QP negotiated a different path MTU.

This change is split from #11684 and is intentionally limited to RC. DC, GGA, and recovery classification state are outside its scope.

## How?
Cache path_mtu - 1 as a 16-bit mask and log2(path_mtu) as an 8-bit shift when the RC data QP is connected. Packet counts use (length + mask) >> shift, avoiding division and an out-of-line MTU lookup on the send path.

Advance next_first_psn after successful inline, data-pointer, IOV, tag, and SGL posts, wrapping in the 24-bit RC PSN space.