### PR TITLE
UCT/IB/MLX5: Avoid caching AH for UD/DC connect

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -1442,7 +1442,7 @@ const char *uct_ib_wc_status_str(enum ibv_wc_status wc_status)
     return ibv_wc_status_str(wc_status);
 }
 
-static ucs_status_t
+ucs_status_t
 uct_ib_device_create_ah(uct_ib_device_t *dev, struct ibv_ah_attr *ah_attr,
                         struct ibv_pd *pd, const char *usage,
                         struct ibv_ah **ah_p)

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -387,6 +387,15 @@ ucs_status_t uct_ib_device_find_port(uct_ib_device_t *dev,
 
 const char *uct_ib_wc_status_str(enum ibv_wc_status wc_status);
 
+/**
+ * Create an AH without caching it. The caller is responsible for destroying
+ * it with ibv_destroy_ah() once it is no longer needed.
+ */
+ucs_status_t
+uct_ib_device_create_ah(uct_ib_device_t *dev, struct ibv_ah_attr *ah_attr,
+                        struct ibv_pd *pd, const char *usage,
+                        struct ibv_ah **ah_p);
+
 ucs_status_t
 uct_ib_device_create_ah_cached(uct_ib_device_t *dev,
                                struct ibv_ah_attr *ah_attr, struct ibv_pd *pd,

--- a/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
@@ -1121,7 +1121,10 @@ ucs_status_t uct_dc_mlx5_ep_fc_pure_grant_send(uct_dc_mlx5_ep_t *ep,
                 "ep->dci: %u dcis length: %u", ep->dci,
                 ucs_array_length(&iface->tx.dcis));
 
-    /* TODO: look at common code with uct_ud_mlx5_iface_get_av */
+    /* TODO: look at common code with uct_ud_mlx5_iface_get_av. That path
+     * now creates its AH uncached to avoid retaining a stale resolved L2
+     * address; this one still relies on the AH cache and should move to
+     * the uncached uct_ib_device_create_ah() too. */
     if (fc_req->sender.payload.is_global) {
         uct_ib_iface_fill_ah_attr_from_gid_lid(
                 ib_iface, fc_req->lid,

--- a/src/uct/ib/mlx5/ud/ud_mlx5_common.c
+++ b/src/uct/ib/mlx5/ud/ud_mlx5_common.c
@@ -44,6 +44,7 @@ uct_ud_mlx5_iface_get_av(uct_ib_iface_t *iface,
     struct mlx5_wqe_av  mlx5_av;
     struct ibv_ah_attr  ah_attr;
     enum ibv_mtu        path_mtu;
+    int                 ret;
 
     status = uct_ib_iface_fill_ah_attr_from_addr(iface, ib_addr, path_index,
                                                  &ah_attr, &path_mtu);
@@ -51,13 +52,23 @@ uct_ud_mlx5_iface_get_av(uct_ib_iface_t *iface,
         return status;
     }
 
-    status = uct_ib_iface_create_ah(iface, &ah_attr, usage, &ah);
+    /* Create the AH transiently (uncached), since it is only used to
+     * extract the AV bytes below and caching it risks retaining a stale
+     * resolved L2 address if the peer's IP-to-MAC mapping changes. */
+    status = uct_ib_device_create_ah(uct_ib_iface_device(iface), &ah_attr,
+                                     uct_ib_iface_md(iface)->pd, usage, &ah);
     if (status != UCS_OK) {
         return status;
     }
     *is_global = ah_attr.is_global;
 
     uct_ib_mlx5_get_av(ah, &mlx5_av);
+
+    ret = ibv_destroy_ah(ah);
+    if (ret != 0) {
+        ucs_warn("%s: ibv_destroy_ah() failed with error %d: %m",
+                 uct_ib_device_name(uct_ib_iface_device(iface)), ret);
+    }
 
     base_av->stat_rate_sl = mlx5_av_base(&mlx5_av)->stat_rate_sl;
     base_av->fl_mlid      = mlx5_av_base(&mlx5_av)->fl_mlid;


### PR DESCRIPTION
## What?
UD mlx5 and DC connect no longer use cached address handle (AH). The shared `uct_ud_mlx5_iface_get_av()` helper now creates a temporary, uncached AH just to extract the AV bytes, then destroys it right away.
## Why?
The cached AH is keyed by resolved LID/GID and has no reliable invalidation path, so a peer's stale L2 address could keep being reused. The AH is only needed transiently here to read its AV bytes.
## How?
`uct_ud_mlx5_iface_get_av()` does not go through the cached AH store anymore. This single shared helper covers both callers: UD mlx5 connect and DC connect.

Connection matching and `is_connected()` already compared the resolved LID/GID/QPN params, not the AH itself, so nothing else needed to change there. DC's pure-grant reply still uses the cached path, left as a follow-up TODO since it could have performance implications.