### PR TITLE
UCT/CUDA_IPC: Check GPU identity for same-process peers

### DIFF
--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2814,11 +2814,16 @@ static ucs_status_t ucp_wireup_select_set_locality_flags(
                                     UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR |
                                     UCT_IFACE_IS_REACHABLE_FIELD_SCOPE |
                                     UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR_LENGTH |
-                                    UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH;
+                                    UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH |
+                                    UCT_IFACE_IS_REACHABLE_FIELD_LOCAL_SYS_DEV |
+                                    UCT_IFACE_IS_REACHABLE_FIELD_REMOTE_SYS_DEV;
         params.device_addr        = ae->dev_addr;
         params.iface_addr         = ae->iface_addr;
         params.device_addr_length = ae->dev_addr_len;
         params.iface_addr_length  = ae->iface_addr_len;
+        params.local_sys_dev      =
+                worker->context->tl_rscs[rsc_index].tl_rsc.sys_device;
+        params.remote_sys_dev     = ae->sys_dev;
         params.scope              = UCT_IFACE_REACHABILITY_SCOPE_DEVICE;
 
         if (uct_iface_is_reachable_v2(wiface->iface, &params)) {

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1502,11 +1502,15 @@ int ucp_wireup_is_reachable(ucp_ep_h ep, unsigned ep_init_flags,
         .field_mask         = UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR |
                               UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR |
                               UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR_LENGTH |
-                              UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH,
+                              UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH |
+                              UCT_IFACE_IS_REACHABLE_FIELD_LOCAL_SYS_DEV |
+                              UCT_IFACE_IS_REACHABLE_FIELD_REMOTE_SYS_DEV,
         .device_addr        = ae->dev_addr,
         .iface_addr         = ae->iface_addr,
         .device_addr_length = ae->dev_addr_len,
-        .iface_addr_length  = ae->iface_addr_len
+        .iface_addr_length  = ae->iface_addr_len,
+        .local_sys_dev      = context->tl_rscs[rsc_index].tl_rsc.sys_device,
+        .remote_sys_dev     = ae->sys_dev
     };
 
     if (info_str != NULL) {

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -292,7 +292,9 @@ typedef enum {
     UCT_IFACE_IS_REACHABLE_FIELD_INFO_STRING_LENGTH = UCS_BIT(3), /**< info_string_length field */
     UCT_IFACE_IS_REACHABLE_FIELD_SCOPE              = UCS_BIT(4), /**< scope field */
     UCT_IFACE_IS_REACHABLE_FIELD_DEVICE_ADDR_LENGTH = UCS_BIT(5), /**< device_addr_length field */
-    UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH  = UCS_BIT(6)  /**< iface_addr_length field */
+    UCT_IFACE_IS_REACHABLE_FIELD_IFACE_ADDR_LENGTH  = UCS_BIT(6), /**< iface_addr_length field */
+    UCT_IFACE_IS_REACHABLE_FIELD_LOCAL_SYS_DEV      = UCS_BIT(7), /**< local_sys_dev field */
+    UCT_IFACE_IS_REACHABLE_FIELD_REMOTE_SYS_DEV     = UCS_BIT(8)  /**< remote_sys_dev field */
 } uct_iface_is_reachable_field_mask_t;
 
 
@@ -662,6 +664,12 @@ typedef struct uct_iface_is_reachable_params {
      * default minimum length according to the address buffer contents.
      */
     size_t                        iface_addr_length;
+
+    /** Local system device id. */
+    ucs_sys_device_t              local_sys_dev;
+
+    /** Remote system device id. */
+    ucs_sys_device_t              remote_sys_dev;
 } uct_iface_is_reachable_params_t;
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -164,9 +164,16 @@ uct_cuda_ipc_iface_is_reachable_v2(const uct_iface_h tl_iface,
                                      sizeof(pid_t));
     ipc_addr       = uct_cuda_ipc_iface_address_unpack(params->iface_addr,
                                                        iface_addr_len);
+    /* CUDA IPC is not useful between endpoints in one process which use the
+     * same GPU. UCP supplies the system device identities; preserve
+     * reachability for UCT callers which do not provide them. */
     if (same_uuid &&
-        uct_cuda_ipc_is_rkey_local(ipc_addr.pid, ipc_addr.pid_ns)) {
-        uct_iface_fill_info_str_buf(params, "same process");
+        uct_cuda_ipc_is_rkey_local(ipc_addr.pid, ipc_addr.pid_ns) &&
+        (params->field_mask & UCT_IFACE_IS_REACHABLE_FIELD_LOCAL_SYS_DEV) &&
+        (params->field_mask & UCT_IFACE_IS_REACHABLE_FIELD_REMOTE_SYS_DEV) &&
+        (params->local_sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) &&
+        (params->local_sys_dev == params->remote_sys_dev)) {
+        uct_iface_fill_info_str_buf(params, "same process and same GPU");
         return 0;
     }
 

--- a/test/gtest/uct/test_uct_iface.cc
+++ b/test/gtest/uct/test_uct_iface.cc
@@ -59,8 +59,19 @@ void test_uct_iface::test_is_reachable()
 
     bool is_reachable = uct_iface_is_reachable_v2(iface, &params);
     if (has_cuda_ipc()) {
-        EXPECT_FALSE(is_reachable);
-        EXPECT_EQ(std::string("same process"), std::string(info_str));
+        /* GPU identity is not supplied by this direct UCT caller. */
+        EXPECT_TRUE(is_reachable);
+
+        params.field_mask |= UCT_IFACE_IS_REACHABLE_FIELD_LOCAL_SYS_DEV |
+                             UCT_IFACE_IS_REACHABLE_FIELD_REMOTE_SYS_DEV;
+        params.local_sys_dev  = 0;
+        params.remote_sys_dev = 0;
+        EXPECT_FALSE(uct_iface_is_reachable_v2(iface, &params));
+        EXPECT_EQ(std::string("same process and same GPU"),
+                  std::string(info_str));
+
+        params.remote_sys_dev = 1;
+        EXPECT_TRUE(uct_iface_is_reachable_v2(iface, &params));
     } else {
         EXPECT_TRUE(is_reachable);
     }


### PR DESCRIPTION
## What?

Fixes #11854 .

Prevent CUDA IPC from being selected for endpoints in the same process on the same GPU. UCX now passes local and remote system-device IDs to the UCT reachability check and rejects CUDA IPC only when both identities match.

The change includes a CUDA IPC reachability test covering:

- no GPU identity supplied: reachable (preserves direct UCT callers);
- same GPU identity: unreachable;
- different GPU identity: reachable.

## Why?

UCX 1.21.0 and newer can select CUDA IPC for same-process, same-GPU UCP endpoints. A CUDA-to-managed-memory rendezvous transfer then creates a 512 MiB CUDA rendezvous-fragment pool per retained UCP context, eventually causing applications to run out-of-GPU-memory.

CUDA IPC is not beneficial for this case. At the same time, rejecting all same-process CUDA IPC paths would incorrectly disable valid same-process, multi-GPU communication.

## How?

`uct_iface_is_reachable_params_t` gains optional local and remote system-device fields. UCP wireup supplies the local resource's system device and the remote address entry's system device.

The CUDA IPC reachability callback rejects a peer only when it is on the same host, has the same PID namespace/process, and both supplied system-device IDs identify the same GPU. This preserves CUDA IPC for same-process peers on distinct GPUs.