### PR TITLE
[DNM] UCT/IB/MLX5: wqe parser for uct flush

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -840,6 +840,23 @@ void *uct_ib_mlx5_txwq_get_wqe(const uct_ib_mlx5_txwq_t *txwq, uint16_t pi)
     return UCS_PTR_BYTE_OFFSET(txwq->qstart, (pi % num_bb) * MLX5_SEND_WQE_BB);
 }
 
+uint8_t uct_ib_mlx5_wqe_opcode(const struct mlx5_wqe_ctrl_seg *ctrl)
+{
+    return ctrl->opmod_idx_opcode >> 24;
+}
+
+void uct_ib_mlx5_txwq_copy_segs(const uct_ib_mlx5_txwq_t *txwq, const void *src,
+                                void *dst, size_t length)
+{
+    size_t copy_len = ucs_min(length, UCS_PTR_BYTE_DIFF(src, txwq->qend));
+
+    memcpy(dst, src, copy_len);
+    if (copy_len < length) {
+        memcpy(UCS_PTR_BYTE_OFFSET(dst, copy_len), txwq->qstart,
+               length - copy_len);
+    }
+}
+
 uint16_t uct_ib_mlx5_txwq_num_posted_wqes(const uct_ib_mlx5_txwq_t *txwq,
                                           uint16_t outstanding)
 {

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -845,18 +845,6 @@ uint8_t uct_ib_mlx5_wqe_opcode(const struct mlx5_wqe_ctrl_seg *ctrl)
     return ctrl->opmod_idx_opcode >> 24;
 }
 
