### PR TITLE
UCT/IB/MLX5/RC: Avoid caching AH for DevX RoCE QP connect

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -1442,7 +1442,7 @@ const char *uct_ib_wc_status_str(enum ibv_wc_status wc_status)
     return ibv_wc_status_str(wc_status);
 }
 
-static ucs_status_t
+ucs_status_t
 uct_ib_device_create_ah(uct_ib_device_t *dev, struct ibv_ah_attr *ah_attr,
                         struct ibv_pd *pd, const char *usage,
                         struct ibv_ah **ah_p)

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -387,6 +387,17 @@ ucs_status_t uct_ib_device_find_port(uct_ib_device_t *dev,
 
 const char *uct_ib_wc_status_str(enum ibv_wc_status wc_status);
 
+/**
+ * Create an address handle without adding it to the device cache.
+ *
+ * The caller owns the returned address handle and must destroy it with
+ * ibv_destroy_ah().
+ */
+ucs_status_t
+uct_ib_device_create_ah(uct_ib_device_t *dev, struct ibv_ah_attr *ah_attr,
+                        struct ibv_pd *pd, const char *usage,
+                        struct ibv_ah **ah_p);
+
 ucs_status_t
 uct_ib_device_create_ah_cached(uct_ib_device_t *dev,
                                struct ibv_ah_attr *ah_attr, struct ibv_pd *pd,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_devx.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_devx.c
@@ -444,8 +444,8 @@ ucs_status_t uct_rc_mlx5_iface_common_devx_connect_qp(
 
         ret = ibv_destroy_ah(ah);
         if (ret != 0) {
-            ucs_warn("%s: ibv_destroy_ah() for qp 0x%x failed: %m",
-                     uct_ib_mlx5_dev_name(md), qp->qp_num);
+            ucs_warn("%s: ibv_destroy_ah() for qp 0x%x failed with error "
+                     "%d: %m", uct_ib_mlx5_dev_name(md), qp->qp_num, ret);
         }
     } else {
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.grh, ah_attr->is_global);

--- a/src/uct/ib/mlx5/rc/rc_mlx5_devx.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_devx.c
@@ -444,7 +444,8 @@ ucs_status_t uct_rc_mlx5_iface_common_devx_connect_qp(
 
         ret = ibv_destroy_ah(ah);
         if (ret != 0) {
-            ucs_warn("ibv_destroy_ah() returned %d: %m", ret);
+            ucs_warn("%s: ibv_destroy_ah() for qp 0x%x failed: %m",
+                     uct_ib_mlx5_dev_name(md), qp->qp_num);
         }
     } else {
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.grh, ah_attr->is_global);

--- a/src/uct/ib/mlx5/rc/rc_mlx5_devx.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_devx.c
@@ -398,6 +398,7 @@ ucs_status_t uct_rc_mlx5_iface_common_devx_connect_qp(
     ucs_status_t status;
     struct ibv_ah *ah;
     void *qpc;
+    int ret;
 
     UCT_IB_MLX5DV_SET(init2rtr_qp_in, in_2rtr, opcode,
                       UCT_IB_MLX5_CMD_OP_INIT2RTR_QP);
@@ -412,8 +413,9 @@ ucs_status_t uct_rc_mlx5_iface_common_devx_connect_qp(
     uct_ib_mlx5_devx_set_qpc_dp_ordering(md, qpc, iface);
 
     if (uct_ib_iface_is_roce(&iface->super.super)) {
-        status = uct_ib_iface_create_ah(&iface->super.super, ah_attr,
-                                        "RC DEVX QP connect", &ah);
+        status = uct_ib_device_create_ah(&md->super.dev, ah_attr,
+                                         md->super.pd, "RC DEVX QP connect",
+                                         &ah);
         if (status != UCS_OK) {
             return status;
         }
@@ -439,6 +441,11 @@ ucs_status_t uct_rc_mlx5_iface_common_devx_connect_qp(
 
         uct_ib_mlx5_devx_set_qpc_port_affinity(md, path_index, qpc,
                                                &opt_param_mask);
+
+        ret = ibv_destroy_ah(ah);
+        if (ret != 0) {
+            ucs_warn("ibv_destroy_ah() returned %d: %m", ret);
+        }
     } else {
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.grh, ah_attr->is_global);
         UCT_IB_MLX5DV_SET(qpc, qpc, primary_address_path.rlid, ah_attr->dlid);


### PR DESCRIPTION
## What?
RC's DevX (mlx5) RoCE QP connect no longer uses the iface-wide cached address handle (AH). It creates a temporary, uncached AH just to extract the AV bytes needed for the QP context, then destroys it right away.
## Why?
The cached AH is keyed by resolved LID/GID and has no reliable invalidation path, so a peer's stale, no-longer-valid L2 address could keep being reused. The AH is only needed transiently here, to read its AV bytes into the QP context.
## How?
`uct_rc_mlx5_iface_common_devx_connect_qp()` now creates the AH on RoCE and destroys it immediately after extracting the AV bytes, instead of going through AH cache. The fix covers every caller: RC (Vebs unaffected), GDAKI, GGA, and the internal tag-matching command QP.