### PR TITLE
UCS/DEBUG: Remove trailing line from tables

### DIFF
--- a/src/ucp/proto/proto_debug.c
+++ b/src/ucp/proto/proto_debug.c
@@ -271,9 +271,6 @@ ucp_proto_select_elem_info(ucp_worker_h worker,
 
     ucs_table_render(&table, strb);
 
-    /* remove trailing newline */
-    ucs_string_buffer_rtrim(strb, "\n");
-
     ucs_table_cleanup(&table);
 }
 

--- a/src/ucs/debug/table.c
+++ b/src/ucs/debug/table.c
@@ -426,6 +426,8 @@ void ucs_table_render(ucs_table_t *table, ucs_string_buffer_t *strb)
         (ucs_array_last(&table->entries)->kind != UCS_TABLE_ENTRY_SEPARATOR)) {
         ucs_table_render_separator(table, widths, 0, strb);
     }
+
+    ucs_string_buffer_rtrim(strb, "\n");
 }
 
 void ucs_table_print(ucs_table_t *table)
@@ -435,6 +437,6 @@ void ucs_table_print(ucs_table_t *table)
     CHECK_STATUS(table);
 
     ucs_table_render(table, &strb);
-    printf("%s", ucs_string_buffer_cstr(&strb));
+    printf("%s\n", ucs_string_buffer_cstr(&strb));
     ucs_string_buffer_cleanup(&strb);
 }

--- a/test/gtest/ucp/test_ucp_tl_info.cc
+++ b/test/gtest/ucp/test_ucp_tl_info.cc
@@ -157,7 +157,7 @@ UCS_TEST_F(test_ucp_tl_info, single_transport) {
         "| Legend: + = enabled, - = disabled                                                               |\n"
         "| All of the available transports are listed, some may be disabled or unsupported on your system. |\n"
         "| All of the visible devices are listed per transport, some may be disabled.                      |\n"
-        "+------------+-----------+-----------+------------------------------------------------------------+\n",
+        "+------------+-----------+-----------+------------------------------------------------------------+",
         render(context, &rscs));
     /* clang-format on */
 
@@ -192,7 +192,7 @@ UCS_TEST_F(test_ucp_tl_info, device_line_wrap) {
         "| Legend: + = enabled, - = disabled                                                               |\n"
         "| All of the available transports are listed, some may be disabled or unsupported on your system. |\n"
         "| All of the visible devices are listed per transport, some may be disabled.                      |\n"
-        "+---------+-----------+------------+--------------------------------------------------------------+\n",
+        "+---------+-----------+------------+--------------------------------------------------------------+",
         render(context, &rscs));
     /* clang-format on */
 
@@ -223,7 +223,7 @@ UCS_TEST_F(test_ucp_tl_info, unavailable_components) {
         "| Legend: + = enabled, - = disabled                                                               |\n"
         "| All of the available transports are listed, some may be disabled or unsupported on your system. |\n"
         "| All of the visible devices are listed per transport, some may be disabled.                      |\n"
-        "+---------------+-----------+-----------+---------------------------------------------------------+\n",
+        "+---------------+-----------+-----------+---------------------------------------------------------+",
         render(context, &rscs));
     /* clang-format on */
 
@@ -264,7 +264,7 @@ UCS_TEST_F(test_ucp_tl_info, multiple_groups) {
         "| Legend: + = enabled, - = disabled                                                               |\n"
         "| All of the available transports are listed, some may be disabled or unsupported on your system. |\n"
         "| All of the visible devices are listed per transport, some may be disabled.                      |\n"
-        "+------------+-----------+------------+-----------------------------------------------------------+\n",
+        "+------------+-----------+------------+-----------------------------------------------------------+",
         render(context, &rscs));
     /* clang-format on */
 
@@ -309,7 +309,7 @@ UCS_TEST_F(test_ucp_tl_info, device_with_system_device) {
         "| Legend: + = enabled, - = disabled                                                               |\n"
         "| All of the available transports are listed, some may be disabled or unsupported on your system. |\n"
         "| All of the visible devices are listed per transport, some may be disabled.                      |\n"
-        "+---------+-----------+------------+--------------------------------------------------------------+\n",
+        "+---------+-----------+------------+--------------------------------------------------------------+",
         render(context, &rscs));
     /* clang-format on */
 
