### PR TITLE
UCP/WIREUP: Add a token trailer and an ACK message to the lane address exchange

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2274,8 +2274,12 @@ static int ucp_ep_recovery_send_request(ucp_ep_h ep)
     ucs_debug("ep %p: sending recovery request, failed=0x%" PRIx64
               " recovery=0x%" PRIx64, ep, failed_lanes, recovery_lanes);
 
-    ucp_wireup_send_lanes_addr_msg(ep, UCP_WIREUP_MSG_LANES_ADDR_REQUEST,
-                                   failed_lanes, recovery_lanes);
+    /* A request answers no other message, so it asks about no lanes: the
+     * requested lanes of a LANES_ADDR message are the lanes its token trailer
+     * answers. */
+    ucp_wireup_send_lanes_addr_msg(ep, UCP_WIREUP_MSG_LANES_ADDR_REQUEST, 0,
+                                   recovery_lanes,
+                                   ++ep->ext->recovery_arg->request_id);
     return 1;
 }
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2275,9 +2275,14 @@ static int ucp_ep_recovery_send_request(ucp_ep_h ep)
               " recovery=0x%" PRIx64, ep, failed_lanes, recovery_lanes);
 
     /* A request answers no other message, so requested_lane_map is empty. */
+    if (++ep->ext->recovery_arg->request_id == 0) {
+        /* 0 is the no-trailer sentinel on the wire */
+        ep->ext->recovery_arg->request_id = 1;
+    }
+
     ucp_wireup_send_lanes_addr_msg(ep, UCP_WIREUP_MSG_LANES_ADDR_REQUEST, 0,
                                    recovery_lanes,
-                                   ++ep->ext->recovery_arg->request_id);
+                                   ep->ext->recovery_arg->request_id);
     return 1;
 }
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -2274,9 +2274,7 @@ static int ucp_ep_recovery_send_request(ucp_ep_h ep)
     ucs_debug("ep %p: sending recovery request, failed=0x%" PRIx64
               " recovery=0x%" PRIx64, ep, failed_lanes, recovery_lanes);
 
-    /* A request answers no other message, so it asks about no lanes: the
-     * requested lanes of a LANES_ADDR message are the lanes its token trailer
-     * answers. */
+    /* A request answers no other message, so requested_lane_map is empty. */
     ucp_wireup_send_lanes_addr_msg(ep, UCP_WIREUP_MSG_LANES_ADDR_REQUEST, 0,
                                    recovery_lanes,
                                    ++ep->ext->recovery_arg->request_id);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -517,7 +517,7 @@ typedef struct ucp_ep_recovery_arg {
      * and echoed by the peer in its answers. Only carried on the wire for now,
      * the follow-up patch matches it against the tokens of an answer to tell
      * apart the round they belong to */
-    uint64_t                request_id;
+    uint32_t                request_id;
     ucp_ep_recovery_probe_t probe[UCP_MAX_LANES];
 } ucp_ep_recovery_arg_t;
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -513,6 +513,11 @@ typedef struct ucp_ep_recovery_arg {
     /* number of retries left before giving up */
     unsigned                retries_left;
     uint8_t                 state;
+    /* Generation of the LANES_ADDR exchange, pre-incremented by every request
+     * and echoed by the peer in its answers. Only carried on the wire for now,
+     * the follow-up patch matches it against the tokens of an answer to tell
+     * apart the round they belong to */
+    uint64_t                request_id;
     ucp_ep_recovery_probe_t probe[UCP_MAX_LANES];
 } ucp_ep_recovery_arg_t;
 

