### PR TITLE
UCT/IB/GDAKI: Relax RoCE route check for GPU-associated NICs

### DIFF
--- a/src/ucs/sys/netlink.c
+++ b/src/ucs/sys/netlink.c
@@ -374,13 +374,25 @@ int ucs_netlink_get_local_route_ndev_index(const struct sockaddr *sa_remote)
     return best_if_index;
 }
 
-int ucs_netlink_is_best_route(int if_index, const struct sockaddr *sa_remote)
+int ucs_netlink_route_matches(int if_index, const struct sockaddr *sa_remote,
+                              ucs_netlink_route_check_t route_check)
 {
     int netmask_len;
 
+    /* If there is no route to the destination through this interface, not even
+     * a default route, return 0. */
     if (!ucs_netlink_route_exists(if_index, sa_remote, &netmask_len)) {
         return 0;
     }
 
+    /* Relaxed mode accepts any matching non-default route. */
+    if ((route_check == UCS_NETLINK_ROUTE_CHECK_RELAXED) &&
+        (netmask_len > 0)) {
+        return 1;
+    }
+
+    /* Accept the route if it is the best match. In relaxed mode, this check is
+     * reached only for a default route, so the default is accepted only when
+     * no interface has a more specific route. */
     return (ucs_netlink_max_netmask_len(sa_remote) == netmask_len);
 }

--- a/src/ucs/sys/netlink.h
+++ b/src/ucs/sys/netlink.h
@@ -14,6 +14,11 @@
 
 BEGIN_C_DECLS
 
+typedef enum {
+    UCS_NETLINK_ROUTE_CHECK_BEST,
+    UCS_NETLINK_ROUTE_CHECK_RELAXED
+} ucs_netlink_route_check_t;
+
 /**
  * Callback function for parsing individual netlink messages.
  *
@@ -72,16 +77,20 @@ int ucs_netlink_route_exists(int if_index, const struct sockaddr *sa_remote,
 int ucs_netlink_get_local_route_ndev_index(const struct sockaddr *sa_remote);
 
 /**
- * Check if this network interface has the best route to the destination
- * address.
+ * Check whether a route to a given destination address through a network
+ * interface matches the requested policy.
  *
  * @param [in]  if_index         Network interface index.
  * @param [in]  sa_remote        Pointer to the destination address.
+ * @param [in]  route_check      When set to UCS_NETLINK_ROUTE_CHECK_RELAXED,
+ *                               accept any non-default route, or a default
+ *                               route if nothing better exists. Otherwise,
+ *                               accept only the best route.
  *
- * @return 1 if this network interface has the best route to the destination
- *         address, or 0 otherwise.
+ * @return 1 if the route is accepted by the requested policy, or 0 otherwise.
  */
-int ucs_netlink_is_best_route(int if_index, const struct sockaddr *sa_remote);
+int ucs_netlink_route_matches(int if_index, const struct sockaddr *sa_remote,
+                              ucs_netlink_route_check_t route_check);
 
 END_C_DECLS
 

--- a/src/uct/ib/base/ib_iface.c
+++ b/src/uct/ib/base/ib_iface.c
@@ -715,8 +715,8 @@ uct_ib_iface_roce_is_routable(uct_ib_iface_t *iface, uint8_t gid_index,
         return 0;
     }
 
-    if (ucs_netlink_is_best_route(ndev_index, sa_remote)) {
-        /* This interface has the best route */
+    if (ucs_netlink_route_matches(ndev_index, sa_remote,
+                                  UCS_NETLINK_ROUTE_CHECK_RELAXED)) {
         return 1;
     }
 

--- a/src/uct/tcp/tcp_iface.c
+++ b/src/uct/tcp/tcp_iface.c
@@ -266,8 +266,13 @@ uct_tcp_iface_is_reachable_v2(const uct_iface_h tl_iface,
         return 0;
     }
 
-    if (!ucs_netlink_is_best_route(ndev_index,
-                                   (const struct sockaddr*)&remote_addr)) {
+    /* TODO: Check using relaxed route (might need bind to device socket
+     * option). We currently assume here that with or without src address bind,
+     * kernel is going to anyway use the best route. So we make UCX refuse other
+     * interfaces. */
+    if (!ucs_netlink_route_matches(ndev_index,
+                                   (const struct sockaddr*)&remote_addr,
+                                   UCS_NETLINK_ROUTE_CHECK_BEST)) {
         uct_iface_fill_info_str_buf(
                     params, "no route to %s",
                     ucs_sockaddr_str((const struct sockaddr *)&remote_addr,


### PR DESCRIPTION
## What?
Allow rc_gda to use a valid route through its GPU-associated NIC even when another NIC has a more-specific route.

## Why?
The regular best-route check can select a NIC associated with another GPU and incorrectly mark rc_gda as unreachable.

## How?
For GDAKI interfaces, add a route check that accepts any matching non-default route, while allowing a default route only as a fallback if no other rules exist for this destination.