@@ -347,7 +347,7 @@ UCS_TEST_F(test_ucp_tl_info, device_name_matches_system_device) {
         "| Legend: + = enabled, - = disabled                                                               |\n"
         "| All of the available transports are listed, some may be disabled or unsupported on your system. |\n"
         "| All of the visible devices are listed per transport, some may be disabled.                      |\n"
-        "+---------+-----------+------------+--------------------------------------------------------------+\n",
+        "+---------+-----------+------------+--------------------------------------------------------------+",
         render(context, &rscs));
     /* clang-format on */
 
@@ -376,7 +376,7 @@ UCS_TEST_F(test_ucp_tl_info, transport_transport_disabled) {
         "| Legend: + = enabled, - = disabled                                                               |\n"
         "| All of the available transports are listed, some may be disabled or unsupported on your system. |\n"
         "| All of the visible devices are listed per transport, some may be disabled.                      |\n"
-        "+---------+-----------+------------+--------------------------------------------------------------+\n",
+        "+---------+-----------+------------+--------------------------------------------------------------+",
         render(context, &rscs));
     /* clang-format on */
 
@@ -414,7 +414,7 @@ UCS_TEST_F(test_ucp_tl_info, sorted_output) {
         "| Legend: + = enabled, - = disabled                                                               |\n"
         "| All of the available transports are listed, some may be disabled or unsupported on your system. |\n"
         "| All of the visible devices are listed per transport, some may be disabled.                      |\n"
-        "+------------+-----------+------------+-----------------------------------------------------------+\n",
+        "+------------+-----------+------------+-----------------------------------------------------------+",
         render(context, &rscs));
     /* clang-format on */
 

--- a/test/gtest/ucp/test_ucp_wireup_lane_info.cc
+++ b/test/gtest/ucp/test_ucp_wireup_lane_info.cc
@@ -197,7 +197,7 @@ UCS_TEST_F(test_ucp_wireup_lane_info, single_transport_multi_device) {
               "| tcp       | ibs2 (mlx5_0)      |       1 | am, rma_bw |\n"
               "|           | ens10f0            |       1 | rma_bw     |\n"
               "|           | ibs7f0 (mlx5_1)    |       1 | rma_bw     |\n"
-              "+-----------+--------------------+---------+------------+\n",
+              "+-----------+--------------------+---------+------------+",
               render(context.get(), key, 0));
     /* clang-format on */
 }
@@ -256,7 +256,7 @@ UCS_TEST_F(test_ucp_wireup_lane_info, multi_transport) {
         "|           | mlx5_1:1           |       2 | rma_bw            |\n"
         "+-----------+--------------------+---------+-------------------+\n"
         "| self      | memory             |       1 | am, rma, rkey_ptr |\n"
-        "+-----------+--------------------+---------+-------------------+\n",
+        "+-----------+--------------------+---------+-------------------+",
         render(context.get(), key, 1));
     /* clang-format on */
 }
@@ -278,7 +278,7 @@ UCS_TEST_F(test_ucp_wireup_lane_info, lane_types_and_count) {
               "| Transport | Device (Sys. dev.) | # Lanes | Lane Types   |\n"
               "+-----------+--------------------+---------+--------------+\n"
               "| tcp       | eth0               |       3 | am, rma, amo |\n"
-              "+-----------+--------------------+---------+--------------+\n",
+              "+-----------+--------------------+---------+--------------+",
               render(context.get(), key, 0));
     /* clang-format on */
 }
@@ -300,7 +300,7 @@ UCS_TEST_F(test_ucp_wireup_lane_info, cm_lane) {
               "| cm        | cm                 |       1 | cm         |\n"
               "+-----------+--------------------+---------+------------+\n"
               "| tcp       | eth0               |       1 | am         |\n"
-              "+-----------+--------------------+---------+------------+\n",
+              "+-----------+--------------------+---------+------------+",
               render(context.get(), key, 0));
     /* clang-format on */
 }

