### PR TITLE
CI/LSAN: Suppress dlerror internal buffer leak

### DIFF
--- a/contrib/lsan.supp
+++ b/contrib/lsan.supp
@@ -1,6 +1,7 @@
 leak:libcuda
 leak:dlopen
 leak:dlsym
+leak:dlerror
 leak:nvmlInitWithFlags
 leak:bfd_map_over_sections
 # see https://github.com/openucx/ucx/blob/ec4407f08dbed639409d796e42bfab1ff718fda5/src/uct/ib/base/ib_md.c#L1392

--- a/contrib/lsan.supp
+++ b/contrib/lsan.supp
@@ -1,6 +1,8 @@
 leak:libcuda
 leak:dlopen
 leak:dlsym
+# glibc caches error string in TLS only freed on pthread key destructor,
+# which never runs for the main thread.
 leak:dlerror
 leak:nvmlInitWithFlags
 leak:bfd_map_over_sections


### PR DESCRIPTION
## What?
Suppress sanitizer `dlerror` false-positive leak:
```

    #0 0xffffbb69a2f4 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0xffffba3920ec in __vasprintf_internal libio/vasprintf.c:71
    #2 0xffffba370c7c in ___asprintf stdio-common/asprintf.c:31
    #3 0xffffba399038 in __dlerror dlfcn/dlerror.c:74
    #4 0xffffbb506a90 in ucs_sys_get_lib_info /scrap/azure/agent-04/AZP_WORKSPACE/1/s/contrib/../src/ucs/sys/lib.c:18
    #5 0xffffbb506b44 in ucs_sys_get_lib_path /scrap/azure/agent-04/AZP_WORKSPACE/1/s/contrib/../src/ucs/sys/lib.c:32
    #6 0xffffbb4f4294 in ucs_profile_write /scrap/azure/agent-04/AZP_WORKSPACE/1/s/contrib/../src/ucs/profile/profile.c:322
    #7 0xffffbb4f5dc0 in ucs_profile_dump /scrap/azure/agent-04/AZP_WORKSPACE/1/s/contrib/../src/ucs/profile/profile.c:699
    #8 0xffffbb4f63f0 in ucs_profile_cleanup /scrap/azure/agent-04/AZP_WORKSPACE/1/s/contrib/../src/ucs/profile/profile.c:764
    #9 0xaaaac1166cec in scoped_profile::~scoped_profile() /scrap/azure/agent-04/AZP_WORKSPACE/1/s/contrib/../test/gtest/ucs/test_profile.cc:48
    #10 0xaaaac11523b0 in test_profile_perf_overhead_Test::test_body()