### PR TITLE
UCT/CUDA: Set Blackwell RTX IPC bandwidth

### DIFF
--- a/src/uct/cuda/base/cuda_iface.h
+++ b/src/uct/cuda/base/cuda_iface.h
@@ -22,7 +22,8 @@ typedef enum uct_cuda_base_gen {
     UCT_CUDA_BASE_GEN_V100 = 7,
     UCT_CUDA_BASE_GEN_A100 = 8,
     UCT_CUDA_BASE_GEN_H100 = 9,
-    UCT_CUDA_BASE_GEN_B100 = 10
+    UCT_CUDA_BASE_GEN_B100 = 10,
+    UCT_CUDA_BASE_GEN_BRTX = 12  /* Blackwell RTX */
 } uct_cuda_base_gen_t;
 
 

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_iface.c
@@ -245,6 +245,8 @@ static double uct_cuda_ipc_iface_get_bw()
         }
 
         return 800000.0 * UCS_MBYTE;
+    case UCT_CUDA_BASE_GEN_BRTX:
+        return 50000.0 * UCS_MBYTE;
     default:
         return 6911.0  * UCS_MBYTE;
     }


### PR DESCRIPTION
## What?

Set the CUDA IPC bandwidth estimate for RTX Pro 6000 Blackwell (CUDA capability 12.0, no NVLink support) GPUs to 50GB/s (conservative PCIe 5.0 bandwidth).

## Why?

The previous fallback estimate of 6911MB/s significantly underestimated PCIe device-to-device bandwidth on Blackwell RTX GPUs. This can cause protocol selection to prefer a GPU-staging pipeline instead of CUDA IPC put zcopy, reducing observed bandwidth substantially.

Below are before and after on a g7e.12xlarge instance:

<details><summary>Before (UCX_TLS=all)</summary>

```
$ CUDA_VISIBLE_DEVICES=0 ucx_perftest -t tag_bw -m cuda -n 10 -s $((1024*1024*100)) & sleep 1; CUDA_VISIBLE_DEVICES=1 UCX_PROTO_INFO=used ucx_perftest -t tag_bw -m cuda -n 10 -s $((1024*1024*100)) localhost
Accepted connection from 127.0.0.1:39566
+--------------+--------------+------------------------------+---------------------+-----------------------+
|              |              |       overhead (usec)        |   bandwidth (MB/s)  |  message rate (msg/s) |
+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+
|    Stage     | # iterations | 50.0%ile | average | overall |  average |  overall |  average  |  overall  |
+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+
+----------------------------------------------------------------------------------------------------------+
| API:          protocol layer                                                                             |
| Test:         tag match bandwidth                                                                        |
| Data layout:  (automatic)                                                                                |
| Send memory:  cuda                                                                                       |
| Recv memory:  cuda                                                                                       |
| Message size: 104857600                                                                                  |
| Window size:  32                                                                                         |
+----------------------------------------------------------------------------------------------------------+
Final:                    10      1.279  3301.501  3301.501    30289.25   30289.25         303         303
[1788178203.525053] [ubuntu:267931:0]   +-------+--------+-------------------------------------------+-----------------+
[1788178203.525053] [ubuntu:267931:0]   | perftest intra-node cfg#1                                                    |
[1788178203.525053] [ubuntu:267931:0]   | tagged message by ucp_tag_send*(multi) from cuda/GPU0                        |
[1788178203.525053] [ubuntu:267931:0]   +-------+--------+-------------------------------------------+-----------------+
[1788178203.525053] [ubuntu:267931:0]   | Count | Range  |                Description                |     Config      |
[1788178203.525053] [ubuntu:267931:0]   +-------+--------+-------------------------------------------+-----------------+
[1788178203.525053] [ubuntu:267931:0]   |     0 |      0 | eager short                               | sysv/memory     |
[1788178203.525053] [ubuntu:267931:0]   |    41 | 1..inf | (?) rendezvous zero-copy read from remote | srd/rdmap49s0:1 |
[1788178203.525053] [ubuntu:267931:0]   +-------+--------+-------------------------------------------+-----------------+
[1788178203.525078] [ubuntu:267931:0]   +-------+--------+----------------------------+-----------------+
[1788178203.525078] [ubuntu:267931:0]   | perftest intra-node cfg#1                                     |
[1788178203.525078] [ubuntu:267931:0]   | rendezvous data fetch(multi) into cuda/GPU0 from cuda         |
[1788178203.525078] [ubuntu:267931:0]   +-------+--------+----------------------------+-----------------+
[1788178203.525078] [ubuntu:267931:0]   | Count | Range  |        Description         |     Config      |
[1788178203.525078] [ubuntu:267931:0]   +-------+--------+----------------------------+-----------------+
[1788178203.525078] [ubuntu:267931:0]   |     0 |      0 | no data fetch              |                 |
[1788178203.525078] [ubuntu:267931:0]   |     6 | 1..inf | zero-copy read from remote | srd/rdmap49s0:1 |
[1788178203.525078] [ubuntu:267931:0]   +-------+--------+----------------------------+-----------------+
```

