### PR TITLE
UCT/UD/VERBS: Avoid caching the peer address handle

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -1442,7 +1442,7 @@ const char *uct_ib_wc_status_str(enum ibv_wc_status wc_status)
     return ibv_wc_status_str(wc_status);
 }
 
-static ucs_status_t
+ucs_status_t
 uct_ib_device_create_ah(uct_ib_device_t *dev, struct ibv_ah_attr *ah_attr,
                         struct ibv_pd *pd, const char *usage,
                         struct ibv_ah **ah_p)

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -387,6 +387,17 @@ ucs_status_t uct_ib_device_find_port(uct_ib_device_t *dev,
 
 const char *uct_ib_wc_status_str(enum ibv_wc_status wc_status);
 
+/**
+ * Create an address handle without adding it to the device cache.
+ *
+ * The caller owns the returned address handle and must destroy it with
+ * ibv_destroy_ah().
+ */
+ucs_status_t
+uct_ib_device_create_ah(uct_ib_device_t *dev, struct ibv_ah_attr *ah_attr,
+                        struct ibv_pd *pd, const char *usage,
+                        struct ibv_ah **ah_p);
+
 ucs_status_t
 uct_ib_device_create_ah_cached(uct_ib_device_t *dev,
                                struct ibv_ah_attr *ah_attr, struct ibv_pd *pd,

--- a/src/uct/ib/mlx5/ud/ud_mlx5.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.c
@@ -879,6 +879,8 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     .create_qp               = uct_ud_mlx5_iface_create_qp,
     .destroy_qp              = uct_ud_mlx5_iface_destroy_qp,
     .unpack_peer_address     = uct_ud_mlx5_iface_unpack_peer_address,
+    .ep_resolve_peer_address = (ucs_status_t(*)(uct_ud_ep_t*))
+                               ucs_empty_function_return_success,
     .ep_get_peer_address     = uct_ud_mlx5_ep_get_peer_address,
     .get_peer_address_length = uct_ud_mlx5_get_peer_address_length,
     .peer_address_str        = uct_ud_mlx5_iface_peer_address_str,

--- a/src/uct/ib/mlx5/ud/ud_mlx5.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5.c
@@ -879,7 +879,8 @@ static uct_ud_iface_ops_t uct_ud_mlx5_iface_ops = {
     .create_qp               = uct_ud_mlx5_iface_create_qp,
     .destroy_qp              = uct_ud_mlx5_iface_destroy_qp,
     .unpack_peer_address     = uct_ud_mlx5_iface_unpack_peer_address,
-    .ep_resolve_peer_address = (ucs_status_t(*)(uct_ud_ep_t*))
+    .ep_resolve_peer_address = (ucs_status_t(*)(uct_ud_ep_t*,
+                                                const uct_ib_address_t*))
                                ucs_empty_function_return_success,
     .ep_get_peer_address     = uct_ud_mlx5_ep_get_peer_address,
     .get_peer_address_length = uct_ud_mlx5_get_peer_address_length,

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -666,6 +666,11 @@ ucs_status_t uct_ud_ep_create_connected_common(const uct_ep_params_t *ep_params,
         goto err_ep_disconnect;
     }
 
+    status = uct_ud_ep_resolve_peer_address(ep);
+    if (status != UCS_OK) {
+        goto err_ep_disconnect;
+    }
+
     skb = uct_ud_ep_prepare_creq(ep);
     if (skb != NULL) {
         uct_ud_iface_send_ctl(iface, ep, skb, NULL, 0,
@@ -703,6 +708,7 @@ uct_ud_ep_connect_to_ep_v2(uct_ep_h tl_ep,
     const uct_ud_ep_addr_t *ep_addr = (const uct_ud_ep_addr_t*)uct_ep_addr;
     uct_ib_device_t *dev            = uct_ib_iface_device(&iface->super);
     void *peer_address;
+    ucs_status_t status;
     char buf[128];
 
     ucs_assert_always(ep->dest_ep_id == UCT_UD_EP_NULL_ID);
@@ -723,9 +729,14 @@ uct_ud_ep_connect_to_ep_v2(uct_ep_h tl_ep,
 
     peer_address = uct_iface_invoke_ops_func(&iface->super, uct_ud_iface_ops_t,
                                              ep_get_peer_address, ep);
-    return uct_ud_iface_unpack_peer_address(iface, ib_addr,
-                                            &ep_addr->iface_addr,
-                                            ep->path_index, peer_address);
+    status = uct_ud_iface_unpack_peer_address(iface, ib_addr,
+                                              &ep_addr->iface_addr,
+                                              ep->path_index, peer_address);
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    return uct_ud_ep_resolve_peer_address(ep);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/ud/base/ud_ep.c
+++ b/src/uct/ib/ud/base/ud_ep.c
@@ -666,7 +666,7 @@ ucs_status_t uct_ud_ep_create_connected_common(const uct_ep_params_t *ep_params,
         goto err_ep_disconnect;
     }
 
-    status = uct_ud_ep_resolve_peer_address(ep);
+    status = uct_ud_ep_resolve_peer_address(ep, ib_addr);
     if (status != UCS_OK) {
         goto err_ep_disconnect;
     }
@@ -736,7 +736,7 @@ uct_ud_ep_connect_to_ep_v2(uct_ep_h tl_ep,
         return status;
     }
 
-    return uct_ud_ep_resolve_peer_address(ep);
+    return uct_ud_ep_resolve_peer_address(ep, ib_addr);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -118,7 +118,9 @@ typedef struct uct_ud_iface_ops {
                                                      const uct_ib_address_t *ib_addr,
                                                      const uct_ud_iface_addr_t *if_addr,
                                                      int path_index, void *address_p);
-    ucs_status_t              (*ep_resolve_peer_address)(uct_ud_ep_t *ud_ep);
+    ucs_status_t              (*ep_resolve_peer_address)(
+                                       uct_ud_ep_t *ud_ep,
+                                       const uct_ib_address_t *ib_addr);
     void*                     (*ep_get_peer_address)(uct_ud_ep_t *ud_ep);
     size_t                    (*get_peer_address_length)();
     const char*               (*peer_address_str)(const uct_ud_iface_t *iface,
@@ -520,13 +522,14 @@ uct_ud_iface_unpack_peer_address(uct_ud_iface_t *iface,
 
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
-uct_ud_ep_resolve_peer_address(uct_ud_ep_t *ep)
+uct_ud_ep_resolve_peer_address(uct_ud_ep_t *ep,
+                               const uct_ib_address_t *ib_addr)
 {
     uct_ib_iface_t *ib_iface   = ucs_derived_of(ep->super.super.iface,
                                                 uct_ib_iface_t);
     uct_ud_iface_ops_t *ud_ops = ucs_derived_of(ib_iface->ops,
                                                 uct_ud_iface_ops_t);
-    return ud_ops->ep_resolve_peer_address(ep);
+    return ud_ops->ep_resolve_peer_address(ep, ib_addr);
 }
 
 

--- a/src/uct/ib/ud/base/ud_iface.h
+++ b/src/uct/ib/ud/base/ud_iface.h
@@ -118,6 +118,7 @@ typedef struct uct_ud_iface_ops {
                                                      const uct_ib_address_t *ib_addr,
                                                      const uct_ud_iface_addr_t *if_addr,
                                                      int path_index, void *address_p);
+    ucs_status_t              (*ep_resolve_peer_address)(uct_ud_ep_t *ud_ep);
     void*                     (*ep_get_peer_address)(uct_ud_ep_t *ud_ep);
     size_t                    (*get_peer_address_length)();
     const char*               (*peer_address_str)(const uct_ud_iface_t *iface,
@@ -515,6 +516,17 @@ uct_ud_iface_unpack_peer_address(uct_ud_iface_t *iface,
                                                 uct_ud_iface_ops_t);
     return ud_ops->unpack_peer_address(iface, ib_addr, if_addr,
                                        path_index, address_p);
+}
+
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_ud_ep_resolve_peer_address(uct_ud_ep_t *ep)
+{
+    uct_ib_iface_t *ib_iface   = ucs_derived_of(ep->super.super.iface,
+                                                uct_ib_iface_t);
+    uct_ud_iface_ops_t *ud_ops = ucs_derived_of(ib_iface->ops,
+                                                uct_ud_iface_ops_t);
+    return ud_ops->ep_resolve_peer_address(ep);
 }
 
 

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -659,12 +659,12 @@ int uct_ud_verbs_ep_is_connected(const uct_ep_h tl_ep,
                                         params->device_addr;
     const struct ibv_ah_attr *ah_attr = &ep->peer_address.ah_attr;
 
-    ucs_assert(ep->ah != NULL);
-
     if (!uct_ud_ep_is_connected_to_addr(&ep->super, params,
                                         ep->peer_address.dest_qpn)) {
         return 0;
     }
+
+    ucs_assert(ep->ah != NULL);
 
     /* Compare the resolved peer identity (LID/GID) directly, same as
      * UD mlx5 does with its av/grh_av - no AH pointer/cache lookup

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -609,16 +609,22 @@ uct_ud_verbs_iface_unpack_peer_address(uct_ud_iface_t *iface,
     uct_ib_iface_t *ib_iface                     = &iface->super;
     uct_ud_verbs_ep_peer_address_t *peer_address =
         (uct_ud_verbs_ep_peer_address_t*)address_p;
+    struct ibv_ah_attr ah_attr;
     enum ibv_mtu path_mtu;
     ucs_status_t status;
 
     memset(peer_address, 0, sizeof(*peer_address));
 
     status = uct_ib_iface_fill_ah_attr_from_addr(ib_iface, ib_addr, path_index,
-                                                 &peer_address->ah_attr,
-                                                 &path_mtu);
+                                                 &ah_attr, &path_mtu);
     if (status != UCS_OK) {
         return status;
+    }
+
+    peer_address->dlid      = ah_attr.dlid;
+    peer_address->is_global = ah_attr.is_global;
+    if (ah_attr.is_global) {
+        peer_address->dgid = ah_attr.grh.dgid;
     }
 
     peer_address->dest_qpn = uct_ib_unpack_uint24(if_addr->qp_num);
@@ -631,22 +637,30 @@ static void *uct_ud_verbs_ep_get_peer_address(uct_ud_ep_t *ud_ep)
     return &ep->peer_address;
 }
 
-/* Creates the ep's real, ep-owned AH (see uct_ud_verbs_ep_t::ah) from the
- * ah_attr that unpack_peer_address() already filled into ep->peer_address.
- * Uncached so it always reflects the current L2 resolution; destroyed
- * explicitly in the ep's cleanup. */
-static ucs_status_t uct_ud_verbs_ep_resolve_peer_address(uct_ud_ep_t *ud_ep)
+/* The ep owns the AH created here (uct_ud_verbs_ep_t::ah). */
+static ucs_status_t
+uct_ud_verbs_ep_resolve_peer_address(uct_ud_ep_t *ud_ep,
+                                     const uct_ib_address_t *ib_addr)
 {
     uct_ud_verbs_ep_t *ep    = ucs_derived_of(ud_ep, uct_ud_verbs_ep_t);
     uct_ib_iface_t *ib_iface = ucs_derived_of(ud_ep->super.super.iface,
                                               uct_ib_iface_t);
+    struct ibv_ah_attr ah_attr;
+    enum ibv_mtu path_mtu;
+    ucs_status_t status;
+
+    status = uct_ib_iface_fill_ah_attr_from_addr(ib_iface, ib_addr,
+                                                 ud_ep->path_index, &ah_attr,
+                                                 &path_mtu);
+    if (status != UCS_OK) {
+        return status;
+    }
 
     /* Release any AH from a previous resolve (e.g. on reconnect) before
      * creating the new one, so it never leaks. */
     uct_ud_verbs_ep_destroy_ah(ep);
 
-    return uct_ib_device_create_ah(uct_ib_iface_device(ib_iface),
-                                   &ep->peer_address.ah_attr,
+    return uct_ib_device_create_ah(uct_ib_iface_device(ib_iface), &ah_attr,
                                    uct_ib_iface_md(ib_iface)->pd,
                                    "UD verbs connect", &ep->ah);
 }
@@ -654,23 +668,33 @@ static ucs_status_t uct_ud_verbs_ep_resolve_peer_address(uct_ud_ep_t *ud_ep)
 int uct_ud_verbs_ep_is_connected(const uct_ep_h tl_ep,
                                  const uct_ep_is_connected_params_t *params)
 {
-    uct_ud_verbs_ep_t *ep             = ucs_derived_of(tl_ep,
-                                                        uct_ud_verbs_ep_t);
-    uct_ib_address_t *ib_addr         = (uct_ib_address_t*)
-                                        params->device_addr;
-    const struct ibv_ah_attr *ah_attr = &ep->peer_address.ah_attr;
+    uct_ud_verbs_ep_t *ep     = ucs_derived_of(tl_ep, uct_ud_verbs_ep_t);
+    uct_ib_iface_t *ib_iface  = ucs_derived_of(ep->super.super.super.iface,
+                                               uct_ib_iface_t);
+    uct_ib_address_t *ib_addr = (uct_ib_address_t*)params->device_addr;
+    struct ibv_ah_attr ah_attr;
+    enum ibv_mtu path_mtu;
+    ucs_status_t status;
 
     if (!uct_ud_ep_is_connected_to_addr(&ep->super, params,
                                         ep->peer_address.dest_qpn)) {
         return 0;
     }
 
-    /* Compare the resolved peer identity (LID/GID) directly, same as
-     * UD mlx5 does with its av/grh_av - no AH pointer/cache lookup
-     * involved. */
-    return uct_ib_iface_is_same_device(ib_addr, ah_attr->dlid,
-                                       ah_attr->is_global ?
-                                       &ah_attr->grh.dgid : NULL);
+    /* ah_attr holds the identity fields (dlid/is_global/dgid, matching
+     * ep->peer_address) refreshed for this path_index. */
+    status = uct_ib_iface_fill_ah_attr_from_addr(ib_iface, ib_addr,
+                                                 ep->super.path_index,
+                                                 &ah_attr, &path_mtu);
+    if (status != UCS_OK) {
+        return 0;
+    }
+
+    return (ah_attr.dlid == ep->peer_address.dlid) &&
+           (ah_attr.is_global == ep->peer_address.is_global) &&
+           (!ah_attr.is_global ||
+            !memcmp(&ah_attr.grh.dgid, &ep->peer_address.dgid,
+                    sizeof(ah_attr.grh.dgid)));
 }
 
 static size_t uct_ud_verbs_get_peer_address_length()
@@ -687,10 +711,15 @@ uct_ud_verbs_iface_peer_address_str(const uct_ud_iface_t *iface,
         (const uct_ud_verbs_ep_peer_address_t*)address;
     size_t len;
 
-    ucs_snprintf_zero(str, max_size, "dest_qpn=%u ",
-                      peer_address->dest_qpn);
-    len = strlen(str);
-    uct_ib_ah_attr_str(str + len, max_size - len, &peer_address->ah_attr);
+    ucs_snprintf_zero(str, max_size, "dest_qpn=%u dlid=%u",
+                      peer_address->dest_qpn, peer_address->dlid);
+    if (peer_address->is_global) {
+        len = strlen(str);
+        ucs_snprintf_zero(str + len, max_size - len, " dgid=");
+        len = strlen(str);
+        uct_ib_gid_str(&peer_address->dgid, str + len, max_size - len);
+    }
+
     return str;
 }
 

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -55,6 +55,7 @@ UCS_CLASS_INIT_FUNC(uct_ud_verbs_ep_t, const uct_ep_params_t *params)
 
     ucs_trace_func("");
     UCS_CLASS_CALL_SUPER_INIT(uct_ud_ep_t, &iface->super, params);
+    memset(&self->peer_address, 0, sizeof(self->peer_address));
     self->ah = NULL;
     return UCS_OK;
 }
@@ -663,8 +664,6 @@ int uct_ud_verbs_ep_is_connected(const uct_ep_h tl_ep,
                                         ep->peer_address.dest_qpn)) {
         return 0;
     }
-
-    ucs_assert(ep->ah != NULL);
 
     /* Compare the resolved peer identity (LID/GID) directly, same as
      * UD mlx5 does with its av/grh_av - no AH pointer/cache lookup

--- a/src/uct/ib/ud/verbs/ud_verbs.c
+++ b/src/uct/ib/ud/verbs/ud_verbs.c
@@ -55,13 +55,30 @@ UCS_CLASS_INIT_FUNC(uct_ud_verbs_ep_t, const uct_ep_params_t *params)
 
     ucs_trace_func("");
     UCS_CLASS_CALL_SUPER_INIT(uct_ud_ep_t, &iface->super, params);
-    self->peer_address.ah = NULL;
+    self->ah = NULL;
     return UCS_OK;
+}
+
+static void uct_ud_verbs_ep_destroy_ah(uct_ud_verbs_ep_t *ep)
+{
+    int ret;
+
+    if (ep->ah == NULL) {
+        return;
+    }
+
+    ret = ibv_destroy_ah(ep->ah);
+    if (ret != 0) {
+        ucs_warn("ibv_destroy_ah() returned %d: %m", ret);
+    }
+
+    ep->ah = NULL;
 }
 
 static UCS_CLASS_CLEANUP_FUNC(uct_ud_verbs_ep_t)
 {
     ucs_trace_func("");
+    uct_ud_verbs_ep_destroy_ah(self);
 }
 
 UCS_CLASS_DEFINE(uct_ud_verbs_ep_t, uct_ud_ep_t);
@@ -95,7 +112,7 @@ uct_ud_verbs_post_send(uct_ud_verbs_iface_t *iface, uct_ud_verbs_ep_t *ep,
     }
 
     wr->wr.ud.remote_qpn = ep->peer_address.dest_qpn;
-    wr->wr.ud.ah         = ep->peer_address.ah;
+    wr->wr.ud.ah         = ep->ah;
 
     UCT_UD_EP_HOOK_CALL_TX(&ep->super, (uct_ud_neth_t*)iface->tx.sge[0].addr);
     ret = ibv_post_send(iface->super.qp, wr, &bad_wr);
@@ -591,26 +608,19 @@ uct_ud_verbs_iface_unpack_peer_address(uct_ud_iface_t *iface,
     uct_ib_iface_t *ib_iface                     = &iface->super;
     uct_ud_verbs_ep_peer_address_t *peer_address =
         (uct_ud_verbs_ep_peer_address_t*)address_p;
-    struct ibv_ah_attr ah_attr;
     enum ibv_mtu path_mtu;
     ucs_status_t status;
 
     memset(peer_address, 0, sizeof(*peer_address));
 
     status = uct_ib_iface_fill_ah_attr_from_addr(ib_iface, ib_addr, path_index,
-                                                 &ah_attr, &path_mtu);
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    status = uct_ib_iface_create_ah(ib_iface, &ah_attr, "UD verbs connect",
-                                    &peer_address->ah);
+                                                 &peer_address->ah_attr,
+                                                 &path_mtu);
     if (status != UCS_OK) {
         return status;
     }
 
     peer_address->dest_qpn = uct_ib_unpack_uint24(if_addr->qp_num);
-
     return UCS_OK;
 }
 
@@ -620,20 +630,48 @@ static void *uct_ud_verbs_ep_get_peer_address(uct_ud_ep_t *ud_ep)
     return &ep->peer_address;
 }
 
+/* Creates the ep's real, ep-owned AH (see uct_ud_verbs_ep_t::ah) from the
+ * ah_attr that unpack_peer_address() already filled into ep->peer_address.
+ * Uncached so it always reflects the current L2 resolution; destroyed
+ * explicitly in the ep's cleanup. */
+static ucs_status_t uct_ud_verbs_ep_resolve_peer_address(uct_ud_ep_t *ud_ep)
+{
+    uct_ud_verbs_ep_t *ep    = ucs_derived_of(ud_ep, uct_ud_verbs_ep_t);
+    uct_ib_iface_t *ib_iface = ucs_derived_of(ud_ep->super.super.iface,
+                                              uct_ib_iface_t);
+
+    /* Release any AH from a previous resolve (e.g. on reconnect) before
+     * creating the new one, so it never leaks. */
+    uct_ud_verbs_ep_destroy_ah(ep);
+
+    return uct_ib_device_create_ah(uct_ib_iface_device(ib_iface),
+                                   &ep->peer_address.ah_attr,
+                                   uct_ib_iface_md(ib_iface)->pd,
+                                   "UD verbs connect", &ep->ah);
+}
+
 int uct_ud_verbs_ep_is_connected(const uct_ep_h tl_ep,
                                  const uct_ep_is_connected_params_t *params)
 {
-    uct_ud_verbs_ep_t *ep     = ucs_derived_of(tl_ep, uct_ud_verbs_ep_t);
-    uct_ib_iface_t *ib_iface  = ucs_derived_of(tl_ep->iface, uct_ib_iface_t);
-    uct_ib_address_t *ib_addr = (uct_ib_address_t*)params->device_addr;
+    uct_ud_verbs_ep_t *ep             = ucs_derived_of(tl_ep,
+                                                        uct_ud_verbs_ep_t);
+    uct_ib_address_t *ib_addr         = (uct_ib_address_t*)
+                                        params->device_addr;
+    const struct ibv_ah_attr *ah_attr = &ep->peer_address.ah_attr;
+
+    ucs_assert(ep->ah != NULL);
 
     if (!uct_ud_ep_is_connected_to_addr(&ep->super, params,
                                         ep->peer_address.dest_qpn)) {
         return 0;
     }
 
-    return uct_ib_iface_is_connected(ib_iface, ib_addr, ep->super.path_index,
-                                     ep->peer_address.ah);
+    /* Compare the resolved peer identity (LID/GID) directly, same as
+     * UD mlx5 does with its av/grh_av - no AH pointer/cache lookup
+     * involved. */
+    return uct_ib_iface_is_same_device(ib_addr, ah_attr->dlid,
+                                       ah_attr->is_global ?
+                                       &ah_attr->grh.dgid : NULL);
 }
 
 static size_t uct_ud_verbs_get_peer_address_length()
@@ -648,9 +686,12 @@ uct_ud_verbs_iface_peer_address_str(const uct_ud_iface_t *iface,
 {
     const uct_ud_verbs_ep_peer_address_t *peer_address =
         (const uct_ud_verbs_ep_peer_address_t*)address;
+    size_t len;
 
-    ucs_snprintf_zero(str, max_size, "ah=%p dest_qpn=%u",
-                      peer_address->ah, peer_address->dest_qpn);
+    ucs_snprintf_zero(str, max_size, "dest_qpn=%u ",
+                      peer_address->dest_qpn);
+    len = strlen(str);
+    uct_ib_ah_attr_str(str + len, max_size - len, &peer_address->ah_attr);
     return str;
 }
 
@@ -687,6 +728,7 @@ static uct_ud_iface_ops_t uct_ud_verbs_iface_ops = {
     .create_qp               = uct_ib_iface_create_qp,
     .destroy_qp              = uct_ud_verbs_iface_destroy_qp,
     .unpack_peer_address     = uct_ud_verbs_iface_unpack_peer_address,
+    .ep_resolve_peer_address = uct_ud_verbs_ep_resolve_peer_address,
     .ep_get_peer_address     = uct_ud_verbs_ep_get_peer_address,
     .get_peer_address_length = uct_ud_verbs_get_peer_address_length,
     .peer_address_str        = uct_ud_verbs_iface_peer_address_str,

--- a/src/uct/ib/ud/verbs/ud_verbs.h
+++ b/src/uct/ib/ud/verbs/ud_verbs.h
@@ -16,13 +16,16 @@
 
 typedef struct {
     uint32_t                          dest_qpn;
-    struct ibv_ah                     *ah;
+    struct ibv_ah_attr                ah_attr; /* Used for connection
+                                                * matching, is_connected(),
+                                                * and creating the AH */
 } uct_ud_verbs_ep_peer_address_t;
 
 
 typedef struct {
     uct_ud_ep_t                       super;
     uct_ud_verbs_ep_peer_address_t    peer_address;
+    struct ibv_ah                     *ah;
 } uct_ud_verbs_ep_t;
 
 

--- a/src/uct/ib/ud/verbs/ud_verbs.h
+++ b/src/uct/ib/ud/verbs/ud_verbs.h
@@ -15,10 +15,11 @@
 
 
 typedef struct {
-    uint32_t                          dest_qpn;
-    struct ibv_ah_attr                ah_attr; /* Used for connection
-                                                * matching, is_connected(),
-                                                * and creating the AH */
+    uint32_t      dest_qpn;
+    uint16_t      dlid;
+    uint8_t       is_global;
+    union ibv_gid dgid; /* Valid only if is_global. Used for connection
+                         * matching and is_connected() */
 } uct_ud_verbs_ep_peer_address_t;
 
 

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -74,7 +74,7 @@ UCS_TEST_F(test_obj_size, size) {
 #  endif
 #  if HAVE_TL_UD
     EXPECTED_SIZE(uct_ud_ep_t, 248);
-    EXPECTED_SIZE(uct_ud_verbs_ep_t, 296);
+    EXPECTED_SIZE(uct_ud_verbs_ep_t, 280);
 #  endif
 #  if HAVE_CUDA
     EXPECTED_SIZE(uct_cuda_ipc_ep_t, 24);

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -74,7 +74,7 @@ UCS_TEST_F(test_obj_size, size) {
 #  endif
 #  if HAVE_TL_UD
     EXPECTED_SIZE(uct_ud_ep_t, 248);
-    EXPECTED_SIZE(uct_ud_verbs_ep_t, 264);
+    EXPECTED_SIZE(uct_ud_verbs_ep_t, 296);
 #  endif
 #  if HAVE_CUDA
     EXPECTED_SIZE(uct_cuda_ipc_ep_t, 24);

--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -950,6 +950,50 @@ UCS_TEST_SKIP_COND_P(test_ud, ctls_loss,
 
 UCT_INSTANTIATE_UD_TEST_CASE(test_ud)
 
+
+class test_ud_verbs_is_connected : public ud_base_test {
+};
+
+/* uct_ud_verbs_ep_is_connected() must compare the peer's actual resolved
+ * LID/GID (via ah_attr), not just the destination QP number - otherwise a
+ * peer that changed its L2 address could be mistaken for still being the
+ * one this ep is connected to. */
+UCS_TEST_P(test_ud_verbs_is_connected, mismatched_device_addr)
+{
+    uct_ep_is_connected_params_t params = {0};
+    uct_iface_attr_t attr;
+    std::string dev_addr, iface_addr;
+
+    connect();
+
+    ASSERT_UCS_OK(uct_iface_query(m_e2->iface(), &attr));
+    dev_addr.resize(attr.device_addr_len);
+    iface_addr.resize(attr.iface_addr_len);
+    ASSERT_UCS_OK(uct_iface_get_device_address(
+            m_e2->iface(), (uct_device_addr_t*)dev_addr.data()));
+    ASSERT_UCS_OK(uct_iface_get_address(m_e2->iface(),
+                                        (uct_iface_addr_t*)iface_addr.data()));
+
+    params.field_mask  = UCT_EP_IS_CONNECTED_FIELD_DEVICE_ADDR |
+                         UCT_EP_IS_CONNECTED_FIELD_IFACE_ADDR;
+    params.device_addr = (uct_device_addr_t*)dev_addr.data();
+    params.iface_addr  = (uct_iface_addr_t*)iface_addr.data();
+
+    EXPECT_TRUE(uct_ep_is_connected(m_e1->ep(0), &params));
+
+    /* Flip the LID/GID - the byte right after uct_ib_address_t::flags is
+     * always either the GID (RoCE) or the LID (IB), see its layout comment
+     * - while keeping the destination QP number (in iface_addr) the same
+     * as the real peer's, to isolate the ah_attr-based comparison from the
+     * dest_qpn check. */
+    ((uint8_t*)dev_addr.data())[1] ^= 1;
+
+    EXPECT_FALSE(uct_ep_is_connected(m_e1->ep(0), &params));
+}
+
+_UCT_INSTANTIATE_TEST_CASE(test_ud_verbs_is_connected, ud_verbs)
+
+
 #if UCT_UD_EP_DEBUG_HOOKS
 class test_ud_stale_ack : public test_ud {
 public:

--- a/test/gtest/uct/ib/test_ud.cc
+++ b/test/gtest/uct/ib/test_ud.cc
@@ -978,6 +978,8 @@ UCS_TEST_P(test_ud_verbs_is_connected, mismatched_device_addr)
                          UCT_EP_IS_CONNECTED_FIELD_IFACE_ADDR;
     params.device_addr = (uct_device_addr_t*)dev_addr.data();
     params.iface_addr  = (uct_iface_addr_t*)iface_addr.data();
+    /* Not in field_mask, kept non-NULL to avoid a Coverity false positive. */
+    params.ep_addr     = (uct_ep_addr_t*)iface_addr.data();
 
     EXPECT_TRUE(uct_ep_is_connected(m_e1->ep(0), &params));
 


### PR DESCRIPTION
## What?
UD verbs no longer uses the AH cache. Instead the endpoint owns its AH for its lifetime. This is trading reuse for correctness in case of L2 changes.
## Why?
AH's L2 resolution can become invalid and the current AH cache cannot have a reliable invalidation path.
## How?
We assume the AH is constant during the ep's lifetime, so it's created once, uncached, and destroyed with the ep. Connection matching and the `is_connected()` call compare `ah_attr` directly instead of the AH pointer value. It's effectively the same key that was already used for the cached AH.