--- a/test/gtest/ucs/test_table.cc
+++ b/test/gtest/ucs/test_table.cc
@@ -64,7 +64,7 @@ protected:
 UCS_TEST_F(test_table, empty_table) {
     table_t table(2);
     EXPECT_EQ("+--+--+\n"
-              "+--+--+\n",
+              "+--+--+",
               table.render());
 
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));
@@ -78,7 +78,7 @@ UCS_TEST_F(test_table, single_cell) {
 
     EXPECT_EQ("+-----+\n"
               "| abc |\n"
-              "+-----+\n",
+              "+-----+",
               table.render());
 
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));
@@ -91,7 +91,7 @@ UCS_TEST_F(test_table, single_cell_empty) {
 
     EXPECT_EQ("+--+\n"
               "|  |\n"
-              "+--+\n",
+              "+--+",
               table.render());
 
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));
@@ -120,7 +120,7 @@ UCS_TEST_F(test_table, wide_columns) {
     EXPECT_EQ("+--------------------+------------------+-------------------+\n"
               "| short              | even longer cell | wide third column |\n"
               "| a much wider value |        x         |                 y |\n"
-              "+--------------------+------------------+-------------------+\n",
+              "+--------------------+------------------+-------------------+",
               table.render());
 
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));
@@ -158,7 +158,7 @@ UCS_TEST_F(test_table, separator) {
               "+---+---+\n"
               "+---+---+\n"
               "|   | d |\n"
-              "+---+---+\n",
+              "+---+---+",
               table.render());
 
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));
@@ -177,7 +177,7 @@ UCS_TEST_F(test_table, trailing_separator_avoids_bottom_frame) {
 
     EXPECT_EQ("+---+--+\n"
               "| x |  |\n"
-              "+---+--+\n",
+              "+---+--+",
               table.render());
 
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));
@@ -218,7 +218,7 @@ UCS_TEST_F(test_table, col_span) {
               "| col_span = 3       |    1 |\n"
               "|   left_2    |   right_2   |\n"
               "| abcd | efgh | ijkl | mnop |\n"
-              "+------+------+------+------+\n",
+              "+------+------+------+------+",
               table.render());
 
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));
@@ -240,7 +240,7 @@ UCS_TEST_F(test_table, col_span_sets_width) {
     EXPECT_EQ("+----+--------------------+\n"
               "| this header is too wide |\n"
               "| ab |                 cd |\n"
-              "+----+--------------------+\n",
+              "+----+--------------------+",
               table.render());
 
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));
@@ -264,7 +264,7 @@ UCS_TEST_F(test_table, cell_fmt) {
     EXPECT_EQ("+--------------+-----+\n"
               "|  42 lo..hi   | k=7 |\n"
               "| 3.1415926536 |   x |\n"
-              "+--------------+-----+\n",
+              "+--------------+-----+",
               table.render());
 
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));
@@ -289,7 +289,7 @@ UCS_TEST_F(test_table, row_prefix) {
               "# | a |\n"
               "# +---+\n"
               "# | b |\n"
-              "# +---+\n",
+              "# +---+",
               table.render());
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));
 }
@@ -313,7 +313,7 @@ UCS_TEST_F(test_table, equal_widths) {
 
     EXPECT_EQ("+--------+--------+--------+\n"
               "| a      | longer | xy     |\n"
-              "+--------+--------+--------+\n",
+              "+--------+--------+--------+",
               table.render());
 
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));
@@ -340,7 +340,7 @@ UCS_TEST_F(test_table, equal_widths_with_col_span) {
     EXPECT_EQ("+--------------------+--------------------+\n"
               "| this header is too wide                 |\n"
               "| ab                 | cd                 |\n"
-              "+--------------------+--------------------+\n",
+              "+--------------------+--------------------+",
               table.render());
 
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));
@@ -359,7 +359,7 @@ UCS_TEST_F(test_table, render_twice) {
 
     EXPECT_EQ("+---+---+\n"
               "| a | b |\n"
-              "+---+---+\n",
+              "+---+---+",
               table.render());
 
     row = table.add_row();
@@ -371,7 +371,7 @@ UCS_TEST_F(test_table, render_twice) {
     EXPECT_EQ("+-------------+-------------+\n"
               "| a           | b           |\n"
               "| aaaaaaaaaaa | bbbbbbbbbbb |\n"
-              "+-------------+-------------+\n",
+              "+-------------+-------------+",
               table.render());
 
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));
@@ -453,7 +453,7 @@ UCS_TEST_F(test_table, separator_merged_1_of_2) {
               "| xx | yy |\n"
               "|    +----+\n"
               "|    | zz |\n"
-              "+----+----+\n",
+              "+----+----+",
               table.render());
 
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));
@@ -483,7 +483,7 @@ UCS_TEST_F(test_table, separator_merged_2_of_3) {
               "| aa | bb | cc |\n"
               "|    |    +----+\n"
               "|    |    | dd |\n"
-              "+----+----+----+\n",
+              "+----+----+----+",
               table.render());
 
     EXPECT_EQ(UCS_OK, ucs_table_get_status(table.get()));


### PR DESCRIPTION
## What?
Remove trailing line from tables rendering to prevent printing an empty line when called with `ucs_log_print_compact`