--- a/src/ucp/wireup/AGENTS.md
+++ b/src/ucp/wireup/AGENTS.md
@@ -9,7 +9,10 @@ exchanged out-of-band) and connection-manager wireup (sockaddr listener).
 
 - `wireup.[ch]` — the wireup state machine. Defines the on-wire message
   types `UCP_WIREUP_MSG_{PRE_REQUEST, REQUEST, REPLY, ACK, EP_CHECK,
-  EP_REMOVED, REPLY_RECONFIG}` and drives transitions on send/recv.
+  EP_REMOVED, REPLY_RECONFIG, LANES_ADDR_REQUEST, LANES_ADDR_REPLY,
+  LANES_ADDR_ACK}` and drives transitions on send/recv. The `LANES_ADDR`
+  family re-exchanges the addresses of failed lanes during recovery, and
+  carries the trailer of the UCT lane tokens used to purge them.
 - `address.[ch]` — packing and unpacking of `ucp_address_t`: per-device
   records, per-iface records, atomic capability bits, system-device IDs,
   and connection info. ABI-sensitive: any layout change must add a version
@@ -41,6 +44,13 @@ exchanged out-of-band) and connection-manager wireup (sockaddr listener).
   through reserved bits/length fields, never field reordering. See the
   `UCP_WIREUP_MSG_*` constants in `wireup.h` and the matching pack/unpack
   in `wireup.c`.
+- A payload section appended to an already released message must be gated
+  by a `*_MIN_DST_VERSION` constant checked against
+  `ucp_ep_config(ep)->key.dst_version`, and must carry its own length so
+  the rest of the payload stays parsable. `LANES_ADDR` token trailers work
+  this way, see `UCP_WIREUP_ADDR_TOKEN_MIN_DST_VERSION`. Their lanes are
+  taken from the lane maps of `ucp_wireup_msg_lanes_info_t` rather than from
+  maps of their own, so keep the two in sync when changing either.
 - New transport capabilities advertised via address records require both
   a packer in `address.c` and a consumer in `select.c`. Forgetting one
   half silently disables the capability for the new build vs. old peers.

--- a/src/ucp/wireup/AGENTS.md
+++ b/src/ucp/wireup/AGENTS.md
@@ -46,11 +46,13 @@ exchanged out-of-band) and connection-manager wireup (sockaddr listener).
   in `wireup.c`.
 - A payload section appended to an already released message must be gated
   by a `*_MIN_DST_VERSION` constant checked against
-  `ucp_ep_config(ep)->key.dst_version`, and must carry its own length so
-  the rest of the payload stays parsable. `LANES_ADDR` token trailers work
-  this way, see `UCP_WIREUP_ADDR_TOKEN_MIN_DST_VERSION`. Their lanes are
-  taken from the lane maps of `ucp_wireup_msg_lanes_info_t` rather than from
-  maps of their own, so keep the two in sync when changing either.
+  `ucp_ep_config(ep)->key.dst_version`. Variable-length pieces go before
+  the rest of the payload so an older peer, which never sees them, still
+  finds the original contents. `LANES_ADDR` token trailers work this way,
+  see `UCP_WIREUP_ADDR_TOKEN_MIN_DST_VERSION`: each token is prefixed by
+  its own length, and the addresses stay last. Trailer lanes are taken
+  from `ucp_wireup_msg_lanes_info_t` rather than from maps of their own,
+  so keep the two in sync when changing either.
 - New transport capabilities advertised via address records require both
   a packer in `address.c` and a consumer in `select.c`. Forgetting one
   half silently disables the capability for the new build vs. old peers.

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -305,10 +305,11 @@ ucp_wireup_pack_token_payload(ucp_ep_h ep, ucp_lane_map_t requested_lane_map,
     /* One length byte per lane of the TX section and of the RX section */
     size_t num_lengths    = ucs_popcount(provided_lane_map) +
                             ucs_popcount(requested_lane_map);
-    size_t payload_length = sizeof(ucp_wireup_msg_tokens_info_t) +
-                            num_lengths + address_length;
     ucp_wireup_msg_tokens_info_t *tokens_info;
+    size_t payload_length;
     void *payload, *ptr;
+
+    payload_length = sizeof(*tokens_info) + num_lengths + address_length;
 
     payload = ucs_malloc(payload_length, "wireup_lanes_addr_payload");
     if (payload == NULL) {

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -75,9 +75,18 @@ const char* ucp_wireup_msg_str(uint8_t msg_type)
         return "LANES_ADDR_REQ";
     case UCP_WIREUP_MSG_LANES_ADDR_REPLY:
         return "LANES_ADDR_REP";
+    case UCP_WIREUP_MSG_LANES_ADDR_ACK:
+        return "LANES_ADDR_ACK";
     default:
         return "<unknown>";
     }
+}
+
+static int ucp_wireup_msg_is_lanes_addr(uint8_t msg_type)
+{
+    return (msg_type == UCP_WIREUP_MSG_LANES_ADDR_REQUEST) ||
+           (msg_type == UCP_WIREUP_MSG_LANES_ADDR_REPLY) ||
+           (msg_type == UCP_WIREUP_MSG_LANES_ADDR_ACK);
 }
 
 static ucp_lane_index_t ucp_wireup_get_msg_lane(ucp_ep_h ep, uint8_t msg_type)
@@ -87,8 +96,7 @@ static ucp_lane_index_t ucp_wireup_get_msg_lane(ucp_ep_h ep, uint8_t msg_type)
     ucp_lane_index_t lane, fallback_lane;
 
     if ((msg_type == UCP_WIREUP_MSG_ACK) ||
-        (msg_type == UCP_WIREUP_MSG_LANES_ADDR_REQUEST) ||
-        (msg_type == UCP_WIREUP_MSG_LANES_ADDR_REPLY)) {
+        ucp_wireup_msg_is_lanes_addr(msg_type)) {
         /* Post-failover, wireup_msg_lane may itself be failed - prefer the
          * re-selected operable AM lane. */
         lane          = ep_config->key.am_lane;
@@ -163,8 +171,7 @@ ucs_status_t ucp_wireup_msg_progress(uct_pending_req_t *self)
 
     wireup_msg_iov[0].iov_base = &req->send.wireup.msg_hdr;
     wireup_msg_iov[0].iov_len  = sizeof(req->send.wireup.msg_hdr);
-    if ((req->send.wireup.msg_hdr.type == UCP_WIREUP_MSG_LANES_ADDR_REQUEST) ||
-        (req->send.wireup.msg_hdr.type == UCP_WIREUP_MSG_LANES_ADDR_REPLY)) {
+    if (ucp_wireup_msg_is_lanes_addr(req->send.wireup.msg_hdr.type)) {
         VALGRIND_CHECK_MEM_IS_DEFINED(&req->send.wireup.lanes_info,
                                       sizeof(req->send.wireup.lanes_info));
         wireup_msg_iov[0].iov_len += sizeof(req->send.wireup.lanes_info);
@@ -257,8 +264,7 @@ ucp_wireup_msg_prepare(ucp_ep_h ep, uint8_t type,
         msg_hdr->dst_ep_id = UCS_PTR_MAP_KEY_INVALID;
     }
 
-    if ((type == UCP_WIREUP_MSG_LANES_ADDR_REQUEST) ||
-        (type == UCP_WIREUP_MSG_LANES_ADDR_REPLY)) {
+    if (ucp_wireup_msg_is_lanes_addr(type)) {
         lanes_info = (ucp_wireup_msg_lanes_info_t *)(msg_hdr + 1);
         lanes_info->requested_lane_map = requested_lane_map;
         lanes_info->provided_lane_map  = provided_lane_map;
@@ -278,12 +284,60 @@ ucp_wireup_msg_prepare(ucp_ep_h ep, uint8_t type,
     return status;
 }
 
+/* Both peers must agree on the presence of the token trailer, and they do so
+ * by the remote release version. */
+static int ucp_wireup_ep_supports_tokens(ucp_ep_h ep)
+{
+    return ucp_ep_config(ep)->key.dst_version >=
+           UCP_WIREUP_ADDR_TOKEN_MIN_DST_VERSION;
+}
+
+/* Replace the packed address by a payload holding the token trailer followed by
+ * the address, as described by @ref ucp_wireup_msg_tokens_info_t. */
+static ucs_status_t
+ucp_wireup_pack_token_payload(ucp_ep_h ep, ucp_lane_map_t requested_lane_map,
+                              ucp_lane_map_t provided_lane_map,
+                              uint64_t request_id, void **payload_p,
+                              size_t *payload_length_p)
+{
+    void *address         = *payload_p;
+    size_t address_length = *payload_length_p;
+    /* One length byte per lane of the TX section and of the RX section */
+    size_t num_lengths    = ucs_popcount(provided_lane_map) +
+                            ucs_popcount(requested_lane_map);
+    size_t payload_length = sizeof(ucp_wireup_msg_tokens_info_t) +
+                            num_lengths + address_length;
+    ucp_wireup_msg_tokens_info_t *tokens_info;
+    void *payload, *ptr;
+
+    payload = ucs_malloc(payload_length, "wireup_lanes_addr_payload");
+    if (payload == NULL) {
+        ucs_error("ep %p: failed to allocate %zu bytes of LANES_ADDR payload",
+                  ep, payload_length);
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    tokens_info             = payload;
+    tokens_info->request_id = request_id;
+
+    /* Both sections declare a zero length for every lane, until the lanes
+     * provide tokens */
+    ptr = UCS_PTR_TYPE_OFFSET(tokens_info, ucp_wireup_msg_tokens_info_t);
+    memset(ptr, 0, num_lengths);
+    memcpy(UCS_PTR_BYTE_OFFSET(ptr, num_lengths), address, address_length);
+
+    ucs_free(address);
+    *payload_p        = payload;
+    *payload_length_p = payload_length;
+    return UCS_OK;
+}
+
 static ucs_status_t
 ucp_wireup_msg_send_full(ucp_ep_h ep, uint8_t type,
                          const ucp_tl_bitmap_t *tl_bitmap,
                          const ucp_lane_index_t *lanes2remote,
                          ucp_lane_map_t requested_lane_map,
-                         ucp_lane_map_t provided_lane_map)
+                         ucp_lane_map_t provided_lane_map, uint64_t request_id)
 {
     ucp_request_t *req;
     ucs_status_t status;
@@ -321,6 +375,19 @@ ucp_wireup_msg_send_full(ucp_ep_h ep, uint8_t type,
         goto err;
     }
 
+    if (ucp_wireup_msg_is_lanes_addr(type) &&
+        ucp_wireup_ep_supports_tokens(ep)) {
+        status = ucp_wireup_pack_token_payload(ep, requested_lane_map,
+                                               provided_lane_map, request_id,
+                                               &req->send.buffer,
+                                               &req->send.length);
+        if (status != UCS_OK) {
+            ucs_free(req->send.buffer);
+            ucp_request_mem_free(req);
+            goto err;
+        }
+    }
+
     ucp_request_send(req);
     /* coverity[leaked_storage] */
     return UCS_OK;
@@ -334,7 +401,7 @@ static ucs_status_t
 ucp_wireup_msg_send(ucp_ep_h ep, uint8_t type, const ucp_tl_bitmap_t *tl_bitmap,
                     const ucp_lane_index_t *lanes2remote)
 {
-    return ucp_wireup_msg_send_full(ep, type, tl_bitmap, lanes2remote, 0, 0);
+    return ucp_wireup_msg_send_full(ep, type, tl_bitmap, lanes2remote, 0, 0, 0);
 }
 
 static ucp_tl_bitmap_t
@@ -1019,7 +1086,8 @@ ucp_wireup_augment_aux_tls(ucp_ep_h ep, ucp_lane_map_t lane_map,
 
 void ucp_wireup_send_lanes_addr_msg(ucp_ep_h ep, uint8_t msg_type,
                                     ucp_lane_map_t requested_lane_map,
-                                    ucp_lane_map_t provided_lane_map)
+                                    ucp_lane_map_t provided_lane_map,
+                                    uint64_t request_id)
 {
     ucp_tl_bitmap_t tl_bitmap;
     ucs_status_t status;
@@ -1027,25 +1095,58 @@ void ucp_wireup_send_lanes_addr_msg(ucp_ep_h ep, uint8_t msg_type,
     tl_bitmap = ucp_wireup_get_ep_tl_bitmap(ep, provided_lane_map);
     ucp_wireup_augment_aux_tls(ep, provided_lane_map, &tl_bitmap);
 
-    ucs_debug("ep %p: send %s requested=0x%" PRIx64 " provided=0x%" PRIx64, ep,
-              ucp_wireup_msg_str(msg_type), (uint64_t)requested_lane_map,
-              (uint64_t)provided_lane_map);
+    ucs_debug("ep %p: send %s requested=0x%" PRIx64 " provided=0x%" PRIx64
+              " request_id=0x%" PRIx64,
+              ep, ucp_wireup_msg_str(msg_type), (uint64_t)requested_lane_map,
+              (uint64_t)provided_lane_map, request_id);
 
     status = ucp_wireup_msg_send_full(ep, msg_type, &tl_bitmap, NULL,
-                                      requested_lane_map, provided_lane_map);
+                                      requested_lane_map, provided_lane_map,
+                                      request_id);
     if (status != UCS_OK) {
         ucs_diag("ep %p: failed to send %s: %s", ep,
                  ucp_wireup_msg_str(msg_type), ucs_status_string(status));
     }
 }
 
+ucs_status_t
+ucp_wireup_skip_token_section(ucp_lane_map_t lane_map, const void *section,
+                              size_t avail, size_t *consumed_p)
+{
+    unsigned num_tokens = ucs_popcount(lane_map);
+    const uint8_t *lengths;
+    size_t offset;
+    unsigned index;
+
+    *consumed_p = 0;
+    if (lane_map == 0) {
+        return UCS_OK;
+    }
+
+    if (avail < num_tokens) {
+        return UCS_ERR_MESSAGE_TRUNCATED;
+    }
+
+    lengths = section;
+    offset  = num_tokens;
+    for (index = 0; index < num_tokens; ++index) {
+        if ((avail - offset) < lengths[index]) {
+            return UCS_ERR_MESSAGE_TRUNCATED;
+        }
+
+        offset += lengths[index];
+    }
+
+    *consumed_p = offset;
+    return UCS_OK;
+}
+
 static UCS_F_NOINLINE void
 ucp_wireup_process_lanes_addr_request(
         ucp_worker_h worker, ucp_ep_h ep, const ucp_wireup_msg_t *msg,
+        const ucp_wireup_msg_lanes_info_t *lanes_info, uint64_t request_id,
         const ucp_unpacked_address_t *remote_address)
 {
-    const ucp_wireup_msg_lanes_info_t *lanes_info =
-            (const ucp_wireup_msg_lanes_info_t *)(msg + 1);
     ucp_lane_map_t peer_unaware, to_rebuild, peer_provided;
     ucs_status_t status;
 
@@ -1084,18 +1185,19 @@ ucp_wireup_process_lanes_addr_request(
 
     /* Always reply, even if peer_provided == 0, so the initiator knows the
      * peer handled the request (empty provided_lane_map means "I couldn't
-     * satisfy any of the lanes you asked about"). */
+     * satisfy any of the lanes you asked about"). The reply answers the lanes
+     * the request provided, so its token trailer belongs to them. */
     ucp_wireup_send_lanes_addr_msg(ep, UCP_WIREUP_MSG_LANES_ADDR_REPLY,
-                                   lanes_info->requested_lane_map, peer_provided);
+                                   lanes_info->provided_lane_map, peer_provided,
+                                   request_id);
 }
 
 static UCS_F_NOINLINE void
 ucp_wireup_process_lanes_addr_reply(
         ucp_worker_h worker, ucp_ep_h ep, const ucp_wireup_msg_t *msg,
+        const ucp_wireup_msg_lanes_info_t *lanes_info, uint64_t request_id,
         const ucp_unpacked_address_t *remote_address)
 {
-    const ucp_wireup_msg_lanes_info_t *lanes_info =
-            (const ucp_wireup_msg_lanes_info_t *)(msg + 1);
     ucp_lane_map_t rebuilt;
 
     ucp_ep_update_remote_id(ep, msg->src_ep_id);
@@ -1116,6 +1218,88 @@ ucp_wireup_process_lanes_addr_reply(
 
     /* ucp_ep_recovery_progress owns FAILED-bit clearing and the retry
      * cadence; do not clear or re-send inline here. */
+
+    if (request_id == 0) {
+        /* The ACK exists only to carry tokens, and a peer which does not add
+         * the trailer would not know the message type either */
+        return;
+    }
+
+    /* Close the exchange, so that the peer knows the reply arrived. The ACK
+     * answers the lanes the reply provided, so its token trailer belongs to
+     * them. */
+    ucp_wireup_send_lanes_addr_msg(ep, UCP_WIREUP_MSG_LANES_ADDR_ACK,
+                                   lanes_info->provided_lane_map, 0,
+                                   request_id);
+}
+
+/* Locate the lanes info and the optional token trailer of a LANES_ADDR
+ * message, and return the packed addresses which follow them. The exchange
+ * generation is 0 if the peer added no trailer. */
+static ucs_status_t
+ucp_wireup_parse_lanes_addr(ucp_ep_h ep, const ucp_wireup_msg_t *msg,
+                            size_t length,
+                            const ucp_wireup_msg_lanes_info_t **lanes_info_p,
+                            uint64_t *request_id_p, const void **address_p)
+{
+    const ucp_wireup_msg_tokens_info_t *tokens_info;
+    const ucp_wireup_msg_lanes_info_t *lanes_info;
+    size_t remain, consumed;
+    ucs_status_t status;
+    const void *ptr;
+
+    if (length < (sizeof(*msg) + sizeof(*lanes_info))) {
+        ucs_warn("ep %p: dropping truncated %s of %zu bytes", ep,
+                 ucp_wireup_msg_str(msg->type), length);
+        return UCS_ERR_MESSAGE_TRUNCATED;
+    }
+
+    lanes_info    = (const ucp_wireup_msg_lanes_info_t*)(msg + 1);
+    ptr           = UCS_PTR_TYPE_OFFSET(lanes_info,
+                                        ucp_wireup_msg_lanes_info_t);
+    remain        = length - sizeof(*msg) - sizeof(*lanes_info);
+    *lanes_info_p = lanes_info;
+    *request_id_p = 0;
+
+    if (!ucp_wireup_ep_supports_tokens(ep)) {
+        /* The peer adds no token trailer, the addresses follow the lanes info
+         * directly */
+        *address_p = ptr;
+        return UCS_OK;
+    }
+
+    if (remain < sizeof(*tokens_info)) {
+        ucs_warn("ep %p: dropping %s without a token trailer", ep,
+                 ucp_wireup_msg_str(msg->type));
+        return UCS_ERR_MESSAGE_TRUNCATED;
+    }
+
+    tokens_info = ptr;
+    ptr         = UCS_PTR_TYPE_OFFSET(tokens_info,
+                                      ucp_wireup_msg_tokens_info_t);
+    remain     -= sizeof(*tokens_info);
+
+    /* The TX tokens belong to the lanes the peer provided, and the RX ones to
+     * the lanes it answers. Both sections are skipped until the tokens
+     * themselves are exchanged. */
+    status = ucp_wireup_skip_token_section(lanes_info->provided_lane_map, ptr,
+                                           remain, &consumed);
+    if (status == UCS_OK) {
+        ptr     = UCS_PTR_BYTE_OFFSET(ptr, consumed);
+        remain -= consumed;
+        status  = ucp_wireup_skip_token_section(lanes_info->requested_lane_map,
+                                                ptr, remain, &consumed);
+    }
+
+    if (status != UCS_OK) {
+        ucs_warn("ep %p: dropping %s with a malformed token section", ep,
+                 ucp_wireup_msg_str(msg->type));
+        return status;
+    }
+
+    *request_id_p = tokens_info->request_id;
+    *address_p    = UCS_PTR_BYTE_OFFSET(ptr, consumed);
+    return UCS_OK;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -1126,7 +1310,9 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
     ucp_worker_h worker   = arg;
     ucp_wireup_msg_t *msg = data;
     ucp_ep_h ep           = NULL;
-    void *address_ptr;
+    uint64_t request_id   = 0;
+    const ucp_wireup_msg_lanes_info_t *lanes_info;
+    const void *address_ptr;
     ucp_unpacked_address_t remote_address;
     ucs_status_t status;
 
@@ -1147,10 +1333,13 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
     }
 
     address_ptr = msg + 1;
-    if ((msg->type == UCP_WIREUP_MSG_LANES_ADDR_REQUEST) ||
-        (msg->type == UCP_WIREUP_MSG_LANES_ADDR_REPLY)) {
-        address_ptr = UCS_PTR_TYPE_OFFSET(address_ptr,
-                                          ucp_wireup_msg_lanes_info_t);
+    if (ucp_wireup_msg_is_lanes_addr(msg->type)) {
+        ucs_assert(ep != NULL);
+        status = ucp_wireup_parse_lanes_addr(ep, msg, length, &lanes_info,
+                                             &request_id, &address_ptr);
+        if (status != UCS_OK) {
+            goto out;
+        }
     }
 
     status = ucp_address_unpack(worker, address_ptr, UCP_ADDRESS_PACK_FLAGS_ALL,
@@ -1178,14 +1367,14 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
         ucs_assert(msg->dst_ep_id != UCS_PTR_MAP_KEY_INVALID);
         ucp_ep_set_lanes_failed_schedule(ep, 0, UCS_ERR_CONNECTION_RESET);
     } else if (msg->type == UCP_WIREUP_MSG_LANES_ADDR_REQUEST) {
-        ucs_assert(msg->dst_ep_id != UCS_PTR_MAP_KEY_INVALID);
-        ucs_assert(ep != NULL);
-        ucp_wireup_process_lanes_addr_request(worker, ep, msg,
-                                              &remote_address);
+        ucp_wireup_process_lanes_addr_request(worker, ep, msg, lanes_info,
+                                              request_id, &remote_address);
     } else if (msg->type == UCP_WIREUP_MSG_LANES_ADDR_REPLY) {
-        ucs_assert(msg->dst_ep_id != UCS_PTR_MAP_KEY_INVALID);
-        ucs_assert(ep != NULL);
-        ucp_wireup_process_lanes_addr_reply(worker, ep, msg, &remote_address);
+        ucp_wireup_process_lanes_addr_reply(worker, ep, msg, lanes_info,
+                                            request_id, &remote_address);
+    } else if (msg->type == UCP_WIREUP_MSG_LANES_ADDR_ACK) {
+        ucs_debug("ep %p: LANES_ADDR_ACK request_id=0x%" PRIx64, ep,
+                  request_id);
     } else {
         ucs_bug("invalid wireup message");
     }

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1310,10 +1310,10 @@ ucp_wireup_parse_lanes_addr(ucp_ep_h ep, const ucp_wireup_msg_t *msg,
 static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
                                            size_t length, unsigned flags)
 {
-    ucp_worker_h worker   = arg;
-    ucp_wireup_msg_t *msg = data;
-    ucp_ep_h ep           = NULL;
-    uint32_t request_id   = 0;
+    ucp_worker_h worker                           = arg;
+    ucp_wireup_msg_t *msg                         = data;
+    ucp_ep_h ep                                   = NULL;
+    uint32_t request_id                           = 0;
     const ucp_wireup_msg_lanes_info_t *lanes_info = NULL;
     const void *address_ptr;
     ucp_unpacked_address_t remote_address;

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -297,7 +297,7 @@ static int ucp_wireup_ep_supports_tokens(ucp_ep_h ep)
 static ucs_status_t
 ucp_wireup_pack_token_payload(ucp_ep_h ep, ucp_lane_map_t requested_lane_map,
                               ucp_lane_map_t provided_lane_map,
-                              uint64_t request_id, void **payload_p,
+                              uint32_t request_id, void **payload_p,
                               size_t *payload_length_p)
 {
     void *address         = *payload_p;
@@ -338,7 +338,7 @@ ucp_wireup_msg_send_full(ucp_ep_h ep, uint8_t type,
                          const ucp_tl_bitmap_t *tl_bitmap,
                          const ucp_lane_index_t *lanes2remote,
                          ucp_lane_map_t requested_lane_map,
-                         ucp_lane_map_t provided_lane_map, uint64_t request_id)
+                         ucp_lane_map_t provided_lane_map, uint32_t request_id)
 {
     ucp_request_t *req;
     ucs_status_t status;
@@ -1088,7 +1088,7 @@ ucp_wireup_augment_aux_tls(ucp_ep_h ep, ucp_lane_map_t lane_map,
 void ucp_wireup_send_lanes_addr_msg(ucp_ep_h ep, uint8_t msg_type,
                                     ucp_lane_map_t requested_lane_map,
                                     ucp_lane_map_t provided_lane_map,
-                                    uint64_t request_id)
+                                    uint32_t request_id)
 {
     ucp_tl_bitmap_t tl_bitmap;
     ucs_status_t status;
@@ -1097,7 +1097,7 @@ void ucp_wireup_send_lanes_addr_msg(ucp_ep_h ep, uint8_t msg_type,
     ucp_wireup_augment_aux_tls(ep, provided_lane_map, &tl_bitmap);
 
     ucs_debug("ep %p: send %s requested=0x%" PRIx64 " provided=0x%" PRIx64
-              " request_id=0x%" PRIx64,
+              " request_id=0x%" PRIx32,
               ep, ucp_wireup_msg_str(msg_type), (uint64_t)requested_lane_map,
               (uint64_t)provided_lane_map, request_id);
 
@@ -1145,7 +1145,7 @@ ucp_wireup_skip_token_section(ucp_lane_map_t lane_map, const void *section,
 static UCS_F_NOINLINE void
 ucp_wireup_process_lanes_addr_request(
         ucp_worker_h worker, ucp_ep_h ep, const ucp_wireup_msg_t *msg,
-        const ucp_wireup_msg_lanes_info_t *lanes_info, uint64_t request_id,
+        const ucp_wireup_msg_lanes_info_t *lanes_info, uint32_t request_id,
         const ucp_unpacked_address_t *remote_address)
 {
     ucp_lane_map_t peer_unaware, to_rebuild, peer_provided;
@@ -1196,7 +1196,7 @@ ucp_wireup_process_lanes_addr_request(
 static UCS_F_NOINLINE void
 ucp_wireup_process_lanes_addr_reply(
         ucp_worker_h worker, ucp_ep_h ep, const ucp_wireup_msg_t *msg,
-        const ucp_wireup_msg_lanes_info_t *lanes_info, uint64_t request_id,
+        const ucp_wireup_msg_lanes_info_t *lanes_info, uint32_t request_id,
         const ucp_unpacked_address_t *remote_address)
 {
     ucp_lane_map_t rebuilt;
@@ -1241,7 +1241,7 @@ static ucs_status_t
 ucp_wireup_parse_lanes_addr(ucp_ep_h ep, const ucp_wireup_msg_t *msg,
                             size_t length,
                             const ucp_wireup_msg_lanes_info_t **lanes_info_p,
-                            uint64_t *request_id_p, const void **address_p)
+                            uint32_t *request_id_p, const void **address_p)
 {
     const ucp_wireup_msg_tokens_info_t *tokens_info;
     const ucp_wireup_msg_lanes_info_t *lanes_info;
@@ -1311,8 +1311,8 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
     ucp_worker_h worker   = arg;
     ucp_wireup_msg_t *msg = data;
     ucp_ep_h ep           = NULL;
-    uint64_t request_id   = 0;
-    const ucp_wireup_msg_lanes_info_t *lanes_info;
+    uint32_t request_id   = 0;
+    const ucp_wireup_msg_lanes_info_t *lanes_info = NULL;
     const void *address_ptr;
     ucp_unpacked_address_t remote_address;
     ucs_status_t status;
@@ -1368,13 +1368,15 @@ static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
         ucs_assert(msg->dst_ep_id != UCS_PTR_MAP_KEY_INVALID);
         ucp_ep_set_lanes_failed_schedule(ep, 0, UCS_ERR_CONNECTION_RESET);
     } else if (msg->type == UCP_WIREUP_MSG_LANES_ADDR_REQUEST) {
+        ucs_assert(lanes_info != NULL);
         ucp_wireup_process_lanes_addr_request(worker, ep, msg, lanes_info,
                                               request_id, &remote_address);
     } else if (msg->type == UCP_WIREUP_MSG_LANES_ADDR_REPLY) {
+        ucs_assert(lanes_info != NULL);
         ucp_wireup_process_lanes_addr_reply(worker, ep, msg, lanes_info,
                                             request_id, &remote_address);
     } else if (msg->type == UCP_WIREUP_MSG_LANES_ADDR_ACK) {
-        ucs_debug("ep %p: LANES_ADDR_ACK request_id=0x%" PRIx64, ep,
+        ucs_debug("ep %p: LANES_ADDR_ACK request_id=0x%" PRIx32, ep,
                   request_id);
     } else {
         ucs_bug("invalid wireup message");

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1220,11 +1220,13 @@ ucp_wireup_process_lanes_addr_reply(
     /* ucp_ep_recovery_progress owns FAILED-bit clearing and the retry
      * cadence; do not clear or re-send inline here. */
 
-    if (request_id == 0) {
+    if (!ucp_wireup_ep_supports_tokens(ep)) {
         /* The ACK exists only to carry tokens, and a peer which does not add
          * the trailer would not know the message type either */
         return;
     }
+
+    ucs_assert(request_id != 0);
 
     /* Close the exchange, so that the peer knows the reply arrived. The ACK
      * answers the lanes the reply provided, so its token trailer belongs to

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -182,7 +182,7 @@ typedef struct ucp_wireup_msg_tokens_info_t {
     /* Exchange generation, echoed by the peer in its answers, to be matched
      * against the tokens once they are carried. Starts from 1, so that 0 tells
      * the receiver the message came without a trailer at all. */
-    uint64_t request_id;
+    uint32_t request_id;
     /* uint8_t tx_lengths[popcount(provided_lane_map)] followed by the TX
      * tokens, then uint8_t rx_lengths[popcount(requested_lane_map)] followed by
      * the RX tokens, then the packed addresses. A zero length means the
@@ -300,7 +300,7 @@ unsigned ucp_wireup_eps_progress(void *arg);
 void ucp_wireup_send_lanes_addr_msg(ucp_ep_h ep, uint8_t msg_type,
                                     ucp_lane_map_t requested_lane_map,
                                     ucp_lane_map_t provided_lane_map,
-                                    uint64_t request_id);
+                                    uint32_t request_id);
 
 
 /* Size of one token section (gtest feeds it crafted buffers). */

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -63,7 +63,7 @@ enum {
  * Minimal peer release version which understands the token trailer of the
  * LANES_ADDR messages. Older peers get the messages without any token.
  */
-#define UCP_WIREUP_ADDR_TOKEN_MIN_DST_VERSION 23
+#define UCP_WIREUP_ADDR_TOKEN_MIN_DST_VERSION 24
 
 
 /**
@@ -161,11 +161,11 @@ typedef struct ucp_wireup_msg {
 
 
 typedef struct ucp_wireup_msg_lanes_info_t {
-    /* Lanes the sender asked about, which are also the lanes the peer provided
-     * in the message being answered, so the RX tokens of the trailer belong to
-     * them. Empty in a REQUEST, which answers nothing. */
+    /* Lanes the sender asked about. Empty in a REQUEST, which answers nothing.
+     * When the token trailer is present, these are also the RX-token lanes. */
     ucp_lane_map_t         requested_lane_map;
-    /* Lanes whose addresses and TX tokens are carried here */
+    /* Lanes whose addresses are carried here. When the token trailer is
+     * present, these are also the TX-token lanes. */
     ucp_lane_map_t         provided_lane_map;
     /* @ref ucp_wireup_msg_tokens_info_t (only towards peers of release version
      * UCP_WIREUP_ADDR_TOKEN_MIN_DST_VERSION and above), then packed addresses
@@ -303,19 +303,7 @@ void ucp_wireup_send_lanes_addr_msg(ucp_ep_h ep, uint8_t msg_type,
                                     uint64_t request_id);
 
 
-/**
- * Measure one token section of a LANES_ADDR message, holding one length byte
- * per lane of @a lane_map followed by the tokens themselves.
- *
- * @param [in]  lane_map    Lanes the section describes, in ascending order.
- * @param [in]  section     Start of the section.
- * @param [in]  avail       Bytes left in the message from @a section on.
- * @param [out] consumed_p  Size of the section.
- *
- * @return UCS_ERR_MESSAGE_TRUNCATED if the section does not fit in @a avail.
- *
- * Exposed for gtest, which feeds it crafted sections.
- */
+/* Size of one token section (gtest feeds it crafted buffers). */
 ucs_status_t
 ucp_wireup_skip_token_section(ucp_lane_map_t lane_map, const void *section,
                               size_t avail, size_t *consumed_p);

--- a/src/ucp/wireup/wireup.h
+++ b/src/ucp/wireup/wireup.h
@@ -53,9 +53,17 @@ enum {
     UCP_WIREUP_MSG_REPLY_RECONFIG,
     UCP_WIREUP_MSG_LANES_ADDR_REQUEST,
     UCP_WIREUP_MSG_LANES_ADDR_REPLY,
+    UCP_WIREUP_MSG_LANES_ADDR_ACK,
 
     UCP_WIREUP_MSG_LAST
 };
+
+
+/*
+ * Minimal peer release version which understands the token trailer of the
+ * LANES_ADDR messages. Older peers get the messages without any token.
+ */
+#define UCP_WIREUP_ADDR_TOKEN_MIN_DST_VERSION 23
 
 
 /**
@@ -153,10 +161,35 @@ typedef struct ucp_wireup_msg {
 
 
 typedef struct ucp_wireup_msg_lanes_info_t {
-    ucp_lane_map_t         requested_lane_map; /* lanes the sender asked about */
-    ucp_lane_map_t         provided_lane_map;  /* lanes actually carried here */
-    /* packed addresses follow */
+    /* Lanes the sender asked about, which are also the lanes the peer provided
+     * in the message being answered, so the RX tokens of the trailer belong to
+     * them. Empty in a REQUEST, which answers nothing. */
+    ucp_lane_map_t         requested_lane_map;
+    /* Lanes whose addresses and TX tokens are carried here */
+    ucp_lane_map_t         provided_lane_map;
+    /* @ref ucp_wireup_msg_tokens_info_t (only towards peers of release version
+     * UCP_WIREUP_ADDR_TOKEN_MIN_DST_VERSION and above), then packed addresses
+     * follow */
 } UCS_S_PACKED ucp_wireup_msg_lanes_info_t;
+
+
+/*
+ * Token trailer of a LANES_ADDR message. Both peers decide whether it is part
+ * of the message by the release version of the remote peer, kept in
+ * ucp_ep_config_key_t::dst_version, so no flag is needed on the wire.
+ */
+typedef struct ucp_wireup_msg_tokens_info_t {
+    /* Exchange generation, echoed by the peer in its answers, to be matched
+     * against the tokens once they are carried. Starts from 1, so that 0 tells
+     * the receiver the message came without a trailer at all. */
+    uint64_t request_id;
+    /* uint8_t tx_lengths[popcount(provided_lane_map)] followed by the TX
+     * tokens, then uint8_t rx_lengths[popcount(requested_lane_map)] followed by
+     * the RX tokens, then the packed addresses. A zero length means the
+     * respective lane carries no token, which is the case for every lane until
+     * the tokens themselves are exchanged. */
+} UCS_S_PACKED ucp_wireup_msg_tokens_info_t;
+
 
 typedef struct {
     double          score;
@@ -260,12 +293,32 @@ unsigned ucp_wireup_eps_progress(void *arg);
 
 
 /**
- * Send a LANES_ADDR_REQUEST/REPLY wireup message over the AM lane, packing
- * addresses for the lanes in @a provided_lane_map.
+ * Send a LANES_ADDR_REQUEST/REPLY/ACK wireup message over the AM lane, packing
+ * addresses for the lanes in @a provided_lane_map. @a request_id identifies the
+ * exchange, and is echoed by the peer in its answer.
  */
 void ucp_wireup_send_lanes_addr_msg(ucp_ep_h ep, uint8_t msg_type,
                                     ucp_lane_map_t requested_lane_map,
-                                    ucp_lane_map_t provided_lane_map);
+                                    ucp_lane_map_t provided_lane_map,
+                                    uint64_t request_id);
+
+
+/**
+ * Measure one token section of a LANES_ADDR message, holding one length byte
+ * per lane of @a lane_map followed by the tokens themselves.
+ *
+ * @param [in]  lane_map    Lanes the section describes, in ascending order.
+ * @param [in]  section     Start of the section.
+ * @param [in]  avail       Bytes left in the message from @a section on.
+ * @param [out] consumed_p  Size of the section.
+ *
+ * @return UCS_ERR_MESSAGE_TRUNCATED if the section does not fit in @a avail.
+ *
+ * Exposed for gtest, which feeds it crafted sections.
+ */
+ucs_status_t
+ucp_wireup_skip_token_section(ucp_lane_map_t lane_map, const void *section,
+                              size_t avail, size_t *consumed_p);
 
 
 /**

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -2459,3 +2459,58 @@ UCS_TEST_P(test_ucp_reconfig_connect_remote, put_canceled)
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_reconfig_connect_remote, tcp, "tcp")
+
+
+/* The token sections of a LANES_ADDR message are parsed before the addresses,
+ * so a malformed section must be rejected rather than shift the addresses. */
+class test_ucp_wireup_token_section : public ucs::test {
+protected:
+    /* One length byte per lane, followed by the tokens themselves */
+    static std::vector<uint8_t>
+    make_section(const std::vector<uint8_t> &lengths)
+    {
+        std::vector<uint8_t> section(lengths);
+
+        for (std::vector<uint8_t>::const_iterator it = lengths.begin();
+             it != lengths.end(); ++it) {
+            section.insert(section.end(), *it, 0xab);
+        }
+
+        return section;
+    }
+
+    static const ucp_lane_map_t THREE_LANES;
+};
+
+const ucp_lane_map_t test_ucp_wireup_token_section::THREE_LANES =
+        UCS_BIT(0) | UCS_BIT(3) | UCS_BIT(5);
+
+UCS_TEST_F(test_ucp_wireup_token_section, skip) {
+    std::vector<uint8_t> section = make_section({4, 0, 7});
+    size_t consumed;
+
+    /* The address follows the section, so extra bytes must be left alone */
+    section.push_back(0xff);
+
+    ASSERT_UCS_OK(ucp_wireup_skip_token_section(THREE_LANES, &section[0],
+                                                section.size(), &consumed));
+    EXPECT_EQ(section.size() - 1, consumed);
+
+    /* Without lanes there is no section at all */
+    ASSERT_UCS_OK(ucp_wireup_skip_token_section(0, &section[0], section.size(),
+                                                &consumed));
+    EXPECT_EQ(0ul, consumed);
+}
+
+UCS_TEST_F(test_ucp_wireup_token_section, skip_truncated) {
+    std::vector<uint8_t> section = make_section({4, 0, 7});
+    size_t consumed;
+
+    /* Cut in the length array, and then in the tokens themselves */
+    EXPECT_EQ(UCS_ERR_MESSAGE_TRUNCATED,
+              ucp_wireup_skip_token_section(THREE_LANES, &section[0], 2,
+                                            &consumed));
+    EXPECT_EQ(UCS_ERR_MESSAGE_TRUNCATED,
+              ucp_wireup_skip_token_section(THREE_LANES, &section[0],
+                                            section.size() - 1, &consumed));
+}

--- a/test/gtest/ucp/test_ucp_wireup.cc
+++ b/test/gtest/ucp/test_ucp_wireup.cc
@@ -2500,6 +2500,14 @@ UCS_TEST_F(test_ucp_wireup_token_section, skip) {
     ASSERT_UCS_OK(ucp_wireup_skip_token_section(0, &section[0], section.size(),
                                                 &consumed));
     EXPECT_EQ(0ul, consumed);
+
+    /* Empty tokens: one zero length per lane, which is what the wire carries
+     * until tokens are exchanged */
+    section = make_section({0, 0, 0});
+    section.push_back(0xff);
+    ASSERT_UCS_OK(ucp_wireup_skip_token_section(THREE_LANES, &section[0],
+                                                section.size(), &consumed));
+    EXPECT_EQ(3ul, consumed);
 }
 
 UCS_TEST_F(test_ucp_wireup_token_section, skip_truncated) {


### PR DESCRIPTION
## What?
Append an optional token trailer to the `LANES_ADDR` wireup messages and add the
`LANES_ADDR_ACK` message which closes the exchange. The trailer is framing only:
its token sections are present but empty, and no token is queried or consumed yet.

## Why?
Groundwork for hardware PSN fault tolerance. Purging a failed UCT lane requires the
PSN tokens of both directions, which have to travel with the lane addresses that
recovery already re-exchanges. Splitting the wire format out of the feature keeps the
protocol change reviewable on its own and lets the token query, per-lane storage and
their consumer land in a follow-up.

## How?
Recovery today is a two-legged exchange over the AM lane. The endpoint which detects
a lane failure sends `LANES_ADDR_REQUEST`, packing the addresses of the lanes it
rebuilt in `provided_lane_map`; the peer replies with `LANES_ADDR_REPLY`, packing the
addresses of the lanes it managed to rebuild in turn.

The trailer goes between the fixed `ucp_wireup_msg_lanes_info_t`, which UCX 1.22
already ships, and the packed addresses:

```
[ucp_wireup_msg_t][lanes_info][request_id][TX lengths][RX lengths][addresses]
```

Each token section holds one length byte per lane followed by the tokens themselves,
so a lane which has no token costs one zero byte. The sections take their lanes from
the maps already in `lanes_info` rather than from maps of their own: the TX section
belongs to `provided_lane_map`, the lanes the message carries addresses for, and the
RX section to `requested_lane_map`, redefined as the lanes the message answers. The
addresses stay last, so they need no length of their own.

Both peers decide on the trailer from the peer release version in
`ucp_ep_config_key_t::dst_version`, gated by `UCP_WIREUP_ADDR_TOKEN_MIN_DST_VERSION`,
so nothing is added to the fixed header and older peers keep parsing the addresses
where they are today. `request_id` carries the recovery generation, echoed by the
peer, for the follow-up to tell answers of different rounds apart.

Why a third leg: an RX token is derived from the TX token of the remote side, so
each peer can only produce the RX tokens of the *other* one. The request carries the
initiator's TX tokens, and the reply carries both the responder's TX tokens and the
RX tokens it derived for the initiator. Nothing has yet delivered the RX tokens the
initiator derives from the reply, which is what `LANES_ADDR_ACK` is for. It exists
only to carry the trailer, so it is withheld from peers below the minimum version.

Testing: gtest coverage of the section parser, including truncated sections which the
empty sections of the wire itself never produce, plus the fault-tolerance suite on
ConnectX-7 (`test_ucp_fault_tolerance` and `test_ucp_wireup`, no failures).