-void uct_ib_mlx5_txwq_copy_segs(const uct_ib_mlx5_txwq_t *txwq, const void *src,
-                                void *dst, size_t length)
-{
-    size_t copy_len = ucs_min(length, UCS_PTR_BYTE_DIFF(src, txwq->qend));
-
-    memcpy(dst, src, copy_len);
-    if (copy_len < length) {
-        memcpy(UCS_PTR_BYTE_OFFSET(dst, copy_len), txwq->qstart,
-               length - copy_len);
-    }
-}
-
 uint16_t uct_ib_mlx5_txwq_num_posted_wqes(const uct_ib_mlx5_txwq_t *txwq,
                                           uint16_t outstanding)
 {

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -905,6 +905,11 @@ ucs_status_t uct_ib_mlx5_txwq_init(uct_priv_worker_t *worker,
 /* Get pointer to a WQE by producer index */
 void *uct_ib_mlx5_txwq_get_wqe(const uct_ib_mlx5_txwq_t *txwq, uint16_t pi);
 
+uint8_t uct_ib_mlx5_wqe_opcode(const struct mlx5_wqe_ctrl_seg *ctrl);
+
+void uct_ib_mlx5_txwq_copy_segs(const uct_ib_mlx5_txwq_t *txwq, const void *src,
+                                void *dst, size_t length);
+
 /* Count how many WQEs are currently posted */
 uint16_t uct_ib_mlx5_txwq_num_posted_wqes(const uct_ib_mlx5_txwq_t *txwq,
                                           uint16_t outstanding);

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -907,9 +907,6 @@ void *uct_ib_mlx5_txwq_get_wqe(const uct_ib_mlx5_txwq_t *txwq, uint16_t pi);
 
 uint8_t uct_ib_mlx5_wqe_opcode(const struct mlx5_wqe_ctrl_seg *ctrl);
 
-void uct_ib_mlx5_txwq_copy_segs(const uct_ib_mlx5_txwq_t *txwq, const void *src,
-                                void *dst, size_t length);
-
 /* Count how many WQEs are currently posted */
 uint16_t uct_ib_mlx5_txwq_num_posted_wqes(const uct_ib_mlx5_txwq_t *txwq,
                                           uint16_t outstanding);

--- a/src/uct/ib/mlx5/ib_mlx5_log.c
+++ b/src/uct/ib/mlx5/ib_mlx5_log.c
@@ -305,7 +305,7 @@ static void uct_ib_mlx5_wqe_dump(uct_ib_iface_t *iface, void *wqe, void *qstart,
     };
 
     struct mlx5_wqe_ctrl_seg *ctrl = wqe;
-    uint8_t opcode                 = ctrl->opmod_idx_opcode >> 24;
+    uint8_t opcode                 = uct_ib_mlx5_wqe_opcode(ctrl);
     uint8_t opmod                  = ctrl->opmod_idx_opcode & 0xff;
     uint32_t qp_num                = ntohl(ctrl->qpn_ds) >> 8;
     int ds                         = ctrl->qpn_ds >> 24;

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -60,6 +60,8 @@ uct_rc_mlx5_op_info_fill(uct_ep_op_info_t *info, const uct_ib_mlx5_txwq_t *txwq,
 
             return UCS_OK;
         }
+
+        /* fall through */
     default:
         ucs_diag("unsupported op %d", uct_ib_mlx5_wqe_opcode(ctrl));
         return UCS_ERR_UNSUPPORTED;

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -18,21 +18,12 @@
 #include <endian.h>
 #include <string.h>
 
-#define UCT_RC_MLX5_RMA_MAX_IOV(_av_size) \
-    ((UCT_IB_MLX5_MAX_SEND_WQE_SIZE - \
-      ((_av_size) + sizeof(struct mlx5_wqe_raddr_seg) + \
-       sizeof(struct mlx5_wqe_ctrl_seg))) / \
-     sizeof(struct mlx5_wqe_data_seg))
-
-typedef struct {
-    union {
-        uint8_t data[UCT_IB_MLX5_MAX_SEND_WQE_SIZE];
-        struct {
-            uct_iov_t    iov[UCT_RC_MLX5_RMA_MAX_IOV(0)];
-            uct_ib_mem_t memh[UCT_RC_MLX5_RMA_MAX_IOV(0)];
-        };
-    };
-} uct_rc_mlx5_op_callback_data_t;
+static int uct_rc_mlx5_op_info_is_flush(const uct_rc_iface_send_op_t *op)
+{
+    return (op != NULL) &&
+           ((op->handler == uct_rc_ep_flush_op_completion_handler) ||
+            (op->handler == uct_rc_ep_flush_remote_handler));
+}
 
 static void uct_rc_mlx5_op_info_try_fill_comp(uct_ep_op_info_t *info,
                                               uct_rc_iface_send_op_t *op)
@@ -43,20 +34,9 @@ static void uct_rc_mlx5_op_info_try_fill_comp(uct_ep_op_info_t *info,
     }
 }
 
-static int uct_rc_mlx5_op_info_is_flush(const uct_rc_iface_send_op_t *op)
+static void uct_rc_mlx5_op_info_fill_flush(uct_ep_op_info_t *info,
+                                           uct_rc_iface_send_op_t *op)
 {
-    return (op != NULL) &&
-           ((op->handler == uct_rc_ep_flush_op_completion_handler) ||
-            (op->handler == uct_rc_ep_flush_remote_handler));
-}
-
-static ucs_status_t uct_rc_mlx5_op_info_fill_flush(uct_ep_op_info_t *info,
-                                                   uct_rc_iface_send_op_t *op)
-{
-    if (!uct_rc_mlx5_op_info_is_flush(op)) {
-        return UCS_ERR_UNSUPPORTED;
-    }
-
     info->field_mask       = UCT_EP_OP_INFO_FIELD_OPERATION |
                              UCT_EP_OP_INFO_FIELD_FLUSH;
     info->operation        = UCT_EP_OP_FLUSH;
@@ -66,8 +46,6 @@ static ucs_status_t uct_rc_mlx5_op_info_fill_flush(uct_ep_op_info_t *info,
                                           UCT_FLUSH_FLAG_LOCAL;
 
     uct_rc_mlx5_op_info_try_fill_comp(info, op);
-
-    return UCS_OK;
 }
 
 ucs_status_t
@@ -77,16 +55,16 @@ uct_rc_mlx5_op_info_fill(uct_ep_op_info_t *info, const uct_ib_mlx5_txwq_t *txwq,
                          int *skip_p,
                          uct_rc_mlx5_op_callback_data_t *callback_data)
 {
-    UCS_UNUSED(txwq);
-    UCS_UNUSED(wqe_size);
-    UCS_UNUSED(callback_data);
-
     *skip_p = 0;
 
     switch (uct_ib_mlx5_wqe_opcode(ctrl)) {
     case MLX5_OPCODE_NOP:
     case MLX5_OPCODE_RDMA_READ:
-        return uct_rc_mlx5_op_info_fill_flush(info, op);
+        if (uct_rc_mlx5_op_info_is_flush(op)) {
+            uct_rc_mlx5_op_info_fill_flush(info, op);
+
+            return UCS_OK;
+        }
     default:
         ucs_diag("unsupported op %d", uct_ib_mlx5_wqe_opcode(ctrl));
         return UCS_ERR_UNSUPPORTED;

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -15,8 +15,6 @@
 #include <uct/ib/rc/base/rc_iface.h>
 #include <ucs/arch/bitops.h>
 #include <ucs/profile/profile.h>
-#include <endian.h>
-#include <string.h>
 
 static int uct_rc_mlx5_op_info_is_flush(const uct_rc_iface_send_op_t *op)
 {
@@ -29,34 +27,31 @@ static void uct_rc_mlx5_op_info_try_fill_comp(uct_ep_op_info_t *info,
                                               uct_rc_iface_send_op_t *op)
 {
     if ((op != NULL) && (op->user_comp != NULL)) {
-        info->field_mask |= UCT_EP_OP_INFO_FIELD_COMP;
         info->comp        = op->user_comp;
+        info->field_mask |= UCT_EP_OP_INFO_FIELD_COMP;
     }
 }
 
 static void uct_rc_mlx5_op_info_fill_flush(uct_ep_op_info_t *info,
                                            uct_rc_iface_send_op_t *op)
 {
-    info->field_mask       = UCT_EP_OP_INFO_FIELD_OPERATION |
-                             UCT_EP_OP_INFO_FIELD_FLUSH;
-    info->operation        = UCT_EP_OP_FLUSH;
-    info->flush.field_mask = UCT_EP_OP_INFO_FLUSH_FIELD_FLAGS;
+    uct_rc_mlx5_op_info_try_fill_comp(info, op);
+
     info->flush.flags      = (op->handler == uct_rc_ep_flush_remote_handler) ?
                                           UCT_FLUSH_FLAG_REMOTE :
                                           UCT_FLUSH_FLAG_LOCAL;
-
-    uct_rc_mlx5_op_info_try_fill_comp(info, op);
+    info->flush.field_mask = UCT_EP_OP_INFO_FLUSH_FIELD_FLAGS;
+    info->operation        = UCT_EP_OP_FLUSH;
+    info->field_mask      |= UCT_EP_OP_INFO_FIELD_OPERATION |
+                             UCT_EP_OP_INFO_FIELD_FLUSH;
 }
 
 ucs_status_t
 uct_rc_mlx5_op_info_fill(uct_ep_op_info_t *info, const uct_ib_mlx5_txwq_t *txwq,
                          uct_rc_iface_send_op_t *op,
                          const struct mlx5_wqe_ctrl_seg *ctrl, size_t wqe_size,
-                         int *skip_p,
                          uct_rc_mlx5_op_callback_data_t *callback_data)
 {
-    *skip_p = 0;
-
     switch (uct_ib_mlx5_wqe_opcode(ctrl)) {
     case MLX5_OPCODE_NOP:
     case MLX5_OPCODE_RDMA_READ:

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -15,7 +15,83 @@
 #include <uct/ib/rc/base/rc_iface.h>
 #include <ucs/arch/bitops.h>
 #include <ucs/profile/profile.h>
+#include <endian.h>
+#include <string.h>
 
+#define UCT_RC_MLX5_RMA_MAX_IOV(_av_size) \
+    ((UCT_IB_MLX5_MAX_SEND_WQE_SIZE - \
+      ((_av_size) + sizeof(struct mlx5_wqe_raddr_seg) + \
+       sizeof(struct mlx5_wqe_ctrl_seg))) / \
+     sizeof(struct mlx5_wqe_data_seg))
+
+typedef struct {
+    union {
+        uint8_t data[UCT_IB_MLX5_MAX_SEND_WQE_SIZE];
+        struct {
+            uct_iov_t    iov[UCT_RC_MLX5_RMA_MAX_IOV(0)];
+            uct_ib_mem_t memh[UCT_RC_MLX5_RMA_MAX_IOV(0)];
+        };
+    };
+} uct_rc_mlx5_op_callback_data_t;
+
+static void uct_rc_mlx5_op_info_try_fill_comp(uct_ep_op_info_t *info,
+                                              uct_rc_iface_send_op_t *op)
+{
+    if ((op != NULL) && (op->user_comp != NULL)) {
+        info->field_mask |= UCT_EP_OP_INFO_FIELD_COMP;
+        info->comp        = op->user_comp;
+    }
+}
+
+static int uct_rc_mlx5_op_info_is_flush(const uct_rc_iface_send_op_t *op)
+{
+    return (op != NULL) &&
+           ((op->handler == uct_rc_ep_flush_op_completion_handler) ||
+            (op->handler == uct_rc_ep_flush_remote_handler));
+}
+
+static ucs_status_t uct_rc_mlx5_op_info_fill_flush(uct_ep_op_info_t *info,
+                                                   uct_rc_iface_send_op_t *op)
+{
+    if (!uct_rc_mlx5_op_info_is_flush(op)) {
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    info->field_mask       = UCT_EP_OP_INFO_FIELD_OPERATION |
+                             UCT_EP_OP_INFO_FIELD_FLUSH;
+    info->operation        = UCT_EP_OP_FLUSH;
+    info->flush.field_mask = UCT_EP_OP_INFO_FLUSH_FIELD_FLAGS;
+    info->flush.flags      = (op->handler == uct_rc_ep_flush_remote_handler) ?
+                                          UCT_FLUSH_FLAG_REMOTE :
+                                          UCT_FLUSH_FLAG_LOCAL;
+
+    uct_rc_mlx5_op_info_try_fill_comp(info, op);
+
+    return UCS_OK;
+}
+
+ucs_status_t
+uct_rc_mlx5_op_info_fill(uct_ep_op_info_t *info, const uct_ib_mlx5_txwq_t *txwq,
+                         uct_rc_iface_send_op_t *op,
+                         const struct mlx5_wqe_ctrl_seg *ctrl, size_t wqe_size,
+                         int *skip_p,
+                         uct_rc_mlx5_op_callback_data_t *callback_data)
+{
+    UCS_UNUSED(txwq);
+    UCS_UNUSED(wqe_size);
+    UCS_UNUSED(callback_data);
+
+    *skip_p = 0;
+
+    switch (uct_ib_mlx5_wqe_opcode(ctrl)) {
+    case MLX5_OPCODE_NOP:
+    case MLX5_OPCODE_RDMA_READ:
+        return uct_rc_mlx5_op_info_fill_flush(info, op);
+    default:
+        ucs_diag("unsupported op %d", uct_ib_mlx5_wqe_opcode(ctrl));
+        return UCS_ERR_UNSUPPORTED;
+    }
+}
 
 ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
   {UCT_IB_CONFIG_PREFIX, "", NULL,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -256,6 +256,30 @@ typedef struct {
     };
 } uct_rc_mlx5_op_callback_data_t;
 
+#define UCT_RC_MLX5_RMA_MAX_IOV(_av_size) \
+    ((UCT_IB_MLX5_MAX_SEND_WQE_SIZE - \
+      ((_av_size) + sizeof(struct mlx5_wqe_raddr_seg) + \
+       sizeof(struct mlx5_wqe_ctrl_seg))) / \
+     sizeof(struct mlx5_wqe_data_seg))
+
+typedef struct {
+    union {
+        uint8_t data[UCT_IB_MLX5_MAX_SEND_WQE_SIZE];
+        struct {
+            uct_iov_t    iov[UCT_RC_MLX5_RMA_MAX_IOV(0)];
+            uct_ib_mem_t memh[UCT_RC_MLX5_RMA_MAX_IOV(0)];
+        };
+    };
+} uct_rc_mlx5_op_callback_data_t;
+
+ucs_status_t
+uct_rc_mlx5_op_info_fill(uct_ep_op_info_t *info, const uct_ib_mlx5_txwq_t *txwq,
+                         uct_rc_iface_send_op_t *op,
+                         const struct mlx5_wqe_ctrl_seg *ctrl, size_t wqe_size,
+                         int *skip_p,
+                         uct_rc_mlx5_op_callback_data_t *callback_data);
+
+
 static UCS_F_ALWAYS_INLINE int
 uct_rc_mlx5_mp_hash_equal(uct_rc_mlx5_mp_hash_key_t key1,
                           uct_rc_mlx5_mp_hash_key_t key2)

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -246,12 +246,6 @@ typedef struct uct_rc_mlx5_mp_hash_key {
     uint32_t                      qp_num;
 } uct_rc_mlx5_mp_hash_key_t;
 
-#define UCT_RC_MLX5_RMA_MAX_IOV(_av_size) \
-    ((UCT_IB_MLX5_MAX_SEND_WQE_SIZE - \
-      ((_av_size) + sizeof(struct mlx5_wqe_raddr_seg) + \
-       sizeof(struct mlx5_wqe_ctrl_seg))) / \
-     sizeof(struct mlx5_wqe_data_seg))
-
 typedef struct {
     union {
         uint8_t data[UCT_IB_MLX5_MAX_SEND_WQE_SIZE];
@@ -266,7 +260,6 @@ ucs_status_t
 uct_rc_mlx5_op_info_fill(uct_ep_op_info_t *info, const uct_ib_mlx5_txwq_t *txwq,
                          uct_rc_iface_send_op_t *op,
                          const struct mlx5_wqe_ctrl_seg *ctrl, size_t wqe_size,
-                         int *skip_p,
                          uct_rc_mlx5_op_callback_data_t *callback_data);
 
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -246,16 +246,6 @@ typedef struct uct_rc_mlx5_mp_hash_key {
     uint32_t                      qp_num;
 } uct_rc_mlx5_mp_hash_key_t;
 
-typedef struct {
-    union {
-        uint8_t data[UCT_IB_MLX5_MAX_SEND_WQE_SIZE];
-        struct {
-            uct_iov_t    iov[UCT_RC_MLX5_RMA_MAX_IOV(0)];
-            uct_ib_mem_t memh[UCT_RC_MLX5_RMA_MAX_IOV(0)];
-        };
-    };
-} uct_rc_mlx5_op_callback_data_t;
-
 #define UCT_RC_MLX5_RMA_MAX_IOV(_av_size) \
     ((UCT_IB_MLX5_MAX_SEND_WQE_SIZE - \
       ((_av_size) + sizeof(struct mlx5_wqe_raddr_seg) + \

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -246,6 +246,15 @@ typedef struct uct_rc_mlx5_mp_hash_key {
     uint32_t                      qp_num;
 } uct_rc_mlx5_mp_hash_key_t;
 
+typedef struct {
+    union {
+        uint8_t data[UCT_IB_MLX5_MAX_SEND_WQE_SIZE];
+        struct {
+            uct_iov_t    iov[UCT_RC_MLX5_RMA_MAX_IOV(0)];
+            uct_ib_mem_t memh[UCT_RC_MLX5_RMA_MAX_IOV(0)];
+        };
+    };
+} uct_rc_mlx5_op_callback_data_t;
 
 static UCS_F_ALWAYS_INLINE int
 uct_rc_mlx5_mp_hash_equal(uct_rc_mlx5_mp_hash_key_t key1,

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -1403,8 +1403,7 @@ UCT_INSTANTIATE_RC_DC_TEST_CASE(test_rc_srq);
 
 class test_rc_purge_outstanding : public test_rc {
 protected:
-    struct flush_purge_ctx {
-        unsigned         other_count;
+    struct purge_ctx {
         unsigned         flush_count;
         unsigned         flags;
         uct_completion_t *comp;
@@ -1416,65 +1415,94 @@ protected:
 
     static void purge_cb(const uct_ep_op_info_t *info, void *arg)
     {
-        flush_purge_ctx *ctx = static_cast<flush_purge_ctx*>(arg);
+        purge_ctx *ctx = static_cast<purge_ctx*>(arg);
 
         EXPECT_TRUE(info->field_mask & UCT_EP_OP_INFO_FIELD_OPERATION);
         if (info->operation != UCT_EP_OP_FLUSH) {
-            ++ctx->other_count;
             return;
         }
 
         ++ctx->flush_count;
+
         EXPECT_TRUE(info->field_mask & UCT_EP_OP_INFO_FIELD_FLUSH);
+
         EXPECT_EQ(UCT_EP_OP_INFO_FLUSH_FIELD_FLAGS, info->flush.field_mask);
         EXPECT_EQ(ctx->flags, info->flush.flags);
         EXPECT_EQ((ctx->comp != NULL),
                   !!(info->field_mask & UCT_EP_OP_INFO_FIELD_COMP));
-        if (ctx->comp != NULL) {
-            EXPECT_EQ(ctx->comp, info->comp);
-        }
+        EXPECT_EQ(ctx->comp, info->comp);
     }
 
-    ucs_status_t purge_stub(flush_purge_ctx *ctx)
+    ucs_status_t purge_stub(purge_ctx *ctx)
     {
-        __be32 rx_token = htobe32(1);
-        uct_ep_outstanding_purge_params_t params = {
-            .field_mask = UCT_EP_OUTSTANDING_FIELD_RX_TOKEN |
-                          UCT_EP_OUTSTANDING_FIELD_CB |
-                          UCT_EP_OUTSTANDING_FIELD_ARG,
-            .rx_token   = &rx_token,
-            .cb         = purge_cb,
-            .arg        = ctx
-        };
+        uct_rc_mlx5_ep_t *ep = ucs_derived_of(m_e1->ep(0), uct_rc_mlx5_ep_t);
+        uct_ib_mlx5_txwq_t *txwq = &ep->super.tx.wq;
+        uct_rc_txqp_t *txqp      = &ep->super.super.txqp;
+        uint16_t ci              = 0;
+        uct_rc_mlx5_op_callback_data_t callback_data;
+        uct_ep_op_info_t info;
+        ucs_status_t status;
+        const struct mlx5_wqe_ctrl_seg *ctrl;
+        uct_rc_iface_send_op_t *op, *t_op;
+        size_t wqe_size;
 
-        return uct_ep_outstanding_purge(m_e1->ep(0), &params);
+        while (ci != txwq->sw_pi) {
+            ctrl     = static_cast<const struct mlx5_wqe_ctrl_seg*>(
+                    uct_ib_mlx5_txwq_get_wqe(txwq, ci));
+            wqe_size = (ctrl->qpn_ds >> 24) * UCT_IB_MLX5_WQE_SEG_SIZE;
+            op       = NULL;
+
+            ucs_queue_for_each(t_op, &txqp->outstanding, queue) {
+                if (t_op->sn == ci) {
+                    op = t_op;
+                    break;
+                }
+            }
+
+            if ((op == NULL) ||
+                ((op->handler != uct_rc_ep_flush_op_completion_handler) &&
+                 (op->handler != uct_rc_ep_flush_remote_handler))) {
+                goto next_wqe;
+            }
+
+            memset(&info, 0, sizeof(info));
+
+            status = uct_rc_mlx5_op_info_fill(&info, txwq, op, ctrl, wqe_size,
+                                              &callback_data);
+
+            if (status != UCS_OK) {
+                return status;
+            }
+
+            purge_cb(&info, ctx);
+
+        next_wqe:
+            ci += ucs_div_round_up(wqe_size, MLX5_SEND_WQE_BB);
+        }
+
+        return UCS_OK;
     }
 };
 
 UCS_TEST_SKIP_COND_P(test_rc_purge_outstanding, flush,
                      !check_caps(UCT_IFACE_FLAG_AM_SHORT))
 {
-    const char payload[]  = "flush";
     uct_completion_t comp = {completion_cb, 1, UCS_OK};
-    flush_purge_ctx ctx   = {0, 0, UCT_FLUSH_FLAG_LOCAL, &comp};
+    purge_ctx ctx         = {0, UCT_FLUSH_FLAG_LOCAL, &comp};
+    uint64_t data         = 1;
     ucs_status_t status;
 
-    ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(0), 0, 0, payload,
-                                  sizeof(payload)));
-    ASSERT_EQ(UCS_INPROGRESS,
-              uct_ep_flush(m_e1->ep(0), UCT_FLUSH_FLAG_LOCAL, &comp));
+    ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(0), 0, 0, &data, sizeof(data)));
 
-    status = purge_stub(&ctx);
-    if (status == UCS_ERR_UNSUPPORTED) {
-        flush();
-        GTEST_SKIP() << "outstanding purge is not supported";
-    }
-    ASSERT_UCS_OK(status);
+    status = uct_ep_flush(m_e1->ep(0), UCT_FLUSH_FLAG_LOCAL, &comp);
+    ASSERT_EQ(UCS_INPROGRESS, status);
 
-    flush();
-    EXPECT_EQ(1u, ctx.other_count);
+    ASSERT_UCS_OK(purge_stub(&ctx));
+
     EXPECT_EQ(1u, ctx.flush_count);
     EXPECT_EQ(1, comp.count);
+
+    flush();
 }
 
 UCS_TEST_SKIP_COND_P(test_rc_purge_outstanding, flush_remote,
@@ -1482,30 +1510,23 @@ UCS_TEST_SKIP_COND_P(test_rc_purge_outstanding, flush_remote,
 {
     mapped_buffer remote(sizeof(uint64_t), 0ul, *m_e2);
     uct_completion_t comp = {completion_cb, 1, UCS_OK};
-    flush_purge_ctx ctx   = {0, 0, UCT_FLUSH_FLAG_REMOTE, &comp};
-    uint64_t value        = 1;
+    purge_ctx ctx         = {0, UCT_FLUSH_FLAG_REMOTE, &comp};
+    uint64_t data         = 1;
     ucs_status_t status;
 
-    ASSERT_UCS_OK(uct_ep_put_short(m_e1->ep(0), &value, sizeof(value),
+    ASSERT_UCS_OK(uct_ep_put_short(m_e1->ep(0), &data, sizeof(data),
                                    remote.addr(), remote.rkey()));
     flush();
 
     status = uct_ep_flush(m_e1->ep(0), UCT_FLUSH_FLAG_REMOTE, &comp);
-    if (status == UCS_ERR_UNSUPPORTED) {
-        GTEST_SKIP() << "remote flush is not supported";
-    }
     ASSERT_EQ(UCS_INPROGRESS, status);
 
-    status = purge_stub(&ctx);
-    if (status == UCS_ERR_UNSUPPORTED) {
-        flush();
-        GTEST_SKIP() << "outstanding purge is not supported";
-    }
-    ASSERT_UCS_OK(status);
+    ASSERT_UCS_OK(purge_stub(&ctx));
 
-    flush();
     EXPECT_EQ(1u, ctx.flush_count);
     EXPECT_EQ(1, comp.count);
+
+    flush();
 }
 
 _UCT_INSTANTIATE_TEST_CASE(test_rc_purge_outstanding, rc_mlx5)

--- a/test/gtest/uct/ib/test_rc.cc
+++ b/test/gtest/uct/ib/test_rc.cc
@@ -1401,4 +1401,113 @@ UCS_TEST_SKIP_COND_P(test_rc_srq, reorder_cyclic,
 
 UCT_INSTANTIATE_RC_DC_TEST_CASE(test_rc_srq);
 
+class test_rc_purge_outstanding : public test_rc {
+protected:
+    struct flush_purge_ctx {
+        unsigned         other_count;
+        unsigned         flush_count;
+        unsigned         flags;
+        uct_completion_t *comp;
+    };
+
+    static void completion_cb(uct_completion_t*)
+    {
+    }
+
+    static void purge_cb(const uct_ep_op_info_t *info, void *arg)
+    {
+        flush_purge_ctx *ctx = static_cast<flush_purge_ctx*>(arg);
+
+        EXPECT_TRUE(info->field_mask & UCT_EP_OP_INFO_FIELD_OPERATION);
+        if (info->operation != UCT_EP_OP_FLUSH) {
+            ++ctx->other_count;
+            return;
+        }
+
+        ++ctx->flush_count;
+        EXPECT_TRUE(info->field_mask & UCT_EP_OP_INFO_FIELD_FLUSH);
+        EXPECT_EQ(UCT_EP_OP_INFO_FLUSH_FIELD_FLAGS, info->flush.field_mask);
+        EXPECT_EQ(ctx->flags, info->flush.flags);
+        EXPECT_EQ((ctx->comp != NULL),
+                  !!(info->field_mask & UCT_EP_OP_INFO_FIELD_COMP));
+        if (ctx->comp != NULL) {
+            EXPECT_EQ(ctx->comp, info->comp);
+        }
+    }
+
+    ucs_status_t purge_stub(flush_purge_ctx *ctx)
+    {
+        __be32 rx_token = htobe32(1);
+        uct_ep_outstanding_purge_params_t params = {
+            .field_mask = UCT_EP_OUTSTANDING_FIELD_RX_TOKEN |
+                          UCT_EP_OUTSTANDING_FIELD_CB |
+                          UCT_EP_OUTSTANDING_FIELD_ARG,
+            .rx_token   = &rx_token,
+            .cb         = purge_cb,
+            .arg        = ctx
+        };
+
+        return uct_ep_outstanding_purge(m_e1->ep(0), &params);
+    }
+};
+
+UCS_TEST_SKIP_COND_P(test_rc_purge_outstanding, flush,
+                     !check_caps(UCT_IFACE_FLAG_AM_SHORT))
+{
+    const char payload[]  = "flush";
+    uct_completion_t comp = {completion_cb, 1, UCS_OK};
+    flush_purge_ctx ctx   = {0, 0, UCT_FLUSH_FLAG_LOCAL, &comp};
+    ucs_status_t status;
+
+    ASSERT_UCS_OK(uct_ep_am_short(m_e1->ep(0), 0, 0, payload,
+                                  sizeof(payload)));
+    ASSERT_EQ(UCS_INPROGRESS,
+              uct_ep_flush(m_e1->ep(0), UCT_FLUSH_FLAG_LOCAL, &comp));
+
+    status = purge_stub(&ctx);
+    if (status == UCS_ERR_UNSUPPORTED) {
+        flush();
+        GTEST_SKIP() << "outstanding purge is not supported";
+    }
+    ASSERT_UCS_OK(status);
+
+    flush();
+    EXPECT_EQ(1u, ctx.other_count);
+    EXPECT_EQ(1u, ctx.flush_count);
+    EXPECT_EQ(1, comp.count);
+}
+
+UCS_TEST_SKIP_COND_P(test_rc_purge_outstanding, flush_remote,
+                     !check_caps(UCT_IFACE_FLAG_PUT_SHORT))
+{
+    mapped_buffer remote(sizeof(uint64_t), 0ul, *m_e2);
+    uct_completion_t comp = {completion_cb, 1, UCS_OK};
+    flush_purge_ctx ctx   = {0, 0, UCT_FLUSH_FLAG_REMOTE, &comp};
+    uint64_t value        = 1;
+    ucs_status_t status;
+
+    ASSERT_UCS_OK(uct_ep_put_short(m_e1->ep(0), &value, sizeof(value),
+                                   remote.addr(), remote.rkey()));
+    flush();
+
+    status = uct_ep_flush(m_e1->ep(0), UCT_FLUSH_FLAG_REMOTE, &comp);
+    if (status == UCS_ERR_UNSUPPORTED) {
+        GTEST_SKIP() << "remote flush is not supported";
+    }
+    ASSERT_EQ(UCS_INPROGRESS, status);
+
+    status = purge_stub(&ctx);
+    if (status == UCS_ERR_UNSUPPORTED) {
+        flush();
+        GTEST_SKIP() << "outstanding purge is not supported";
+    }
+    ASSERT_UCS_OK(status);
+
+    flush();
+    EXPECT_EQ(1u, ctx.flush_count);
+    EXPECT_EQ(1, comp.count);
+}
+
+_UCT_INSTANTIATE_TEST_CASE(test_rc_purge_outstanding, rc_mlx5)
+
 #endif


### PR DESCRIPTION
What?
Add wqe parse support for uct flush.

Why?
FT need extract info from wqe before replay uct flush.

How?
Add parser for uct flush local/remote