### PR TITLE
[TEMP][DO NOT REVIEW] Isolate PR 11685 mock topology state

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ Ivan Kochin <ikochin@nvidia.com>
 Jakir Kham <jakirkham@gmail.com>
 Jason Gunthorpe <jgg@mellanox.com>
 Jeff Daily <jeff.daily@amd.com>
+Jeffrey Mahou <jmahou@nvidia.com>
 Jianxin Xiong <jianxin.xiong@intel.com>
 John Snyder <jms285@duke.edu>
 Jonas Zhou <JonasZhou@zhaoxin.com>

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -1024,7 +1024,7 @@ run_malloc_hook_gtest() {
 }
 
 set_gtest_common_test_flags() {
-	export GTEST_RANDOM_SEED=0
+	export GTEST_RANDOM_SEED=37290
 	export GTEST_SHUFFLE=1
 	# Run UCT tests for TCP over fastest device only
 	export GTEST_UCT_TCP_FASTEST_DEV=1
@@ -1040,7 +1040,7 @@ set_gtest_make_test_flags() {
 	# Report TOP-20 longest test at the end of testing
 	export GTEST_REPORT_LONGEST_TESTS=20
 
-	GTEST_EXTRA_ARGS=""
+	GTEST_EXTRA_ARGS="-s 11689"
 	if [ "$TEST_PERF" == 1 ] && [[ "$VALGRIND_CHECK" != "yes" ]]
 	then
 		# Check performance with 10 retries and 2 seconds interval

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -331,9 +331,13 @@ static ucp_proto_select_param_t ucp_proto_rndv_remote_select_param_init(
                                     &mem_info, select_param->sg_count);
     } else {
         /* If we know the remote buffer parameters, these are actually the local
-         * parameters for the remote protocol
+         * parameters for the remote protocol. The rkey system device belongs
+         * to the remote topology namespace, so it cannot represent a local
+         * device while estimating the protocol that the peer will select.
+         * The peer will use its actual local system device when selecting the
+         * protocol.
          */
-        mem_info.sys_dev = init_params->rkey_config_key->sys_dev;
+        mem_info.sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
         mem_info.type    = init_params->rkey_config_key->mem_type;
         mem_info.flags   = ucp_proto_rndv_rkey_mem_flags_estimate(init_params);
         ucp_proto_select_param_init(&remote_select_param, params->remote_op_id,

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -326,6 +326,8 @@ static void
 ucp_proto_rndv_get_mtype_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_t *context = init_params->worker->context;
+    ucp_proto_init_params_t mtype_init_params;
+    ucp_proto_select_param_t mtype_select_param;
     ucs_memory_type_t frag_mem_type;
     ucp_md_map_t mdesc_md_map;
     ucs_status_t status;
@@ -347,7 +349,10 @@ ucp_proto_rndv_get_mtype_probe(const ucp_proto_init_params_t *init_params)
             continue;
         }
 
-        ucp_proto_rndv_get_common_probe(init_params,
+        ucp_proto_rndv_mtype_init_params_copy(init_params, &frag_mem_info,
+                                              &mtype_select_param,
+                                              &mtype_init_params);
+        ucp_proto_rndv_get_common_probe(&mtype_init_params,
                                         UCS_BIT(UCP_RNDV_MODE_GET_PIPELINE),
                                         frag_size, UCT_EP_OP_PUT_ZCOPY, 0,
                                         mdesc_md_map, 1, &frag_mem_info);

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -326,8 +326,7 @@ static void
 ucp_proto_rndv_get_mtype_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_t *context = init_params->worker->context;
-    ucp_proto_init_params_t mtype_init_params;
-    ucp_proto_select_param_t mtype_select_param;
+    ucp_proto_rndv_mtype_init_params_t mtype_init_params;
     ucs_memory_type_t frag_mem_type;
     ucp_md_map_t mdesc_md_map;
     ucs_status_t status;
@@ -350,9 +349,8 @@ ucp_proto_rndv_get_mtype_probe(const ucp_proto_init_params_t *init_params)
         }
 
         ucp_proto_rndv_mtype_init_params_copy(init_params, &frag_mem_info,
-                                              &mtype_select_param,
                                               &mtype_init_params);
-        ucp_proto_rndv_get_common_probe(&mtype_init_params,
+        ucp_proto_rndv_get_common_probe(&mtype_init_params.super,
                                         UCS_BIT(UCP_RNDV_MODE_GET_PIPELINE),
                                         frag_size, UCT_EP_OP_PUT_ZCOPY, 0,
                                         mdesc_md_map, 1, &frag_mem_info);

--- a/src/ucp/rndv/rndv_get.c
+++ b/src/ucp/rndv/rndv_get.c
@@ -348,8 +348,8 @@ ucp_proto_rndv_get_mtype_probe(const ucp_proto_init_params_t *init_params)
             continue;
         }
 
-        ucp_proto_rndv_mtype_init_params_copy(init_params, &frag_mem_info,
-                                              &mtype_init_params);
+        ucp_proto_rndv_mtype_init_params_prepare(init_params, &frag_mem_info,
+                                                 &mtype_init_params);
         ucp_proto_rndv_get_common_probe(&mtype_init_params.super,
                                         UCS_BIT(UCP_RNDV_MODE_GET_PIPELINE),
                                         frag_size, UCT_EP_OP_PUT_ZCOPY, 0,

--- a/src/ucp/rndv/rndv_mtype.inl
+++ b/src/ucp/rndv/rndv_mtype.inl
@@ -60,7 +60,7 @@ static UCS_F_ALWAYS_INLINE void ucp_proto_rndv_mtype_init_params_copy(
     mtype_init_params->super                = *init_params;
     mtype_init_params->select_param         = *init_params->select_param;
     mtype_init_params->select_param.sys_dev = frag_mem_info->sys_dev;
-    mtype_init_params->super.select_param  = &mtype_init_params->select_param;
+    mtype_init_params->super.select_param   = &mtype_init_params->select_param;
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t

--- a/src/ucp/rndv/rndv_mtype.inl
+++ b/src/ucp/rndv/rndv_mtype.inl
@@ -44,6 +44,20 @@ ucp_proto_rndv_mtype_init(const ucp_proto_init_params_t *init_params,
     return UCS_OK;
 }
 
+static UCS_F_ALWAYS_INLINE void ucp_proto_rndv_mtype_init_params_copy(
+        const ucp_proto_init_params_t *init_params,
+        const ucp_memory_info_t *frag_mem_info,
+        ucp_proto_select_param_t *select_param,
+        ucp_proto_init_params_t *mtype_init_params)
+{
+    /* Use the staging buffer device for local lane modeling without changing
+     * the protocol selection lookup key. */
+    *mtype_init_params              = *init_params;
+    *select_param                   = *init_params->select_param;
+    select_param->sys_dev           = frag_mem_info->sys_dev;
+    mtype_init_params->select_param = select_param;
+}
+
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_rndv_mtype_request_init(ucp_request_t *req,
                                   ucs_memory_type_t frag_mem_type,

--- a/src/ucp/rndv/rndv_mtype.inl
+++ b/src/ucp/rndv/rndv_mtype.inl
@@ -49,7 +49,6 @@ typedef struct {
     ucp_proto_select_param_t select_param;
 } ucp_proto_rndv_mtype_init_params_t;
 
-
 static UCS_F_ALWAYS_INLINE void ucp_proto_rndv_mtype_init_params_copy(
         const ucp_proto_init_params_t *init_params,
         const ucp_memory_info_t *frag_mem_info,

--- a/src/ucp/rndv/rndv_mtype.inl
+++ b/src/ucp/rndv/rndv_mtype.inl
@@ -44,18 +44,23 @@ ucp_proto_rndv_mtype_init(const ucp_proto_init_params_t *init_params,
     return UCS_OK;
 }
 
+typedef struct {
+    ucp_proto_init_params_t  super;
+    ucp_proto_select_param_t select_param;
+} ucp_proto_rndv_mtype_init_params_t;
+
+
 static UCS_F_ALWAYS_INLINE void ucp_proto_rndv_mtype_init_params_copy(
         const ucp_proto_init_params_t *init_params,
         const ucp_memory_info_t *frag_mem_info,
-        ucp_proto_select_param_t *select_param,
-        ucp_proto_init_params_t *mtype_init_params)
+        ucp_proto_rndv_mtype_init_params_t *mtype_init_params)
 {
     /* Use the staging buffer device for local lane modeling without changing
      * the protocol selection lookup key. */
-    *mtype_init_params              = *init_params;
-    *select_param                   = *init_params->select_param;
-    select_param->sys_dev           = frag_mem_info->sys_dev;
-    mtype_init_params->select_param = select_param;
+    mtype_init_params->super                = *init_params;
+    mtype_init_params->select_param         = *init_params->select_param;
+    mtype_init_params->select_param.sys_dev = frag_mem_info->sys_dev;
+    mtype_init_params->super.select_param  = &mtype_init_params->select_param;
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t

--- a/src/ucp/rndv/rndv_mtype.inl
+++ b/src/ucp/rndv/rndv_mtype.inl
@@ -49,16 +49,16 @@ typedef struct {
     ucp_proto_select_param_t select_param;
 } ucp_proto_rndv_mtype_init_params_t;
 
-static UCS_F_ALWAYS_INLINE void ucp_proto_rndv_mtype_init_params_copy(
+static UCS_F_ALWAYS_INLINE void ucp_proto_rndv_mtype_init_params_prepare(
         const ucp_proto_init_params_t *init_params,
         const ucp_memory_info_t *frag_mem_info,
         ucp_proto_rndv_mtype_init_params_t *mtype_init_params)
 {
     /* Use the staging buffer device for local lane modeling without changing
      * the protocol selection lookup key. */
-    mtype_init_params->super                = *init_params;
     mtype_init_params->select_param         = *init_params->select_param;
     mtype_init_params->select_param.sys_dev = frag_mem_info->sys_dev;
+    mtype_init_params->super                = *init_params;
     mtype_init_params->super.select_param   = &mtype_init_params->select_param;
 }
 

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -597,8 +597,7 @@ static void
 ucp_proto_rndv_put_mtype_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_t *context = init_params->worker->context;
-    ucp_proto_init_params_t mtype_init_params;
-    ucp_proto_select_param_t mtype_select_param;
+    ucp_proto_rndv_mtype_init_params_t mtype_init_params;
     ucs_memory_type_t frag_mem_type;
     uct_completion_callback_t comp_cb;
     ucp_md_map_t mdesc_md_map;
@@ -634,10 +633,6 @@ ucp_proto_rndv_put_mtype_probe(const ucp_proto_init_params_t *init_params)
         return;
     }
 
-    ucp_proto_rndv_mtype_init_params_copy(init_params, &frag_mem_info,
-                                          &mtype_select_param,
-                                          &mtype_init_params);
-
     flags = context->config.ext.rndv_errh_ppln_enable ?
             UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING : 0;
 
@@ -647,9 +642,11 @@ ucp_proto_rndv_put_mtype_probe(const ucp_proto_init_params_t *init_params)
         comp_cb = ucp_proto_rndv_put_mtype_completion;
     }
 
+    ucp_proto_rndv_mtype_init_params_copy(init_params, &frag_mem_info,
+                                          &mtype_init_params);
     ucp_proto_rndv_put_common_probe(
-            &mtype_init_params, UCS_BIT(UCP_RNDV_MODE_PUT_PIPELINE), frag_size,
-            UCT_EP_OP_GET_ZCOPY, flags, mdesc_md_map, comp_cb, 1,
+            &mtype_init_params.super, UCS_BIT(UCP_RNDV_MODE_PUT_PIPELINE),
+            frag_size, UCT_EP_OP_GET_ZCOPY, flags, mdesc_md_map, comp_cb, 1,
             UCP_WORKER_STAT_RNDV_PUT_MTYPE_ZCOPY, &frag_mem_info);
 }
 

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -644,10 +644,12 @@ ucp_proto_rndv_put_mtype_probe(const ucp_proto_init_params_t *init_params)
 
     ucp_proto_rndv_mtype_init_params_copy(init_params, &frag_mem_info,
                                           &mtype_init_params);
-    ucp_proto_rndv_put_common_probe(
-            &mtype_init_params.super, UCS_BIT(UCP_RNDV_MODE_PUT_PIPELINE),
-            frag_size, UCT_EP_OP_GET_ZCOPY, flags, mdesc_md_map, comp_cb, 1,
-            UCP_WORKER_STAT_RNDV_PUT_MTYPE_ZCOPY, &frag_mem_info);
+    ucp_proto_rndv_put_common_probe(&mtype_init_params.super,
+                                    UCS_BIT(UCP_RNDV_MODE_PUT_PIPELINE),
+                                    frag_size, UCT_EP_OP_GET_ZCOPY, flags,
+                                    mdesc_md_map, comp_cb, 1,
+                                    UCP_WORKER_STAT_RNDV_PUT_MTYPE_ZCOPY,
+                                    &frag_mem_info);
 }
 
 static void

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -597,6 +597,8 @@ static void
 ucp_proto_rndv_put_mtype_probe(const ucp_proto_init_params_t *init_params)
 {
     ucp_context_t *context = init_params->worker->context;
+    ucp_proto_init_params_t mtype_init_params;
+    ucp_proto_select_param_t mtype_select_param;
     ucs_memory_type_t frag_mem_type;
     uct_completion_callback_t comp_cb;
     ucp_md_map_t mdesc_md_map;
@@ -632,6 +634,10 @@ ucp_proto_rndv_put_mtype_probe(const ucp_proto_init_params_t *init_params)
         return;
     }
 
+    ucp_proto_rndv_mtype_init_params_copy(init_params, &frag_mem_info,
+                                          &mtype_select_param,
+                                          &mtype_init_params);
+
     flags = context->config.ext.rndv_errh_ppln_enable ?
             UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING : 0;
 
@@ -642,7 +648,7 @@ ucp_proto_rndv_put_mtype_probe(const ucp_proto_init_params_t *init_params)
     }
 
     ucp_proto_rndv_put_common_probe(
-            init_params, UCS_BIT(UCP_RNDV_MODE_PUT_PIPELINE), frag_size,
+            &mtype_init_params, UCS_BIT(UCP_RNDV_MODE_PUT_PIPELINE), frag_size,
             UCT_EP_OP_GET_ZCOPY, flags, mdesc_md_map, comp_cb, 1,
             UCP_WORKER_STAT_RNDV_PUT_MTYPE_ZCOPY, &frag_mem_info);
 }

--- a/src/ucp/rndv/rndv_put.c
+++ b/src/ucp/rndv/rndv_put.c
@@ -642,8 +642,8 @@ ucp_proto_rndv_put_mtype_probe(const ucp_proto_init_params_t *init_params)
         comp_cb = ucp_proto_rndv_put_mtype_completion;
     }
 