</details>

<details><summary>Before (UCX_TLS=^srd)</summary>

```
$ CUDA_VISIBLE_DEVICES=0 ucx_perftest -t tag_bw -m cuda -n 10 -s $((1024*1024*100)) & sleep 1; CUDA_VISIBLE_DEVICES=1 UCX_TLS=^srd UCX_PROTO_INFO=used ucx_perftest -t tag_bw -m cuda -n 10 -s $((1024*1024*100)) localhost
Waiting for connection...
+--------------+--------------+------------------------------+---------------------+-----------------------+
|              |              |       overhead (usec)        |   bandwidth (MB/s)  |  message rate (msg/s) |
+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+
|    Stage     | # iterations | 50.0%ile | average | overall |  average |  overall |  average  |  overall  |
+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+
Accepted connection from 127.0.0.1:52146
+----------------------------------------------------------------------------------------------------------+
| API:          protocol layer                                                                             |
| Test:         tag match bandwidth                                                                        |
| Data layout:  (automatic)                                                                                |
| Send memory:  cuda                                                                                       |
| Recv memory:  cuda                                                                                       |
| Message size: 104857600                                                                                  |
| Window size:  32                                                                                         |
+----------------------------------------------------------------------------------------------------------+
Final:                    10      1.205 38405.323 38405.323     2603.81    2603.81          26          26
[1788178227.212199] [ubuntu:267953:0]   +-------+--------------+---------------------------------------------------------------------------------------------+---------------+
[1788178227.212199] [ubuntu:267953:0]   | perftest intra-node cfg#1                                                                                                          |
[1788178227.212199] [ubuntu:267953:0]   | tagged message by ucp_tag_send*(multi) from cuda/GPU0                                                                              |
[1788178227.212199] [ubuntu:267953:0]   +-------+--------------+---------------------------------------------------------------------------------------------+---------------+
[1788178227.212199] [ubuntu:267953:0]   | Count |    Range     |                                         Description                                         |    Config     |
[1788178227.212199] [ubuntu:267953:0]   +-------+--------------+---------------------------------------------------------------------------------------------+---------------+
[1788178227.212199] [ubuntu:267953:0]   |     0 |            0 | eager short                                                                                 | sysv/memory   |
[1788178227.212199] [ubuntu:267953:0]   |     0 |     1..22150 | (?) rendezvous cuda_copy, copy to attached, frag host, cuda_copy, frag host                 |               |
[1788178227.212199] [ubuntu:267953:0]   |     0 | 22151..82275 | (?) rendezvous zero-copy flushed write to remote                                            | cuda_ipc/cuda |
[1788178227.212199] [ubuntu:267953:0]   |     0 |  82276..512K | (?) rendezvous cuda_copy, flushed write to remote, frag host, cuda_copy, frag host          | cma/memory    |
[1788178227.212199] [ubuntu:267953:0]   |    13 |  524289..inf | (?) rendezvous pipeline cuda_copy, flushed write to remote, frag host, cuda_copy, frag host | cma/memory    |
[1788178227.212199] [ubuntu:267953:0]   +-------+--------------+---------------------------------------------------------------------------------------------+---------------+
[1788178227.212231] [ubuntu:267953:0]   +-------+-------------+-------------------------------------------------+-------------+
[1788178227.212231] [ubuntu:267953:0]   | perftest intra-node cfg#1                                                           |
[1788178227.212231] [ubuntu:267953:0]   | rendezvous data send(multi) from cuda/GPU0 to host                                  |
[1788178227.212231] [ubuntu:267953:0]   +-------+-------------+-------------------------------------------------+-------------+
[1788178227.212231] [ubuntu:267953:0]   | Count |    Range    |                   Description                   |   Config    |
[1788178227.212231] [ubuntu:267953:0]   +-------+-------------+-------------------------------------------------+-------------+
[1788178227.212231] [ubuntu:267953:0]   |     0 |           0 | fragmented copy-in copy-out                     | sysv/memory |
[1788178227.212231] [ubuntu:267953:0]   |  2600 |     1..512K | cuda_copy, copy to attached, frag host          |             |
[1788178227.212231] [ubuntu:267953:0]   |     0 | 524289..inf | pipeline cuda_copy, copy to attached, frag host |             |
[1788178227.212231] [ubuntu:267953:0]   +-------+-------------+-------------------------------------------------+-------------+
[1788178227.212253] [ubuntu:267953:0]   +-------+--------------+------------------------------------------------------------------------------+---------------+
[1788178227.212253] [ubuntu:267953:0]   | perftest intra-node cfg#1                                                                                           |
[1788178227.212253] [ubuntu:267953:0]   | rendezvous data fetch(multi) into cuda/GPU0 from cuda                                                               |
[1788178227.212253] [ubuntu:267953:0]   +-------+--------------+------------------------------------------------------------------------------+---------------+
[1788178227.212253] [ubuntu:267953:0]   | Count |    Range     |                                 Description                                  |    Config     |
[1788178227.212253] [ubuntu:267953:0]   +-------+--------------+------------------------------------------------------------------------------+---------------+
[1788178227.212253] [ubuntu:267953:0]   |     0 |            0 | no data fetch                                                                |               |
[1788178227.212253] [ubuntu:267953:0]   |     3 |     1..19234 | (?) cuda_copy, copy to attached, frag host, cuda_copy, frag host             |               |
[1788178227.212253] [ubuntu:267953:0]   |     0 | 19235..82275 | (?) zero-copy flushed write to remote                                        | cuda_ipc/cuda |
[1788178227.212253] [ubuntu:267953:0]   |     0 |  82276..512K | (?) cuda_copy, flushed write to remote, frag host, cuda_copy, frag host      | cma/memory    |
[1788178227.212253] [ubuntu:267953:0]   |     0 |  524289..inf | pipeline cuda_copy, flushed write to remote, frag host, cuda_copy, frag host | cma/memory    |
[1788178227.212253] [ubuntu:267953:0]   +-------+--------------+------------------------------------------------------------------------------+---------------+
```

