### PR TITLE
UCP/CORE: Fix rkey-config ceiling diagnostic OOB read

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -125,6 +125,7 @@ Tomer Gilad <tgilad@nvidia.com>
 Tony Curtis <tonycurtis32@gmail.com>
 Tzafrir Cohen <tzafrirc@nvidia.com>
 Valentin Petrov <valentinp@mellanox.com>
+Vipul Sharma <vipuls181999@gmail.com>
 Wenbin Lu <wenbin.lu@stonybrook.edu>
 William Gallagher <wgallagher@nvidia.com>
 Xin Zhao <xinz@mellanox.com>

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2246,7 +2246,7 @@ out:
 
 static void
 ucp_worker_dump_rkey_config_key(ucs_string_buffer_t *log_strb,
-                                ucp_rkey_config_key_t *key)
+                                const ucp_rkey_config_key_t *key)
 {
     ucs_string_buffer_appendf(
             log_strb,
@@ -2291,7 +2291,7 @@ ucp_worker_add_rkey_config(ucp_worker_h worker,
         }
 
         ucs_string_buffer_appendf(&log_strb, "rkey key new: ");
-        ucp_worker_dump_rkey_config_key(&log_strb, &rkey_config->key);
+        ucp_worker_dump_rkey_config_key(&log_strb, key);
 
         ucs_debug("%s", ucs_string_buffer_cstr(&log_strb));
         ucs_string_buffer_cleanup(&log_strb);


### PR DESCRIPTION
## Summary

Fix an out-of-bounds read in the rkey-config ceiling diagnostic path.

When `ucp_worker_add_rkey_config()` hits `UCP_WORKER_MAX_RKEY_CONFIG`, it dumps all existing rkey keys plus the rejected new key. The dump loop uses `ucs_array_for_each(rkey_config, &worker->rkey_config)`, then reads `&rkey_config->key` for the "rkey key new:" line. After the loop completes, `rkey_config` points one element past the last array entry, so `&rkey_config->key` reads heap memory past the array and can fault the process.

Use the rejected `key` argument instead.

## Context

We hit this in production when a serving process exceeded the rkey-config limit and the diagnostic dump faulted instead of logging useful state.

## Test plan

- [x] Patch applies cleanly to `master`
- [ ] Existing UCP unit tests
- [ ] Manual: trigger `UCP_WORKER_MAX_RKEY_CONFIG` and verify dump logs the rejected key without faulting