-    ucp_proto_rndv_mtype_init_params_copy(init_params, &frag_mem_info,
-                                          &mtype_init_params);
+    ucp_proto_rndv_mtype_init_params_prepare(init_params, &frag_mem_info,
+                                             &mtype_init_params);
     ucp_proto_rndv_put_common_probe(&mtype_init_params.super,
                                     UCS_BIT(UCP_RNDV_MODE_PUT_PIPELINE),
                                     frag_size, UCT_EP_OP_GET_ZCOPY, flags,

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -937,8 +937,8 @@ protected:
 
     ucs::mock         m_progress_mock;
     bool              m_is_peer_closed{false};
-    bool m_fail_target_proto{true};
-    bool m_target_proto_seen{false};
+    bool              m_fail_target_proto{true};
+    bool              m_target_proto_seen{false};
     std::string       m_proto_name{};
     /* Protocol stage during which data transfer happens */
     uint8_t           m_proto_xfer_stage{};

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -937,8 +937,8 @@ protected:
 
     ucs::mock         m_progress_mock;
     bool              m_is_peer_closed{false};
-    bool              m_fail_target_proto{true};
-    bool              m_target_proto_seen{false};
+    bool m_fail_target_proto{true};
+    bool m_target_proto_seen{false};
     std::string       m_proto_name{};
     /* Protocol stage during which data transfer happens */
     uint8_t           m_proto_xfer_stage{};

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -840,15 +840,12 @@ protected:
         ucs::mock mock;
 
         if (proto->name == self->m_proto_name) {
-            self->m_target_proto_seen = true;
-            if (self->m_fail_target_proto) {
-                if (self->m_replace_ops) {
-                    mock_rndv_ops(req->send.ep, mock);
-                }
+            if (self->m_replace_ops) {
+                mock_rndv_ops(req->send.ep, mock);
+            }
 
-                if (stage == self->m_proto_xfer_stage) {
-                    self->close_peer();
-                }
+            if (stage == self->m_proto_xfer_stage) {
+                self->close_peer();
             }
         }
 
@@ -907,20 +904,6 @@ protected:
         setup_progress_mock(sender().worker(), m_progress_mock);
         setup_progress_mock(receiver().worker(), m_progress_mock);
 
-        if (mode == rndv_mode::put_ppln) {
-            /* The capability check in init() does not include staging-device
-             * reachability. Verify that this topology actually selected the
-             * protocol whose abort handling is under test. */
-            m_fail_target_proto = false;
-            m_target_proto_seen = false;
-            smoke_test(true);
-            if (!m_target_proto_seen) {
-                m_progress_mock.cleanup();
-                UCS_TEST_SKIP_R("rndv/put/mtype was not selected");
-            }
-        }
-
-        m_fail_target_proto = true;
         {
             scoped_log_handler err_wrapper(wrap_errors_logger);
             scoped_log_handler warn_wrapper(wrap_warns_logger);
@@ -937,8 +920,6 @@ protected:
 
     ucs::mock         m_progress_mock;
     bool              m_is_peer_closed{false};
-    bool              m_fail_target_proto{true};
-    bool              m_target_proto_seen{false};
     std::string       m_proto_name{};
     /* Protocol stage during which data transfer happens */
     uint8_t           m_proto_xfer_stage{};

--- a/test/gtest/ucp/test_ucp_peer_failure.cc
+++ b/test/gtest/ucp/test_ucp_peer_failure.cc
@@ -840,12 +840,15 @@ protected:
         ucs::mock mock;
 
         if (proto->name == self->m_proto_name) {
-            if (self->m_replace_ops) {
-                mock_rndv_ops(req->send.ep, mock);
-            }
+            self->m_target_proto_seen = true;
+            if (self->m_fail_target_proto) {
+                if (self->m_replace_ops) {
+                    mock_rndv_ops(req->send.ep, mock);
+                }
 
-            if (stage == self->m_proto_xfer_stage) {
-                self->close_peer();
+                if (stage == self->m_proto_xfer_stage) {
+                    self->close_peer();
+                }
             }
         }
 
@@ -904,6 +907,20 @@ protected:
         setup_progress_mock(sender().worker(), m_progress_mock);
         setup_progress_mock(receiver().worker(), m_progress_mock);
 
+        if (mode == rndv_mode::put_ppln) {
+            /* The capability check in init() does not include staging-device
+             * reachability. Verify that this topology actually selected the
+             * protocol whose abort handling is under test. */
+            m_fail_target_proto = false;
+            m_target_proto_seen = false;
+            smoke_test(true);
+            if (!m_target_proto_seen) {
+                m_progress_mock.cleanup();
+                UCS_TEST_SKIP_R("rndv/put/mtype was not selected");
+            }
+        }
+
+        m_fail_target_proto = true;
         {
             scoped_log_handler err_wrapper(wrap_errors_logger);
             scoped_log_handler warn_wrapper(wrap_warns_logger);
@@ -920,6 +937,8 @@ protected:
 
     ucs::mock         m_progress_mock;
     bool              m_is_peer_closed{false};
+    bool              m_fail_target_proto{true};
+    bool              m_target_proto_seen{false};
     std::string       m_proto_name{};
     /* Protocol stage during which data transfer happens */
     uint8_t           m_proto_xfer_stage{};

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -1394,10 +1394,15 @@ protected:
     {
         static constexpr size_t msg_size = UCS_KBYTE;
         uint8_t remote                   = 0;
+        ucp_worker_h worker              = sender().worker();
+
+        if (worker->mem_type_ep[UCS_MEMORY_TYPE_CUDA_MANAGED] == NULL) {
+            UCS_TEST_SKIP_R("CUDA managed memory type endpoint is unavailable");
+        }
+
         auto memh           = mem_map(receiver(), &remote, sizeof(remote));
         auto rkey_packed    = rkey_pack(receiver(), memh);
         auto rkey           = rkey_unpack(sender().ep(), rkey_packed);
-        ucp_worker_h worker = sender().worker();
         ucp_worker_cfg_index_t ep_cfg_index = ep_config_index(sender());
         ucp_rkey_config_t *rkey_config = &ucs_array_elem(&worker->rkey_config,
                                                          rkey->cfg_index);

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -13,6 +13,7 @@ extern "C" {
 #include <uct/base/uct_iface.h>
 #include <ucp/proto/proto_debug.h>
 #include <ucp/proto/proto_select.inl>
+#include <ucp/rndv/proto_rndv.h>
 #include <ucs/memory/numa.h>
 #include <ucs/sys/sys.h>
 #include <ucs/sys/topo/base/topo.h>
@@ -865,6 +866,71 @@ UCS_TEST_P(test_ucp_proto_mock_rcx, rma_put_2_lanes,
         {0,    2048, "short",     "rc_mlx5/mock_1:1"},
         {2049, INF,  "zero-copy", "47% on rc_mlx5/mock_1:1 and 53% on rc_mlx5/mock_0:1"},
     }, key, 0);
+}
+
+UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_remote_sys_dev_namespace,
+           "IB_NUM_PATHS?=1", "RNDV_SCHEME=put_zcopy")
+{
+    constexpr size_t select_size = UCS_MBYTE;
+    uint8_t remote               = 0;
+    auto memh                    = mem_map(receiver(), &remote,
+                                           sizeof(remote));
+    auto rkey_packed             = rkey_pack(receiver(), memh);
+    auto rkey                    = rkey_unpack(sender().ep(), rkey_packed);
+    ucp_worker_h worker          = sender().worker();
+    ucp_worker_cfg_index_t ep_cfg_index = ep_config_index(sender());
+    const ucs_sys_device_t remote_sys_dev =
+            get_mock_sys_dev_by_name("mock_0:1");
+    const ucp_rkey_config_t *base_rkey_config =
+            &ucs_array_elem(&worker->rkey_config, rkey->cfg_index);
+    const ucp_ep_config_t *ep_config =
+            ucp_worker_ep_config(worker, ep_cfg_index);
+    ucp_rkey_config_key_t rkey_config_key = base_rkey_config->key;
+    ucs_sys_dev_distance_t lanes_distance[UCP_MAX_LANES];
+    ucp_worker_cfg_index_t rkey_cfg_index;
+    ucp_rkey_config_t *rkey_config;
+    ucp_proto_select_param_t select_param;
+    ucp_memory_info_t mem_info;
+    const ucp_proto_select_elem_t *select_elem;
+    const ucp_proto_threshold_elem_t *threshold;
+    const ucp_proto_rndv_ctrl_priv_t *rpriv;
+    ucp_lane_index_t lane;
+
+    ASSERT_EQ(UCS_SYS_DEVICE_ID_UNKNOWN, rkey_config_key.sys_dev);
+    ASSERT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, remote_sys_dev);
+
+    for (lane = 0; lane < ep_config->key.num_lanes; ++lane) {
+        lanes_distance[lane] = base_rkey_config->lanes_distance[lane];
+    }
+
+    /* Simulate an rkey received from a peer whose process-local sys_dev value
+     * happens to name a device in this process as well. */
+    rkey_config_key.sys_dev = remote_sys_dev;
+    ASSERT_UCS_OK(ucp_worker_rkey_config_get(worker, &rkey_config_key,
+                                             lanes_distance,
+                                             &rkey_cfg_index));
+
+    mem_info.type    = UCS_MEMORY_TYPE_HOST;
+    mem_info.sys_dev = get_mock_sys_dev_by_name("mock_1:1");
+    mem_info.flags   = UCS_MEM_FLAG_REGISTRABLE;
+    ucp_proto_select_param_init(&select_param, UCP_OP_ID_RNDV_RECV, 0, 0,
+                                UCP_DATATYPE_CONTIG, &mem_info, 1);
+
+    rkey_config = &ucs_array_elem(&worker->rkey_config, rkey_cfg_index);
+    select_elem = ucp_proto_select_lookup_slow(
+            worker, &rkey_config->proto_select, 1, ep_cfg_index,
+            rkey_cfg_index, &select_param);
+    ASSERT_NE(nullptr, select_elem);
+
+    threshold = ucp_proto_thresholds_search_slow(select_elem->thresholds,
+                                                  select_size);
+    ASSERT_STREQ("rndv/rtr", threshold->proto_config.proto->name);
+    rpriv = static_cast<const ucp_proto_rndv_ctrl_priv_t *>(
+            threshold->proto_config.priv);
+
+    EXPECT_EQ(remote_sys_dev, rkey_config->key.sys_dev);
+    EXPECT_EQ(UCS_SYS_DEVICE_ID_UNKNOWN,
+              rpriv->remote_proto_config.select_param.sys_dev);
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_rcx, rcx, "rc_x")

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -558,16 +558,25 @@ protected:
     }
 
     void
-    send_recv_am(size_t size, ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_HOST)
+    send_recv_am(size_t size, ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_HOST,
+                 ucs_sys_device_t sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN)
     {
         /* Prepare receiver data handler */
         mem_buffer recv_buf(size, mem_type);
+        ucs::handle<ucp_mem_h, ucp_context_h> recv_memh;
+        if (sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
+            recv_memh = mem_map(receiver(), recv_buf);
+            recv_memh->sys_dev = sys_dev;
+        }
+
         struct ctx_t {
             mem_buffer                     *buf;
             bool                            received;
             ucp_worker_h                    worker;
             ucp_am_recv_data_nbx_callback_t cmpl;
-        } ctx = {&recv_buf, false, receiver().worker()};
+            ucp_mem_h                       memh;
+        } ctx = {&recv_buf, false, receiver().worker(), nullptr,
+                 recv_memh.get()};
 
         ctx.cmpl = [](void *req, ucs_status_t status, size_t len, void *arg) {
             ((ctx_t *)arg)->received = true;
@@ -590,6 +599,10 @@ protected:
                                   UCP_OP_ATTR_FIELD_USER_DATA;
             params.user_data    = arg;
             params.cb.recv_am   = ctx->cmpl;
+            if (ctx->memh != nullptr) {
+                params.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;
+                params.memh          = ctx->memh;
+            }
 
             auto sptr = ucp_am_recv_data_nbx(ctx->worker, data, ctx->buf->ptr(),
                                              len, &params);
@@ -611,7 +624,15 @@ protected:
 
         /* Send data */
         mem_buffer buf(size, mem_type);
+        ucs::handle<ucp_mem_h, ucp_context_h> send_memh;
         ucp_request_param_t param = {};
+        if (sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
+            send_memh = mem_map(sender(), buf);
+            send_memh->sys_dev = sys_dev;
+            param.op_attr_mask = UCP_OP_ATTR_FIELD_MEMH;
+            param.memh         = send_memh;
+        }
+
         auto sptr = ucp_am_send_nbx(sender().ep(), AM_ID, NULL, 0ul, buf.ptr(),
                                     buf.size(), &param);
         EXPECT_FALSE(UCS_PTR_IS_ERR(sptr));
@@ -1344,6 +1365,182 @@ UCS_TEST_P(test_ucp_proto_mock_gpu, cuda_managed_ppln_host_frag,
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_gpu, rcx_gpu,
+                              "rc_x,cuda,rocm")
+
+class test_ucp_proto_mock_mtype_sys_dev : public test_ucp_proto_mock {
+public:
+    test_ucp_proto_mock_mtype_sys_dev()
+    {
+        mock_transport("rc_mlx5");
+    }
+
+    virtual void init() override
+    {
+        auto iface_attr_func = [](uct_iface_attr_t &iface_attr) {
+            iface_attr.cap.am.max_short  = 2000;
+            iface_attr.bandwidth.shared  = 28e9;
+            iface_attr.latency.c         = 600e-9;
+            iface_attr.latency.m         = 1e-9;
+        };
+
+        add_mock_iface("mock_0:1", iface_attr_func);
+        add_mock_iface("mock_1:1", iface_attr_func);
+        test_ucp_proto_mock::init();
+
+        s_first_nic_sys_dev = get_mock_sys_dev_by_name("mock_0:1");
+        s_frag_sys_dev      = add_mock_sys_dev(0, "mock_frag");
+        s_user_sys_dev      = add_mock_sys_dev(1, "mock_user");
+
+        const ucs_sys_topo_ops_t topo_ops = {
+            .get_distance                   = get_distance,
+            .get_memory_distance            = get_memory_distance,
+            .get_memory_distance_for_cpuset = get_memory_distance_for_cpuset
+        };
+        ASSERT_UCS_OK(ucs_sys_topo_provider_push(&topo_ops));
+        m_topo_provider_pushed = true;
+
+        set_frag_sys_dev(sender());
+        set_frag_sys_dev(receiver());
+    }
+
+    virtual void cleanup() override
+    {
+        if (m_topo_provider_pushed) {
+            ucs_sys_topo_provider_pop();
+            m_topo_provider_pushed = false;
+        }
+
+        s_first_nic_sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+        s_frag_sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
+        s_user_sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
+        test_ucp_proto_mock::cleanup();
+    }
+
+protected:
+    void check_mtype_uses_frag_sys_dev(const char *operation_desc)
+    {
+        static constexpr size_t msg_size = UCS_MBYTE;
+
+        ASSERT_NE(s_user_sys_dev, s_frag_sys_dev);
+        ASSERT_NE(s_first_nic_sys_dev, s_frag_sys_dev);
+        send_recv_am(msg_size, UCS_MEMORY_TYPE_CUDA_MANAGED, s_user_sys_dev);
+
+        const ucp_ep_config_t *ep_config = ucp_worker_ep_config(
+                sender().worker(), ep_config_index(sender()));
+        ucp_proto_select_key_t select_key;
+        ucp_proto_select_elem_t select_elem;
+        bool found = false;
+
+        kh_foreach(ep_config->proto_select.hash, select_key.u64, select_elem, {
+            if ((select_key.param.op_id_flags == UCP_OP_ID_AM_SEND) &&
+                (select_key.param.op_attr == 0) &&
+                (select_key.param.dt_class == UCP_DATATYPE_CONTIG) &&
+                (select_key.param.mem_type == UCS_MEMORY_TYPE_CUDA_MANAGED) &&
+                (select_key.param.sys_dev == s_user_sys_dev)) {
+                const ucp_proto_threshold_elem_t *threshold =
+                        ucp_proto_thresholds_search_slow(select_elem.thresholds,
+                                                         msg_size);
+                ucp_proto_query_attr_t attr;
+
+                ASSERT_STREQ("am/rndv", threshold->proto_config.proto->name);
+                ucp_proto_config_query(sender().worker(),
+                                       &threshold->proto_config, msg_size,
+                                       &attr);
+                EXPECT_NE(std::string::npos,
+                          std::string(attr.desc).find(operation_desc));
+                EXPECT_STREQ("rc_mlx5/mock_1:1", attr.config);
+                found = true;
+            }
+        })
+
+        EXPECT_TRUE(found);
+    }
+
+private:
+    static ucs_sys_device_t add_mock_sys_dev(uint8_t function,
+                                             const char *name)
+    {
+        const ucs_sys_bus_id_t bus_id = {
+            .domain   = 0xfffe,
+            .bus      = 0xfe,
+            .slot     = 0x1f,
+            .function = function,
+        };
+        ucs_sys_device_t sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+
+        EXPECT_UCS_OK(ucs_topo_find_device_by_bus_id(&bus_id, &sys_dev));
+        EXPECT_UCS_OK(ucs_topo_sys_device_set_name(sys_dev, name, 10));
+        return sys_dev;
+    }
+
+    static void set_frag_sys_dev(entity &e)
+    {
+        ucp_memory_info_t mem_info;
+        ucp_md_index_t md_index;
+
+        ASSERT_UCS_OK(ucp_mm_get_alloc_md_index(
+                e.ucph(), UCS_MEMORY_TYPE_HOST, UCS_SYS_DEVICE_ID_UNKNOWN,
+                &md_index, &mem_info));
+        e.ucph()->alloc_md[UCS_MEMORY_TYPE_HOST].sys_dev = s_frag_sys_dev;
+    }
+
+    static ucs_status_t get_distance(ucs_sys_device_t device1,
+                                     ucs_sys_device_t device2,
+                                     ucs_sys_dev_distance_t *distance)
+    {
+        *distance = ucs_topo_default_distance;
+        if (((device1 == s_frag_sys_dev) &&
+             (device2 == s_first_nic_sys_dev)) ||
+            ((device2 == s_frag_sys_dev) &&
+             (device1 == s_first_nic_sys_dev))) {
+            distance->latency = 1e-3;
+        }
+        return UCS_OK;
+    }
+
+    static void
+    get_memory_distance(ucs_sys_device_t, ucs_sys_dev_distance_t *distance)
+    {
+        *distance = ucs_topo_default_distance;
+    }
+
+    static void
+    get_memory_distance_for_cpuset(ucs_sys_device_t, const ucs_cpu_set_t *,
+                                   ucs_sys_dev_distance_t *distance)
+    {
+        *distance = ucs_topo_default_distance;
+    }
+
+    bool m_topo_provider_pushed{false};
+    static ucs_sys_device_t s_first_nic_sys_dev;
+    static ucs_sys_device_t s_frag_sys_dev;
+    static ucs_sys_device_t s_user_sys_dev;
+};
+
+ucs_sys_device_t test_ucp_proto_mock_mtype_sys_dev::s_first_nic_sys_dev =
+        UCS_SYS_DEVICE_ID_UNKNOWN;
+ucs_sys_device_t test_ucp_proto_mock_mtype_sys_dev::s_frag_sys_dev =
+        UCS_SYS_DEVICE_ID_UNKNOWN;
+ucs_sys_device_t test_ucp_proto_mock_mtype_sys_dev::s_user_sys_dev =
+        UCS_SYS_DEVICE_ID_UNKNOWN;
+
+UCS_TEST_P(test_ucp_proto_mock_mtype_sys_dev, get_uses_frag_sys_dev,
+           "RNDV_SCHEME=get_ppln", "RNDV_THRESH=1",
+           "RNDV_FRAG_MEM_TYPES=host", "RNDV_FRAG_SIZE=host:8K",
+           "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1")
+{
+    check_mtype_uses_frag_sys_dev("read from remote");
+}
+
+UCS_TEST_P(test_ucp_proto_mock_mtype_sys_dev, put_uses_frag_sys_dev,
+           "RNDV_SCHEME=put_ppln", "RNDV_THRESH=1",
+           "RNDV_FRAG_MEM_TYPES=host", "RNDV_FRAG_SIZE=host:8K",
+           "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1")
+{
+    check_mtype_uses_frag_sys_dev("write to remote");
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_mtype_sys_dev, rcx_gpu,
                               "rc_x,cuda,rocm")
 
 class test_ucp_proto_mock_cuda_ipc : public test_ucp_proto_mock {

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -1365,8 +1365,12 @@ public:
         add_mock_iface("mock_1:1", iface_attr_func);
         test_ucp_proto_mock::init();
 
-        s_user_sys_dev = add_mock_sys_dev(0, "mock_user");
-        s_frag_sys_dev = add_mock_sys_dev(1, "mock_frag");
+        s_user_sys_dev = get_mock_sys_dev_by_name("mock_0:1");
+        s_frag_sys_dev = get_mock_sys_dev_by_name("mock_1:1");
+        EXPECT_UCS_OK(ucs_topo_sys_device_set_class(
+                s_user_sys_dev, UCS_TOPO_DEVICE_CLASS_ACC));
+        EXPECT_UCS_OK(ucs_topo_sys_device_set_class(
+                s_frag_sys_dev, UCS_TOPO_DEVICE_CLASS_ACC));
 
         set_frag_sys_dev(sender());
         set_frag_sys_dev(receiver());
@@ -1374,6 +1378,8 @@ public:
 
     virtual void cleanup() override
     {
+        test_ucp_proto_mock::cleanup();
+
         if (s_user_sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
             EXPECT_UCS_OK(ucs_topo_sys_device_set_class(
                     s_user_sys_dev, UCS_TOPO_DEVICE_CLASS_UNKNOWN));
@@ -1385,7 +1391,6 @@ public:
 
         s_frag_sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
         s_user_sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
-        test_ucp_proto_mock::cleanup();
     }
 
 protected:
@@ -1445,23 +1450,6 @@ protected:
     }
 
 private:
-    static ucs_sys_device_t add_mock_sys_dev(uint8_t function, const char *name)
-    {
-        const ucs_sys_bus_id_t bus_id = {
-            .domain   = 0xfffe,
-            .bus      = 0xfe,
-            .slot     = 0x1f,
-            .function = function,
-        };
-        ucs_sys_device_t sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
-
-        EXPECT_UCS_OK(ucs_topo_find_device_by_bus_id(&bus_id, &sys_dev));
-        EXPECT_UCS_OK(ucs_topo_sys_device_set_name(sys_dev, name, 10));
-        EXPECT_UCS_OK(ucs_topo_sys_device_set_class(sys_dev,
-                                                    UCS_TOPO_DEVICE_CLASS_ACC));
-        return sys_dev;
-    }
-
     static void set_frag_sys_dev(entity &e)
     {
         ucp_memory_info_t mem_info;

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -558,25 +558,16 @@ protected:
     }
 
     void
-    send_recv_am(size_t size, ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_HOST,
-                 ucs_sys_device_t sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN)
+    send_recv_am(size_t size, ucs_memory_type_t mem_type = UCS_MEMORY_TYPE_HOST)
     {
         /* Prepare receiver data handler */
         mem_buffer recv_buf(size, mem_type);
-        ucs::handle<ucp_mem_h, ucp_context_h> recv_memh;
-        if (sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
-            recv_memh = mem_map(receiver(), recv_buf);
-            recv_memh->sys_dev = sys_dev;
-        }
-
         struct ctx_t {
             mem_buffer                     *buf;
             bool                            received;
             ucp_worker_h                    worker;
             ucp_am_recv_data_nbx_callback_t cmpl;
-            ucp_mem_h                       memh;
-        } ctx = {&recv_buf, false, receiver().worker(), nullptr,
-                 recv_memh.get()};
+        } ctx = {&recv_buf, false, receiver().worker()};
 
         ctx.cmpl = [](void *req, ucs_status_t status, size_t len, void *arg) {
             ((ctx_t *)arg)->received = true;
@@ -599,10 +590,6 @@ protected:
                                   UCP_OP_ATTR_FIELD_USER_DATA;
             params.user_data    = arg;
             params.cb.recv_am   = ctx->cmpl;
-            if (ctx->memh != nullptr) {
-                params.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;
-                params.memh          = ctx->memh;
-            }
 
             auto sptr = ucp_am_recv_data_nbx(ctx->worker, data, ctx->buf->ptr(),
                                              len, &params);
@@ -624,15 +611,7 @@ protected:
 
         /* Send data */
         mem_buffer buf(size, mem_type);
-        ucs::handle<ucp_mem_h, ucp_context_h> send_memh;
         ucp_request_param_t param = {};
-        if (sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
-            send_memh = mem_map(sender(), buf);
-            send_memh->sys_dev = sys_dev;
-            param.op_attr_mask = UCP_OP_ATTR_FIELD_MEMH;
-            param.memh         = send_memh;
-        }
-
         auto sptr = ucp_am_send_nbx(sender().ep(), AM_ID, NULL, 0ul, buf.ptr(),
                                     buf.size(), &param);
         EXPECT_FALSE(UCS_PTR_IS_ERR(sptr));
@@ -1387,17 +1366,8 @@ public:
         add_mock_iface("mock_1:1", iface_attr_func);
         test_ucp_proto_mock::init();
 
-        s_first_nic_sys_dev = get_mock_sys_dev_by_name("mock_0:1");
-        s_frag_sys_dev      = add_mock_sys_dev(0, "mock_frag");
-        s_user_sys_dev      = add_mock_sys_dev(1, "mock_user");
-
-        const ucs_sys_topo_ops_t topo_ops = {
-            .get_distance                   = get_distance,
-            .get_memory_distance            = get_memory_distance,
-            .get_memory_distance_for_cpuset = get_memory_distance_for_cpuset
-        };
-        ASSERT_UCS_OK(ucs_sys_topo_provider_push(&topo_ops));
-        m_topo_provider_pushed = true;
+        s_user_sys_dev = add_mock_sys_dev(0, "mock_user");
+        s_frag_sys_dev = add_mock_sys_dev(1, "mock_frag");
 
         set_frag_sys_dev(sender());
         set_frag_sys_dev(receiver());
@@ -1405,55 +1375,70 @@ public:
 
     virtual void cleanup() override
     {
-        if (m_topo_provider_pushed) {
-            ucs_sys_topo_provider_pop();
-            m_topo_provider_pushed = false;
+        if (s_user_sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
+            EXPECT_UCS_OK(ucs_topo_sys_device_set_class(
+                    s_user_sys_dev, UCS_TOPO_DEVICE_CLASS_UNKNOWN));
+        }
+        if (s_frag_sys_dev != UCS_SYS_DEVICE_ID_UNKNOWN) {
+            EXPECT_UCS_OK(ucs_topo_sys_device_set_class(
+                    s_frag_sys_dev, UCS_TOPO_DEVICE_CLASS_UNKNOWN));
         }
 
-        s_first_nic_sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
-        s_frag_sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
-        s_user_sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
+        s_frag_sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+        s_user_sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
         test_ucp_proto_mock::cleanup();
     }
 
 protected:
-    void check_mtype_uses_frag_sys_dev(const char *operation_desc)
+    void check_mtype_uses_frag_sys_dev(ucp_operation_id_t op_id,
+                                       const char *proto_name)
     {
-        static constexpr size_t msg_size = UCS_MBYTE;
+        static constexpr size_t msg_size = UCS_KBYTE;
+        uint8_t remote                   = 0;
+        auto memh                        = mem_map(receiver(), &remote,
+                                                   sizeof(remote));
+        auto rkey_packed                 = rkey_pack(receiver(), memh);
+        auto rkey                        = rkey_unpack(sender().ep(),
+                                                       rkey_packed);
+        ucp_worker_h worker              = sender().worker();
+        ucp_worker_cfg_index_t ep_cfg_index =
+                ep_config_index(sender());
+        ucp_rkey_config_t *rkey_config = &ucs_array_elem(
+                &worker->rkey_config, rkey->cfg_index);
+        ucp_memory_info_t mem_info;
+        ucp_proto_select_param_t select_param;
+        const ucp_proto_select_elem_t *select_elem;
+        const ucp_proto_threshold_elem_t *threshold;
+        ucp_proto_query_attr_t attr;
+        unsigned user_ordinal, frag_ordinal;
 
         ASSERT_NE(s_user_sys_dev, s_frag_sys_dev);
-        ASSERT_NE(s_first_nic_sys_dev, s_frag_sys_dev);
-        send_recv_am(msg_size, UCS_MEMORY_TYPE_CUDA_MANAGED, s_user_sys_dev);
+        user_ordinal = ucs_topo_sys_device_get_bdf_class_ordinal(
+                s_user_sys_dev);
+        frag_ordinal = ucs_topo_sys_device_get_bdf_class_ordinal(
+                s_frag_sys_dev);
+        ASSERT_NE(UCS_SYS_DEVICE_ORDINAL_INVALID, user_ordinal);
+        ASSERT_NE(UCS_SYS_DEVICE_ORDINAL_INVALID, frag_ordinal);
+        ASSERT_NE(user_ordinal % 2, frag_ordinal % 2);
 
-        const ucp_ep_config_t *ep_config = ucp_worker_ep_config(
-                sender().worker(), ep_config_index(sender()));
-        ucp_proto_select_key_t select_key;
-        ucp_proto_select_elem_t select_elem;
-        bool found = false;
+        mem_info.type    = UCS_MEMORY_TYPE_CUDA_MANAGED;
+        mem_info.sys_dev = s_user_sys_dev;
+        mem_info.flags   = UCS_MEM_FLAG_REGISTRABLE;
+        ucp_proto_select_param_init(&select_param, op_id, 0, 0,
+                                    UCP_DATATYPE_CONTIG, &mem_info, 1);
+        select_elem = ucp_proto_select_lookup_slow(
+                worker, &rkey_config->proto_select, 1, ep_cfg_index,
+                rkey->cfg_index, &select_param);
+        ASSERT_NE(nullptr, select_elem);
 
-        kh_foreach(ep_config->proto_select.hash, select_key.u64, select_elem, {
-            if ((select_key.param.op_id_flags == UCP_OP_ID_AM_SEND) &&
-                (select_key.param.op_attr == 0) &&
-                (select_key.param.dt_class == UCP_DATATYPE_CONTIG) &&
-                (select_key.param.mem_type == UCS_MEMORY_TYPE_CUDA_MANAGED) &&
-                (select_key.param.sys_dev == s_user_sys_dev)) {
-                const ucp_proto_threshold_elem_t *threshold =
-                        ucp_proto_thresholds_search_slow(select_elem.thresholds,
-                                                         msg_size);
-                ucp_proto_query_attr_t attr;
-
-                ASSERT_STREQ("am/rndv", threshold->proto_config.proto->name);
-                ucp_proto_config_query(sender().worker(),
-                                       &threshold->proto_config, msg_size,
-                                       &attr);
-                EXPECT_NE(std::string::npos,
-                          std::string(attr.desc).find(operation_desc));
-                EXPECT_STREQ("rc_mlx5/mock_1:1", attr.config);
-                found = true;
-            }
-        })
-
-        EXPECT_TRUE(found);
+        threshold = ucp_proto_thresholds_search_slow(select_elem->thresholds,
+                                                      msg_size);
+        ASSERT_STREQ(proto_name, threshold->proto_config.proto->name);
+        ucp_proto_config_query(worker, &threshold->proto_config, msg_size,
+                               &attr);
+        EXPECT_STREQ((frag_ordinal % 2) ? "rc_mlx5/mock_1:1" :
+                                        "rc_mlx5/mock_0:1",
+                     attr.config);
     }
 
 private:
@@ -1470,6 +1455,8 @@ private:
 
         EXPECT_UCS_OK(ucs_topo_find_device_by_bus_id(&bus_id, &sys_dev));
         EXPECT_UCS_OK(ucs_topo_sys_device_set_name(sys_dev, name, 10));
+        EXPECT_UCS_OK(ucs_topo_sys_device_set_class(
+                sys_dev, UCS_TOPO_DEVICE_CLASS_ACC));
         return sys_dev;
     }
 
@@ -1484,41 +1471,10 @@ private:
         e.ucph()->alloc_md[UCS_MEMORY_TYPE_HOST].sys_dev = s_frag_sys_dev;
     }
 
-    static ucs_status_t get_distance(ucs_sys_device_t device1,
-                                     ucs_sys_device_t device2,
-                                     ucs_sys_dev_distance_t *distance)
-    {
-        *distance = ucs_topo_default_distance;
-        if (((device1 == s_frag_sys_dev) &&
-             (device2 == s_first_nic_sys_dev)) ||
-            ((device2 == s_frag_sys_dev) &&
-             (device1 == s_first_nic_sys_dev))) {
-            distance->latency = 1e-3;
-        }
-        return UCS_OK;
-    }
-
-    static void
-    get_memory_distance(ucs_sys_device_t, ucs_sys_dev_distance_t *distance)
-    {
-        *distance = ucs_topo_default_distance;
-    }
-
-    static void
-    get_memory_distance_for_cpuset(ucs_sys_device_t, const ucs_cpu_set_t *,
-                                   ucs_sys_dev_distance_t *distance)
-    {
-        *distance = ucs_topo_default_distance;
-    }
-
-    bool m_topo_provider_pushed{false};
-    static ucs_sys_device_t s_first_nic_sys_dev;
     static ucs_sys_device_t s_frag_sys_dev;
     static ucs_sys_device_t s_user_sys_dev;
 };
 
-ucs_sys_device_t test_ucp_proto_mock_mtype_sys_dev::s_first_nic_sys_dev =
-        UCS_SYS_DEVICE_ID_UNKNOWN;
 ucs_sys_device_t test_ucp_proto_mock_mtype_sys_dev::s_frag_sys_dev =
         UCS_SYS_DEVICE_ID_UNKNOWN;
 ucs_sys_device_t test_ucp_proto_mock_mtype_sys_dev::s_user_sys_dev =
@@ -1529,7 +1485,7 @@ UCS_TEST_P(test_ucp_proto_mock_mtype_sys_dev, get_uses_frag_sys_dev,
            "RNDV_FRAG_MEM_TYPES=host", "RNDV_FRAG_SIZE=host:8K",
            "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1")
 {
-    check_mtype_uses_frag_sys_dev("read from remote");
+    check_mtype_uses_frag_sys_dev(UCP_OP_ID_RNDV_RECV, "rndv/get/mtype");
 }
 
 UCS_TEST_P(test_ucp_proto_mock_mtype_sys_dev, put_uses_frag_sys_dev,
@@ -1537,7 +1493,7 @@ UCS_TEST_P(test_ucp_proto_mock_mtype_sys_dev, put_uses_frag_sys_dev,
            "RNDV_FRAG_MEM_TYPES=host", "RNDV_FRAG_SIZE=host:8K",
            "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1")
 {
-    check_mtype_uses_frag_sys_dev("write to remote");
+    check_mtype_uses_frag_sys_dev(UCP_OP_ID_RNDV_SEND, "rndv/put/mtype");
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_mock_mtype_sys_dev, rcx_gpu,

--- a/test/gtest/ucp/test_ucp_proto_mock.cc
+++ b/test/gtest/ucp/test_ucp_proto_mock.cc
@@ -873,18 +873,17 @@ UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_remote_sys_dev_namespace,
 {
     constexpr size_t select_size = UCS_MBYTE;
     uint8_t remote               = 0;
-    auto memh                    = mem_map(receiver(), &remote,
-                                           sizeof(remote));
-    auto rkey_packed             = rkey_pack(receiver(), memh);
-    auto rkey                    = rkey_unpack(sender().ep(), rkey_packed);
-    ucp_worker_h worker          = sender().worker();
-    ucp_worker_cfg_index_t ep_cfg_index = ep_config_index(sender());
-    const ucs_sys_device_t remote_sys_dev =
-            get_mock_sys_dev_by_name("mock_0:1");
+    auto memh           = mem_map(receiver(), &remote, sizeof(remote));
+    auto rkey_packed    = rkey_pack(receiver(), memh);
+    auto rkey           = rkey_unpack(sender().ep(), rkey_packed);
+    ucp_worker_h worker = sender().worker();
+    ucp_worker_cfg_index_t ep_cfg_index   = ep_config_index(sender());
+    const ucs_sys_device_t remote_sys_dev = get_mock_sys_dev_by_name(
+            "mock_0:1");
     const ucp_rkey_config_t *base_rkey_config =
             &ucs_array_elem(&worker->rkey_config, rkey->cfg_index);
-    const ucp_ep_config_t *ep_config =
-            ucp_worker_ep_config(worker, ep_cfg_index);
+    const ucp_ep_config_t *ep_config      = ucp_worker_ep_config(worker,
+                                                                 ep_cfg_index);
     ucp_rkey_config_key_t rkey_config_key = base_rkey_config->key;
     ucs_sys_dev_distance_t lanes_distance[UCP_MAX_LANES];
     ucp_worker_cfg_index_t rkey_cfg_index;
@@ -907,8 +906,7 @@ UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_remote_sys_dev_namespace,
      * happens to name a device in this process as well. */
     rkey_config_key.sys_dev = remote_sys_dev;
     ASSERT_UCS_OK(ucp_worker_rkey_config_get(worker, &rkey_config_key,
-                                             lanes_distance,
-                                             &rkey_cfg_index));
+                                             lanes_distance, &rkey_cfg_index));
 
     mem_info.type    = UCS_MEMORY_TYPE_HOST;
     mem_info.sys_dev = get_mock_sys_dev_by_name("mock_1:1");
@@ -917,15 +915,16 @@ UCS_TEST_P(test_ucp_proto_mock_rcx, rndv_remote_sys_dev_namespace,
                                 UCP_DATATYPE_CONTIG, &mem_info, 1);
 
     rkey_config = &ucs_array_elem(&worker->rkey_config, rkey_cfg_index);
-    select_elem = ucp_proto_select_lookup_slow(
-            worker, &rkey_config->proto_select, 1, ep_cfg_index,
-            rkey_cfg_index, &select_param);
+    select_elem = ucp_proto_select_lookup_slow(worker,
+                                               &rkey_config->proto_select, 1,
+                                               ep_cfg_index, rkey_cfg_index,
+                                               &select_param);
     ASSERT_NE(nullptr, select_elem);
 
     threshold = ucp_proto_thresholds_search_slow(select_elem->thresholds,
-                                                  select_size);
+                                                 select_size);
     ASSERT_STREQ("rndv/rtr", threshold->proto_config.proto->name);
-    rpriv = static_cast<const ucp_proto_rndv_ctrl_priv_t *>(
+    rpriv = static_cast<const ucp_proto_rndv_ctrl_priv_t*>(
             threshold->proto_config.priv);
 
     EXPECT_EQ(remote_sys_dev, rkey_config->key.sys_dev);
@@ -1356,10 +1355,10 @@ public:
     virtual void init() override
     {
         auto iface_attr_func = [](uct_iface_attr_t &iface_attr) {
-            iface_attr.cap.am.max_short  = 2000;
-            iface_attr.bandwidth.shared  = 28e9;
-            iface_attr.latency.c         = 600e-9;
-            iface_attr.latency.m         = 1e-9;
+            iface_attr.cap.am.max_short = 2000;
+            iface_attr.bandwidth.shared = 28e9;
+            iface_attr.latency.c        = 600e-9;
+            iface_attr.latency.m        = 1e-9;
         };
 
         add_mock_iface("mock_0:1", iface_attr_func);
@@ -1395,16 +1394,13 @@ protected:
     {
         static constexpr size_t msg_size = UCS_KBYTE;
         uint8_t remote                   = 0;
-        auto memh                        = mem_map(receiver(), &remote,
-                                                   sizeof(remote));
-        auto rkey_packed                 = rkey_pack(receiver(), memh);
-        auto rkey                        = rkey_unpack(sender().ep(),
-                                                       rkey_packed);
-        ucp_worker_h worker              = sender().worker();
-        ucp_worker_cfg_index_t ep_cfg_index =
-                ep_config_index(sender());
-        ucp_rkey_config_t *rkey_config = &ucs_array_elem(
-                &worker->rkey_config, rkey->cfg_index);
+        auto memh           = mem_map(receiver(), &remote, sizeof(remote));
+        auto rkey_packed    = rkey_pack(receiver(), memh);
+        auto rkey           = rkey_unpack(sender().ep(), rkey_packed);
+        ucp_worker_h worker = sender().worker();
+        ucp_worker_cfg_index_t ep_cfg_index = ep_config_index(sender());
+        ucp_rkey_config_t *rkey_config = &ucs_array_elem(&worker->rkey_config,
+                                                         rkey->cfg_index);
         ucp_memory_info_t mem_info;
         ucp_proto_select_param_t select_param;
         const ucp_proto_select_elem_t *select_elem;
@@ -1426,24 +1422,25 @@ protected:
         mem_info.flags   = UCS_MEM_FLAG_REGISTRABLE;
         ucp_proto_select_param_init(&select_param, op_id, 0, 0,
                                     UCP_DATATYPE_CONTIG, &mem_info, 1);
-        select_elem = ucp_proto_select_lookup_slow(
-                worker, &rkey_config->proto_select, 1, ep_cfg_index,
-                rkey->cfg_index, &select_param);
+        select_elem = ucp_proto_select_lookup_slow(worker,
+                                                   &rkey_config->proto_select,
+                                                   1, ep_cfg_index,
+                                                   rkey->cfg_index,
+                                                   &select_param);
         ASSERT_NE(nullptr, select_elem);
 
         threshold = ucp_proto_thresholds_search_slow(select_elem->thresholds,
-                                                      msg_size);
+                                                     msg_size);
         ASSERT_STREQ(proto_name, threshold->proto_config.proto->name);
         ucp_proto_config_query(worker, &threshold->proto_config, msg_size,
                                &attr);
         EXPECT_STREQ((frag_ordinal % 2) ? "rc_mlx5/mock_1:1" :
-                                        "rc_mlx5/mock_0:1",
+                                          "rc_mlx5/mock_0:1",
                      attr.config);
     }
 
 private:
-    static ucs_sys_device_t add_mock_sys_dev(uint8_t function,
-                                             const char *name)
+    static ucs_sys_device_t add_mock_sys_dev(uint8_t function, const char *name)
     {
         const ucs_sys_bus_id_t bus_id = {
             .domain   = 0xfffe,
@@ -1451,12 +1448,12 @@ private:
             .slot     = 0x1f,
             .function = function,
         };
-        ucs_sys_device_t sys_dev = UCS_SYS_DEVICE_ID_UNKNOWN;
+        ucs_sys_device_t sys_dev      = UCS_SYS_DEVICE_ID_UNKNOWN;
 
         EXPECT_UCS_OK(ucs_topo_find_device_by_bus_id(&bus_id, &sys_dev));
         EXPECT_UCS_OK(ucs_topo_sys_device_set_name(sys_dev, name, 10));
-        EXPECT_UCS_OK(ucs_topo_sys_device_set_class(
-                sys_dev, UCS_TOPO_DEVICE_CLASS_ACC));
+        EXPECT_UCS_OK(ucs_topo_sys_device_set_class(sys_dev,
+                                                    UCS_TOPO_DEVICE_CLASS_ACC));
         return sys_dev;
     }
 
@@ -1465,9 +1462,9 @@ private:
         ucp_memory_info_t mem_info;
         ucp_md_index_t md_index;
 
-        ASSERT_UCS_OK(ucp_mm_get_alloc_md_index(
-                e.ucph(), UCS_MEMORY_TYPE_HOST, UCS_SYS_DEVICE_ID_UNKNOWN,
-                &md_index, &mem_info));
+        ASSERT_UCS_OK(ucp_mm_get_alloc_md_index(e.ucph(), UCS_MEMORY_TYPE_HOST,
+                                                UCS_SYS_DEVICE_ID_UNKNOWN,
+                                                &md_index, &mem_info));
         e.ucph()->alloc_md[UCS_MEMORY_TYPE_HOST].sys_dev = s_frag_sys_dev;
     }
 
@@ -1481,17 +1478,15 @@ ucs_sys_device_t test_ucp_proto_mock_mtype_sys_dev::s_user_sys_dev =
         UCS_SYS_DEVICE_ID_UNKNOWN;
 
 UCS_TEST_P(test_ucp_proto_mock_mtype_sys_dev, get_uses_frag_sys_dev,
-           "RNDV_SCHEME=get_ppln", "RNDV_THRESH=1",
-           "RNDV_FRAG_MEM_TYPES=host", "RNDV_FRAG_SIZE=host:8K",
-           "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1")
+           "RNDV_SCHEME=get_ppln", "RNDV_THRESH=1", "RNDV_FRAG_MEM_TYPES=host",
+           "RNDV_FRAG_SIZE=host:8K", "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1")
 {
     check_mtype_uses_frag_sys_dev(UCP_OP_ID_RNDV_RECV, "rndv/get/mtype");
 }
 
 UCS_TEST_P(test_ucp_proto_mock_mtype_sys_dev, put_uses_frag_sys_dev,
-           "RNDV_SCHEME=put_ppln", "RNDV_THRESH=1",
-           "RNDV_FRAG_MEM_TYPES=host", "RNDV_FRAG_SIZE=host:8K",
-           "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1")
+           "RNDV_SCHEME=put_ppln", "RNDV_THRESH=1", "RNDV_FRAG_MEM_TYPES=host",
+           "RNDV_FRAG_SIZE=host:8K", "IB_NUM_PATHS?=1", "MAX_RNDV_LANES=1")
 {
     check_mtype_uses_frag_sys_dev(UCP_OP_ID_RNDV_SEND, "rndv/put/mtype");
 }


### PR DESCRIPTION
Temporary CI diagnostic for PR #11685.

This branch keeps the exact #11685 merge production code unchanged and retains the previously validated selection diagnostics. It removes only the two mock tests newly added by #11685, restoring test_ucp_proto_mock.cc exactly to the base revision, while leaving the original failing AM RNDV test unchanged.

Purpose: determine whether the Azure failure is caused by production protocol selection or by topology/mock state leaking from the new tests into a later randomized test.

This PR is not intended for review or merge. It will be closed and the temporary branch deleted after the Azure result is captured.