### PR TITLE
CONFIG/SPEC: Bump version to 1.24.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 AC_PREREQ([2.63])
 
 define([ucx_ver_major], 1)  # Major version. Usually does not change.
-define([ucx_ver_minor], 23) # Minor version. Increased for each release.
+define([ucx_ver_minor], 24) # Minor version. Increased for each release.
 define([ucx_ver_patch], 0)  # Patch version. Increased for a bugfix release.
 define([ucx_ver_extra], )   # Extra version string. Empty for a general release.
 

--- a/ucx.spec.in
+++ b/ucx.spec.in
@@ -456,6 +456,8 @@ with the host CPU.
 %endif
 
 %changelog
+* Wed Aug 26 2026 Leonid Genkin <lgenkin@nvidia.com> 1.24.0-1
+- Bump version to 1.24.0
 * Thu Jun 25 2026 Shachar Hasson <shasson@nvidia.com> 1.23.0-1
 - Bump version to 1.23.0
 * Wed Mar 18 2026 Yossi Itigin <yosefe@nvidia.com> 1.22.0-1


### PR DESCRIPTION
## What?
Bump the version on master from 1.23.0 to 1.24.0.

## Why?
The v1.23.x release branch has been created, so master should move to the next development release.