</details>

<details><summary>After (UCX_MAX_RNDV_RAILS=2)</summary>

```
$ CUDA_VISIBLE_DEVICES=0 ucx_perftest -t tag_bw -m cuda -n 10 -s $((1024*1024*100)) & sleep 1; CUDA_VISIBLE_DEVICES=1 UCX_PROTO_INFO=used ucx_perftest -t tag_bw -m cuda -n 10 -s $((1024*1024*100)) localhost
Waiting for connection...
+--------------+--------------+------------------------------+---------------------+-----------------------+
|              |              |       overhead (usec)        |   bandwidth (MB/s)  |  message rate (msg/s) |
+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+
|    Stage     | # iterations | 50.0%ile | average | overall |  average |  overall |  average  |  overall  |
+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+
Accepted connection from 127.0.0.1:46164
+----------------------------------------------------------------------------------------------------------+
| API:          protocol layer                                                                             |
| Test:         tag match bandwidth                                                                        |
| Data layout:  (automatic)                                                                                |
| Send memory:  cuda                                                                                       |
| Recv memory:  cuda                                                                                       |
| Message size: 104857600                                                                                  |
| Window size:  32                                                                                         |
+----------------------------------------------------------------------------------------------------------+
Final:                    10      1.246  2457.094  2457.094    40698.48   40698.48         407         407
[1788182447.964412] [ubuntu:367184:0]   +-------+-------------+--------------------------------------------------+-------------------------------------------------+
[1788182447.964412] [ubuntu:367184:0]   | perftest intra-node cfg#1                                                                                                |
[1788182447.964412] [ubuntu:367184:0]   | tagged message by ucp_tag_send*(multi) from cuda/GPU0                                                                    |
[1788182447.964412] [ubuntu:367184:0]   +-------+-------------+--------------------------------------------------+-------------------------------------------------+
[1788182447.964412] [ubuntu:367184:0]   | Count |    Range    |                   Description                    |                     Config                      |
[1788182447.964412] [ubuntu:367184:0]   +-------+-------------+--------------------------------------------------+-------------------------------------------------+
[1788182447.964412] [ubuntu:367184:0]   |     0 |           0 | eager short                                      | sysv/memory                                     |
[1788182447.964412] [ubuntu:367184:0]   |     0 |   1..225166 | (?) rendezvous zero-copy read from remote        | srd/rdmap49s0:1                                 |
[1788182447.964412] [ubuntu:367184:0]   |    73 | 225167..inf | (?) rendezvous zero-copy flushed write to remote | 49% on srd/rdmap49s0:1 and 51% on cuda_ipc/cuda |
[1788182447.964412] [ubuntu:367184:0]   +-------+-------------+--------------------------------------------------+-------------------------------------------------+
[1788182447.964443] [ubuntu:367184:0]   +-------+-------------+---------------------------------------+-------------------------------------------------+
[1788182447.964443] [ubuntu:367184:0]   | perftest intra-node cfg#1                                                                                     |
[1788182447.964443] [ubuntu:367184:0]   | rendezvous data fetch(multi) into cuda/GPU0 from cuda                                                         |
[1788182447.964443] [ubuntu:367184:0]   +-------+-------------+---------------------------------------+-------------------------------------------------+
[1788182447.964443] [ubuntu:367184:0]   | Count |    Range    |              Description              |                     Config                      |
[1788182447.964443] [ubuntu:367184:0]   +-------+-------------+---------------------------------------+-------------------------------------------------+
[1788182447.964443] [ubuntu:367184:0]   |     0 |           0 | no data fetch                         |                                                 |
[1788182447.964443] [ubuntu:367184:0]   |     7 |   1..208606 | zero-copy read from remote            | srd/rdmap49s0:1                                 |
[1788182447.964443] [ubuntu:367184:0]   |     0 | 208607..inf | (?) zero-copy flushed write to remote | 49% on srd/rdmap49s0:1 and 51% on cuda_ipc/cuda |
[1788182447.964443] [ubuntu:367184:0]   +-------+-------------+---------------------------------------+-------------------------------------------------+
[1788182447.964461] [ubuntu:367184:0]   +-------+--------+-----------------------------------+-------------------------------------------------+
[1788182447.964461] [ubuntu:367184:0]   | perftest intra-node cfg#1                                                                            |
[1788182447.964461] [ubuntu:367184:0]   | rendezvous data send(multi) from cuda/GPU0 to cuda                                                   |
[1788182447.964461] [ubuntu:367184:0]   +-------+--------+-----------------------------------+-------------------------------------------------+
[1788182447.964461] [ubuntu:367184:0]   | Count | Range  |            Description            |                     Config                      |
[1788182447.964461] [ubuntu:367184:0]   +-------+--------+-----------------------------------+-------------------------------------------------+
[1788182447.964461] [ubuntu:367184:0]   |     0 |      0 | fragmented copy-in copy-out       | sysv/memory                                     |
[1788182447.964461] [ubuntu:367184:0]   |   146 | 1..inf | zero-copy flushed write to remote | 49% on srd/rdmap49s0:1 and 51% on cuda_ipc/cuda |
[1788182447.964461] [ubuntu:367184:0]   +-------+--------+-----------------------------------+-------------------------------------------------+
```

