### PR TITLE
CUDA_IPC: Don't show CUDA error on exit, from static destroy - v1.23

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.c
@@ -250,7 +250,8 @@ static void uct_cuda_ipc_cache_evict_lru(uct_cuda_ipc_cache_t *cache)
     }
 }
 
-static void uct_cuda_ipc_cache_purge(uct_cuda_ipc_cache_t *cache)
+static void uct_cuda_ipc_cache_purge(uct_cuda_ipc_cache_t *cache,
+                                     int close_handles)
 {
     uct_cuda_ipc_cache_region_t *region, *tmp;
     ucs_list_link_t region_list;
@@ -259,7 +260,10 @@ static void uct_cuda_ipc_cache_purge(uct_cuda_ipc_cache_t *cache)
     ucs_pgtable_purge(&cache->pgtable, uct_cuda_ipc_cache_region_collect_callback,
                       &region_list);
     ucs_list_for_each_safe(region, tmp, &region_list, list) {
-        uct_cuda_ipc_close_memhandle(region);
+        if (close_handles) {
+            uct_cuda_ipc_close_memhandle(region);
+        }
+
         ucs_free(region);
     }
 
@@ -743,7 +747,7 @@ uct_cuda_ipc_cache_put_region(uct_cuda_ipc_cache_t *cache,
             if (ucs_unlikely(status != UCS_OK)) {
                 if (ucs_likely(status == UCS_ERR_ALREADY_EXISTS)) {
                     /* unmap all cache entries and retry */
-                    uct_cuda_ipc_cache_purge(cache);
+                    uct_cuda_ipc_cache_purge(cache, 1);
                     status = uct_cuda_ipc_open_memhandle(
                             ext_key, cu_dev, (CUdeviceptr*)mapped_addr,
                             log_level);
@@ -909,9 +913,9 @@ err:
     return status;
 }
 
-void uct_cuda_ipc_destroy_cache(uct_cuda_ipc_cache_t *cache)
+void uct_cuda_ipc_destroy_cache(uct_cuda_ipc_cache_t *cache, int close_handles)
 {
-    uct_cuda_ipc_cache_purge(cache);
+    uct_cuda_ipc_cache_purge(cache, close_handles);
     ucs_pgtable_cleanup(&cache->pgtable);
     pthread_rwlock_destroy(&cache->lock);
     free(cache->name);
@@ -945,6 +949,7 @@ UCS_STATIC_INIT {
 
 UCS_STATIC_CLEANUP {
     uct_cuda_ipc_cache_t *rem_cache;
+    int num_devices, close_handles;
 
 #if HAVE_CUDA_FABRIC
     CUmemoryPool mpool;
@@ -957,8 +962,14 @@ UCS_STATIC_CLEANUP {
     pthread_rwlock_destroy(&uct_cuda_ipc_rem_mpool_cache.lock);
 #endif
 
+    /* There is no guarantee that this cleanup happens before the CUDA driver
+     * shutdown. If the driver is already deinitialized, the memory handles
+     * cannot be closed, and there is no need to do it, because the driver
+     * releases all the mappings anyway. */
+    close_handles = (cuDeviceGetCount(&num_devices) != CUDA_ERROR_DEINITIALIZED);
+
     kh_foreach_value(&uct_cuda_ipc_remote_cache.hash, rem_cache, {
-        uct_cuda_ipc_destroy_cache(rem_cache);
+        uct_cuda_ipc_destroy_cache(rem_cache, close_handles);
     })
     kh_destroy_inplace(cuda_ipc_rem_cache, &uct_cuda_ipc_remote_cache.hash);
     ucs_rw_spinlock_cleanup(&uct_cuda_ipc_remote_cache.lock);

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_cache.h
@@ -47,7 +47,7 @@ ucs_status_t uct_cuda_ipc_create_cache(uct_cuda_ipc_cache_t **cache,
                                        const char *name);
 
 
-void uct_cuda_ipc_destroy_cache(uct_cuda_ipc_cache_t *cache);
+void uct_cuda_ipc_destroy_cache(uct_cuda_ipc_cache_t *cache, int close_handles);
 
 
 /**

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -406,7 +406,7 @@ protected:
     virtual void cleanup() {
         if (m_cache != NULL) {
             drain_cache();
-            uct_cuda_ipc_destroy_cache(m_cache);
+            uct_cuda_ipc_destroy_cache(m_cache, 1);
         }
         uct_cuda_ipc_cache_set_global_limits(ULONG_MAX, SIZE_MAX);
         ucs::test::cleanup();


### PR DESCRIPTION
## What?
Backport of https://github.com/openucx/ucx/pull/11846
Address https://github.com/ai-dynamo/nixl/issues/2171

## Why?
We should ignore this diagnostic on cleanup, because it's not a real issue, as all this mem handles will be destroyed anyway, as the cuda driver is shutting down 

## How?
Add log_level param
