### PR TITLE
UCT/BASE: revert log level and token cap

### DIFF
--- a/src/uct/base/uct_iface.h
+++ b/src/uct/base/uct_iface.h
@@ -1048,7 +1048,7 @@ ucs_log_level_t uct_base_iface_failure_log_level(uct_base_iface_t *iface,
                                                  ucs_status_t err_handler_status,
                                                  ucs_status_t status)
 {
-    if (UCS_STATUS_IS_ERR(err_handler_status)) {
+    if (err_handler_status != UCS_OK) {
         return UCS_LOG_LEVEL_FATAL;
     } else if ((status == UCS_ERR_ENDPOINT_TIMEOUT) ||
                (status == UCS_ERR_CONNECTION_RESET)) {

--- a/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_iface.c
@@ -1132,10 +1132,6 @@ uct_rc_mlx5_iface_query_v2(uct_iface_h tl_iface,
             }
         }
 
-        if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_CAP_FLAGS) {
-            iface_attr->cap.flags |= UCT_IFACE_FLAG_V2_QUERY_TOKEN;
-        }
-
         if (iface_attr->field_mask & UCT_IFACE_ATTR_FIELD_TX_TOKEN_LENGTH) {
             iface_attr->tx_token_length = sizeof(uct_rc_mlx5_tx_token_t);
         }

--- a/test/gtest/uct/v2/test_uct_query.cc
+++ b/test/gtest/uct/v2/test_uct_query.cc
@@ -114,17 +114,6 @@ UCS_TEST_P(test_uct_query, query_perf)
     }
 }
 
-UCS_TEST_P(test_uct_query, query_token_support)
-{
-    uct_iface_attr_v2_t attr = {};
-
-    attr.field_mask = UCT_IFACE_ATTR_FIELD_CAP_FLAGS;
-    attr.cap.flags  = UINT64_MAX;
-
-    ASSERT_UCS_OK(uct_iface_query_v2(get_iface(), &attr));
-    EXPECT_EQ(0ul, attr.cap.flags & UCT_IFACE_FLAG_V2_QUERY_TOKEN);
-}
-
 UCT_INSTANTIATE_TEST_CASE(test_uct_query)
 
 class test_uct_query_ib : public test_uct_query {

--- a/test/gtest/uct/v2/test_uct_query.cc
+++ b/test/gtest/uct/v2/test_uct_query.cc
@@ -16,9 +16,6 @@ extern "C" {
 #include <uct/api/uct.h>
 #include <uct/api/v2/uct_v2.h>
 #include <uct/base/uct_iface.h>
-#ifdef HAVE_MLX5_DV
-#include <uct/ib/mlx5/ib_mlx5.h>
-#endif
 }
 
 
@@ -120,24 +117,12 @@ UCS_TEST_P(test_uct_query, query_perf)
 UCS_TEST_P(test_uct_query, query_token_support)
 {
     uct_iface_attr_v2_t attr = {};
-    uint64_t iface_cap_flags = 0;
 
     attr.field_mask = UCT_IFACE_ATTR_FIELD_CAP_FLAGS;
     attr.cap.flags  = UINT64_MAX;
 
     ASSERT_UCS_OK(uct_iface_query_v2(get_iface(), &attr));
-
-#ifdef HAVE_MLX5_DV
-    if (has_transport("rc_mlx5")) {
-        uct_ib_mlx5_md_t *md = uct_ib_mlx5_iface_md(
-                ucs_derived_of(get_iface(), uct_ib_iface_t));
-        if (md->flags & UCT_IB_MLX5_MD_FLAG_DEVX) {
-            iface_cap_flags = UCT_IFACE_FLAG_V2_QUERY_TOKEN;
-        }
-    }
-#endif
-
-    EXPECT_EQ(iface_cap_flags, attr.cap.flags & UCT_IFACE_FLAG_V2_QUERY_TOKEN);
+    EXPECT_EQ(0ul, attr.cap.flags & UCT_IFACE_FLAG_V2_QUERY_TOKEN);
 }
 
 UCT_INSTANTIATE_TEST_CASE(test_uct_query)


### PR DESCRIPTION
## What?
revert log level and token cap

## Why?
Do not change log level for all transports.
Set token cap until token, purge and in progress return code are all supported.

## How?
Revert log level changes.
Revert cap flags.
