### PR TITLE
UCT/IB: Use per-device MR flags in dmabuf capability probe

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -134,6 +134,7 @@ Yihua Xu <yihua.xu@intel.com>
 Yiltan Hassan Temucin <yiltan.temucin@amd.com>
 Yossi Itigin <yosefe@nvidia.com>
 Yuriy Shestakov <yuriis@mellanox.com>
+Zack Cao <silverwindcao@gmail.com>
 Zhenlong Ma <zhenlongm@nvidia.com>
 Zhongkai Zhang <zhzhang@habana.ai>
 Zhu Yanjun <yanjunz@mellanox.com>

--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -1320,7 +1320,7 @@ static void uct_ib_md_check_dmabuf(uct_ib_md_t *md)
     struct ibv_mr *mr;
 
     mr = ibv_reg_dmabuf_mr(md->pd, 0, ucs_get_page_size(), 0, bad_fd,
-                           UCT_IB_MEM_ACCESS_FLAGS);
+                           md->dev.mr_access_flags);
     if (mr != NULL) {
         ibv_dereg_mr(mr);
         /* dmabuf is supported */


### PR DESCRIPTION
## Summary

Use per-device MR access flags in the UCX dmabuf capability probe so AWS EFA does not silently disable GPUDirect RDMA.

`uct_ib_md_check_dmabuf()` probes dmabuf support by registering with a deliberately bad fd and treating any errno other than `EBADF` as "unsupported". The probe hardcoded `UCT_IB_MEM_ACCESS_FLAGS`, which includes `IBV_ACCESS_REMOTE_ATOMIC`.

AWS EFA validates access flags before the fd and supports only `LOCAL_WRITE|REMOTE_READ|REMOTE_WRITE`, so `efa_alloc_mr` returns `-EOPNOTSUPP` and UCX never sets `UCT_MD_FLAG_REG_DMABUF`. GPUDirect RDMA stays disabled on EFA, forcing GPU→host→SRD→host→GPU copies instead of direct transfers.

UCX already computes the correct per-device flags in `md->dev.mr_access_flags` (set for EFA in `ib_efa_md.c`, used for real registrations in `ib_md.c`). Use those flags in the probe as well.

## Impact

No-op on mlx5/verbs, where `dev->mr_access_flags == UCT_IB_MEM_ACCESS_FLAGS`. EFA is the transport where the flags differ, and it assigns them before `uct_ib_md_open_common()` calls the probe.

## Context

We observed this on B300 clusters running tiered-disaggregation KV transfers over EFA: dmabuf registration was never enabled, collapsing throughput.

## Test plan

- [x] Patch applies cleanly to `master`
- [ ] Existing UCT/IB unit tests
- [ ] On EFA: verify `UCT_MD_FLAG_REG_DMABUF` is set and GPUDirect RDMA is enabled