### PR TITLE
UCS/TOPO: Fix off-by-one error in max device id check

### DIFF
--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -662,7 +662,7 @@ static ssize_t ucp_memh_do_pack(ucp_mem_h memh, uint64_t flags, int rkey_compat,
 {
     ucp_memory_info_t mem_info;
     ucs_status_t status;
-    ucs_sys_dev_distance_t sys_dev_distances[UCS_SYS_DEVICE_ID_MAX] = {};
+    ucs_sys_dev_distance_t sys_dev_distances[UCS_SYS_DEVICE_ID_COUNT] = {};
     ucs_sys_dev_distance_t *sys_distance;
     ucs_sys_device_t ep_sys_dev;
 
@@ -810,7 +810,7 @@ ucp_rkey_unpack_lanes_distance(const ucp_ep_config_key_t *ep_config_key,
 {
     const void *p                 = buffer;
     ucp_sys_dev_map_t sys_dev_map = 0;
-    ucs_sys_dev_distance_t distance, distance_by_dev[UCS_SYS_DEVICE_ID_MAX];
+    ucs_sys_dev_distance_t distance, distance_by_dev[UCS_SYS_DEVICE_ID_COUNT];
     ucs_sys_device_t sys_dev;
     ucp_lane_index_t lane;
     char buf[128];

--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -23,7 +23,6 @@
 #include <inttypes.h>
 
 
-#define UCS_TOPO_MAX_SYS_DEVICES     256
 #define UCS_TOPO_SYSFS_PCI_PREFIX    "/sys/bus/pci/devices/"
 #define UCS_TOPO_SYSFS_DEVICES_ROOT  "/sys/devices"
 #define UCS_TOPO_DEVICE_NAME_UNKNOWN "<unknown>"
@@ -101,7 +100,7 @@ KHASH_INIT(bus_to_sys_dev, ucs_topo_bus_value_key_t, ucs_sys_device_t, 1,
 typedef struct ucs_topo_global_ctx {
     ucs_spinlock_t             lock;
     khash_t(bus_to_sys_dev)    bus_to_sys_dev_hash;
-    ucs_topo_sys_device_info_t devices[UCS_TOPO_MAX_SYS_DEVICES];
+    ucs_topo_sys_device_info_t devices[UCS_SYS_DEVICE_ID_COUNT];
     unsigned                   num_devices;
 } ucs_topo_global_ctx_t;
 
@@ -432,7 +431,7 @@ ucs_topo_find_device_by_bus_id_value(const ucs_sys_bus_id_t *bus_id,
     } else if ((kh_put_status == UCS_KH_PUT_BUCKET_EMPTY) ||
                (kh_put_status == UCS_KH_PUT_BUCKET_CLEAR)) {
         ucs_assert_always(ucs_topo_global_ctx.num_devices <
-                          UCS_TOPO_MAX_SYS_DEVICES);
+                          UCS_SYS_DEVICE_ID_COUNT);
 
         name = ucs_malloc(UCS_SYS_BDF_NAME_MAX, "sys_dev_bdf_name");
         if (name == NULL) {

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -18,8 +18,9 @@
 BEGIN_C_DECLS
 
 
-/* Upper limit on system device id */
-#define UCS_SYS_DEVICE_ID_MAX UINT8_MAX
+/* Maximal valid system device id and number of valid ids */
+#define UCS_SYS_DEVICE_ID_MAX   (UINT8_MAX - 1)
+#define UCS_SYS_DEVICE_ID_COUNT (UCS_SYS_DEVICE_ID_MAX + 1)
 
 /* Indicate that the ucs_sys_device_t for the device has no real bus_id
  * e.g. virtual devices like CMA/knem */

--- a/test/gtest/ucs/test_topo.cc
+++ b/test/gtest/ucs/test_topo.cc
@@ -136,7 +136,7 @@ UCS_TEST_F(test_topo, find_device_by_bus_id) {
 
     status = ucs_topo_find_device_by_bus_id(&dummy_bus_id, &dev1);
     ASSERT_UCS_OK(status);
-    EXPECT_LT(dev1, UCS_SYS_DEVICE_ID_MAX);
+    EXPECT_LE(dev1, UCS_SYS_DEVICE_ID_MAX);
     status = ucs_topo_sys_device_set_name(dev1, "test_bus_id_1", 10);
     ASSERT_UCS_OK(status);
 
@@ -153,7 +153,7 @@ UCS_TEST_F(test_topo, find_device_by_bus_id) {
     status = ucs_topo_find_device_by_bus_id(&dummy_bus_id, &dev2);
     ASSERT_UCS_OK(status);
     EXPECT_EQ((unsigned)dev1 + 1, dev2);
-    EXPECT_LT(dev2, UCS_SYS_DEVICE_ID_MAX);
+    EXPECT_LE(dev2, UCS_SYS_DEVICE_ID_MAX);
     status = ucs_topo_sys_device_set_name(dev2, "test_bus_id_2", 10);
     ASSERT_UCS_OK(status);
 
@@ -188,7 +188,7 @@ UCS_TEST_F(test_topo, find_device_by_bus_id_and_user_value) {
     status = ucs_topo_find_device_by_bus_id_and_user_value(&dummy_bus_id,
                                                            user_value1, &dev1);
     ASSERT_UCS_OK(status);
-    EXPECT_LT(dev1, UCS_SYS_DEVICE_ID_MAX);
+    EXPECT_LE(dev1, UCS_SYS_DEVICE_ID_MAX);
 
     status = ucs_topo_find_device_by_bus_id_and_user_value(&dummy_bus_id,
                                                            user_value1,


### PR DESCRIPTION
## What?
Fix off-by-one error that could potentially assign a device with id `UCS_SYS_DEVICE_ID_UNKNOWN`.

## Why?
Previously `UCS_TOPO_MAX_SYS_DEVICES` was set to `256` which also included the special value of `UCS_SYS_DEVICE_ID_UNKNOWN`.
This means that a real device could be allocated an id that is equal to `UCS_SYS_DEVICE_ID_UNKNOWN`.
The correct value is `255`, but instead of just changing the value I made the macros depend on each other so it would be more robust.