</details>

<details><summary>After (UCX_MAX_RNDV_RAILS=1)</summary>

```
$ CUDA_VISIBLE_DEVICES=0 ucx_perftest -t tag_bw -m cuda -n 10 -s $((1024*1024*100)) & sleep 1; CUDA_VISIBLE_DEVICES=1 UCX_PROTO_INFO=used UCX_MAX_RNDV_RAILS=1 ucx_perftest -t tag_bw -m cuda -n 10 -s $((1024*1024*100)) localhost
Waiting for connection...
+--------------+--------------+------------------------------+---------------------+-----------------------+
|              |              |       overhead (usec)        |   bandwidth (MB/s)  |  message rate (msg/s) |
+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+
|    Stage     | # iterations | 50.0%ile | average | overall |  average |  overall |  average  |  overall  |
+--------------+--------------+----------+---------+---------+----------+----------+-----------+-----------+
Accepted connection from 127.0.0.1:38586
+----------------------------------------------------------------------------------------------------------+
| API:          protocol layer                                                                             |
| Test:         tag match bandwidth                                                                        |
| Data layout:  (automatic)                                                                                |
| Send memory:  cuda                                                                                       |
| Recv memory:  cuda                                                                                       |
| Message size: 104857600                                                                                  |
| Window size:  32                                                                                         |
+----------------------------------------------------------------------------------------------------------+
Final:                    10      1.383  1880.693  1880.693    53171.88   53171.88         532         532
[1788182375.858103] [ubuntu:367158:0]   +-------+-------------+--------------------------------------------------+-----------------+
[1788182375.858103] [ubuntu:367158:0]   | perftest intra-node cfg#1                                                                |
[1788182375.858103] [ubuntu:367158:0]   | tagged message by ucp_tag_send*(multi) from cuda/GPU0                                    |
[1788182375.858103] [ubuntu:367158:0]   +-------+-------------+--------------------------------------------------+-----------------+
[1788182375.858103] [ubuntu:367158:0]   | Count |    Range    |                   Description                    |     Config      |
[1788182375.858103] [ubuntu:367158:0]   +-------+-------------+--------------------------------------------------+-----------------+
[1788182375.858103] [ubuntu:367158:0]   |     0 |           0 | eager short                                      | sysv/memory     |
[1788182375.858103] [ubuntu:367158:0]   |     0 |   1..219729 | (?) rendezvous zero-copy read from remote        | srd/rdmap49s0:1 |
[1788182375.858103] [ubuntu:367158:0]   |    73 | 219730..inf | (?) rendezvous zero-copy flushed write to remote | cuda_ipc/cuda   |
[1788182375.858103] [ubuntu:367158:0]   +-------+-------------+--------------------------------------------------+-----------------+
[1788182375.858133] [ubuntu:367158:0]   +-------+-------------+---------------------------------------+-----------------+
[1788182375.858133] [ubuntu:367158:0]   | perftest intra-node cfg#1                                                     |
[1788182375.858133] [ubuntu:367158:0]   | rendezvous data fetch(multi) into cuda/GPU0 from cuda                         |
[1788182375.858133] [ubuntu:367158:0]   +-------+-------------+---------------------------------------+-----------------+
[1788182375.858133] [ubuntu:367158:0]   | Count |    Range    |              Description              |     Config      |
[1788182375.858133] [ubuntu:367158:0]   +-------+-------------+---------------------------------------+-----------------+
[1788182375.858133] [ubuntu:367158:0]   |     0 |           0 | no data fetch                         |                 |
[1788182375.858133] [ubuntu:367158:0]   |     7 |   1..203169 | zero-copy read from remote            | srd/rdmap49s0:1 |
[1788182375.858133] [ubuntu:367158:0]   |     0 | 203170..inf | (?) zero-copy flushed write to remote | cuda_ipc/cuda   |
[1788182375.858133] [ubuntu:367158:0]   +-------+-------------+---------------------------------------+-----------------+
[1788182375.858149] [ubuntu:367158:0]   +-------+--------+-----------------------------------+---------------+
[1788182375.858149] [ubuntu:367158:0]   | perftest intra-node cfg#1                                          |
[1788182375.858149] [ubuntu:367158:0]   | rendezvous data send(multi) from cuda/GPU0 to cuda                 |
[1788182375.858149] [ubuntu:367158:0]   +-------+--------+-----------------------------------+---------------+
[1788182375.858149] [ubuntu:367158:0]   | Count | Range  |            Description            |    Config     |
[1788182375.858149] [ubuntu:367158:0]   +-------+--------+-----------------------------------+---------------+
[1788182375.858149] [ubuntu:367158:0]   |     0 |      0 | fragmented copy-in copy-out       | sysv/memory   |
[1788182375.858149] [ubuntu:367158:0]   |    73 | 1..inf | zero-copy flushed write to remote | cuda_ipc/cuda |
[1788182375.858149] [ubuntu:367158:0]   +-------+--------+-----------------------------------+---------------+
```

</details>

## How?

Identify Blackwell RTX GPUs by CUDA compute capability major version 12.