### PR TITLE
UCP/API: Endpoint parameter controlling remote key resources.

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -972,10 +972,14 @@ run_mpi_tests() {
 				# The test checks that after destroying a UCP remote key on the
 				# remote process, the local memory can be released. However, the
 				# internal caches may hold references to the memory, e.g. via
-				# opened CUDA IPC memory handle. All the caches are disabled
-				# to be able to release the memory after the remote key is
-				# destroyed.
-				${MPIRUN_COMMON} -np 2 -x UCX_MEMTYPE_CACHE=n \
+				# opened CUDA IPC memory handle. The test creates its endpoint
+				# with UCP_EP_PARAMS_FLAGS_RKEY_BOUND_LIFETIME so the CUDA IPC
+				# handle is released when the remote key is destroyed; other
+				# caches unrelated to that are disabled here so they don't
+				# interfere with the memory-release check.
+				${MPIRUN_COMMON} -np 2 \
+								-x UCX_GDR_COPY_RCACHE=n \
+								-x UCX_RCACHE_ENABLE=n \
 								./test/mpi/test_ucp_rkey_destroy
 			fi
 

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -978,7 +978,7 @@ run_mpi_tests() {
 				# caches unrelated to that are disabled here so they don't
 				# interfere with the memory-release check.
 				${MPIRUN_COMMON} -np 2 \
-								-x UCX_GDR_COPY_RCACHE=n \
+								-x UCX_TLS=^gdr_copy \
 								-x UCX_RCACHE_ENABLE=n \
 								./test/mpi/test_ucp_rkey_destroy
 			fi

--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -297,7 +297,7 @@ enum ucp_ep_params_flags_field {
                                                            send to a particular
                                                            remote endpoint, for
                                                            example stream */
-    UCP_EP_PARAMS_FLAGS_SEND_CLIENT_ID = UCS_BIT(2)   /**< Send client id
+    UCP_EP_PARAMS_FLAGS_SEND_CLIENT_ID = UCS_BIT(2), /**< Send client id
                                                            when connecting to remote
                                                            socket address as part of the
                                                            connection request payload.
@@ -305,6 +305,12 @@ enum ucp_ep_params_flags_field {
                                                            can be obtained from
                                                            @ref ucp_conn_request_h using
                                                            @ref ucp_conn_request_query */
+    /**
+     * Resources used by remote keys unpacked (see @ref ucp_ep_rkey_unpack) on
+     * this endpoint have their lifetime bound to the remote key, and are
+     * released once it is destroyed (see @ref ucp_rkey_destroy).
+     */
+    UCP_EP_PARAMS_FLAGS_RKEY_BOUND_LIFETIME = UCS_BIT(3)
 };
 
 

--- a/src/ucp/core/ucp_device.c
+++ b/src/ucp/core/ucp_device.c
@@ -250,8 +250,8 @@ static ucs_status_t ucp_device_local_mem_list_element_pack(
         return UCS_ERR_INVALID_PARAM;
     }
 
-    status = uct_md_mem_elem_pack(ucp_md->md, uct_memh, UCT_INVALID_RKEY,
-                                  mem_element, &release_handle);
+    status = uct_md_mem_elem_pack(ucp_md->md, uct_memh, NULL, mem_element,
+                                  &release_handle);
     if (status != UCS_OK) {
         ucs_error("failed to pack local mem element for memh=%p", memh);
         return status;
@@ -534,7 +534,7 @@ static ucs_status_t ucp_device_remote_mem_list_element_pack(
     ucp_ep_config_t *ep_config = ucp_ep_config(ep);
     uct_md_h md;
     uint8_t rkey_index;
-    uct_rkey_t uct_rkey;
+    uct_rkey_bundle_t *uct_rkey;
     uct_ep_h uct_ep;
     uct_device_ep_h device_ep;
     void *release_handle;
@@ -556,8 +556,8 @@ static ucs_status_t ucp_device_remote_mem_list_element_pack(
 
     rkey_index = ucs_bitmap2idx(rkey->md_map,
                                 ep_config->key.lanes[lane].dst_md_index);
-    uct_rkey   = ucp_rkey_get_tl_rkey(rkey, rkey_index);
-    ucs_assert(uct_rkey != UCT_INVALID_RKEY);
+    uct_rkey   = &rkey->tl_rkey[rkey_index].rkey;
+    ucs_assert(uct_rkey->rkey != UCT_INVALID_RKEY);
 
     md              = ucp_ep_md(ep, lane);
     mem_element->ep = device_ep;

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -274,6 +274,7 @@ static ucp_ep_h ucp_ep_allocate(ucp_worker_h worker, const char *peer_name)
     ep->ext->fence_seq                    = 0;
     ep->ext->uct_eps                      = NULL;
     ep->ext->flush_sys_dev_map            = 0;
+    ep->ext->flags                        = 0;
 
     UCS_STATIC_ASSERT(sizeof(ep->ext->ep_match) >=
                       sizeof(ep->ext->flush_state));
@@ -1283,6 +1284,10 @@ ucs_status_t ucp_ep_create(ucp_worker_h worker, const ucp_ep_params_t *params,
             ucs_snprintf_zero(ep->name, UCP_ENTITY_NAME_MAX, "%p", ep);
         }
 #endif
+
+        if (flags & UCP_EP_PARAMS_FLAGS_RKEY_BOUND_LIFETIME) {
+            ep->ext->flags |= UCP_EP_EXT_FLAG_RKEY_BOUND_LIFETIME;
+        }
 
         ucp_ep_params_check_err_handling(ep, params);
         ucp_ep_update_flags(ep, UCP_EP_FLAG_USED, 0);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -517,6 +517,11 @@ typedef struct ucp_ep_recovery_arg {
 } ucp_ep_recovery_arg_t;
 
 
+enum ucp_ep_ext_flags {
+    UCP_EP_EXT_FLAG_RKEY_BOUND_LIFETIME = UCS_BIT(0)
+};
+
+
 /**
  * Endpoint extension
  */
@@ -581,6 +586,9 @@ typedef struct ucp_ep_ext {
      * Map of system devices that require a flush operation
      */
     ucp_sys_dev_map_t             flush_sys_dev_map;
+
+    /* Flags from ucp_ep_ext_flags */
+    uint8_t flags;
 } ucp_ep_ext_t;
 
 

--- a/src/ucp/core/ucp_rkey.c
+++ b/src/ucp/core/ucp_rkey.c
@@ -976,6 +976,10 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_ep_rkey_unpack_internal,
 
     unpack_params.field_mask = UCT_RKEY_UNPACK_FIELD_SYS_DEVICE;
     unpack_params.sys_device = sys_dev;
+    if (ep->ext->flags & UCP_EP_EXT_FLAG_RKEY_BOUND_LIFETIME) {
+        unpack_params.field_mask |= UCT_RKEY_UNPACK_FIELD_FLAGS;
+        unpack_params.flags       = UCT_RKEY_UNPACK_FLAG_BOUND_LIFETIME;
+    }
 
     /* Go over remote MD indices and unpack rkey of each UCT MD */
     rkey_index = 0; /* Index of the rkey in the array */

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -765,8 +765,24 @@ typedef struct uct_rkey_compare_params {
  * @brief Rkey unpack parameters field mask.
  */
 typedef enum {
-    UCT_RKEY_UNPACK_FIELD_SYS_DEVICE = UCS_BIT(0)  /**< sys_device field */
+    UCT_RKEY_UNPACK_FIELD_SYS_DEVICE = UCS_BIT(0), /**< sys_device field */
+    UCT_RKEY_UNPACK_FIELD_FLAGS      = UCS_BIT(1)
 } uct_rkey_unpack_field_mask_t;
+
+
+/**
+ * @ingroup UCT_MD
+ * @brief Rkey unpack flags.
+ */
+typedef enum {
+    /**
+     * Indicate that resources required for accessing the unpacked remote key
+     * are created at unpack time, and their lifetime is bound to the remote
+     * key: they must be released once the key is released (see
+     * @ref uct_rkey_release).
+     */
+    UCT_RKEY_UNPACK_FLAG_BOUND_LIFETIME = UCS_BIT(0)
+} uct_rkey_unpack_flags_t;
 
 
 /**
@@ -786,6 +802,11 @@ typedef struct uct_rkey_unpack_params {
      * (default behavior).
      */
     ucs_sys_device_t     sys_device;
+
+    /**
+     * Flags to unpack rkey with, using bits from @ref uct_rkey_unpack_flags_t.
+     */
+    uint64_t             flags;
 } uct_rkey_unpack_params_t;
 
 

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1613,14 +1613,17 @@ ucs_status_t uct_rkey_unpack_v2(uct_component_h component,
  *
  * @param [in]  md                Memory domain.
  * @param [in]  memh              Memory handle to pack (can be NULL).
- * @param [in]  rkey              Remote key to pack (can be UCT_INVALID_RKEY).
+ * @param [in]  rkey_ob           Remote key bundle as returned by
+ *                                the @ref uct_rkey_unpack_v2 function
+ *                                (can be NULL).
  * @param [out] mem_elem          Filled with the packed memh and rkey.
  * @param [out] release_handle_p  Handle for releasing resources allocated
  *                                during packing.
  *
  * @return UCS_OK on success or error code in case of failure.
  */
-ucs_status_t uct_md_mem_elem_pack(uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
+ucs_status_t uct_md_mem_elem_pack(uct_md_h md, uct_mem_h memh,
+                                  const uct_rkey_bundle_t *rkey_ob,
                                   uct_device_mem_elem_t *mem_elem,
                                   void **release_handle_p);
 

--- a/src/uct/base/uct_md.c
+++ b/src/uct/base/uct_md.c
@@ -751,11 +751,15 @@ ucs_status_t uct_md_dummy_mem_dereg(uct_md_h uct_md,
     return UCS_OK;
 }
 
-ucs_status_t uct_md_mem_elem_pack(uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
+ucs_status_t uct_md_mem_elem_pack(uct_md_h md, uct_mem_h memh,
+                                  const uct_rkey_bundle_t *rkey_ob,
                                   uct_device_mem_elem_t *mem_elem,
                                   void **release_handle_p)
 {
-    return md->ops->mem_elem_pack(md, memh, rkey, mem_elem, release_handle_p);
+    uct_rkey_t rkey           = rkey_ob ? rkey_ob->rkey : UCT_INVALID_RKEY;
+    void *rkey_release_handle = rkey_ob ? rkey_ob->handle : NULL;
+    return md->ops->mem_elem_pack(md, memh, rkey, rkey_release_handle, mem_elem,
+                                  release_handle_p);
 }
 
 void uct_md_mem_elem_release(uct_md_h md, void *release_handle)

--- a/src/uct/base/uct_md.h
+++ b/src/uct/base/uct_md.h
@@ -127,7 +127,7 @@ typedef ucs_status_t (*uct_md_detect_memory_type_func_t)(uct_md_h md,
                                                          ucs_memory_type_t *mem_type_p);
 
 typedef ucs_status_t (*uct_md_mem_elem_pack_func_t)(
-        uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
+        uct_md_h md, uct_mem_h memh, uct_rkey_t rkey, void *rkey_release_handle,
         uct_device_mem_elem_t *mem_elem, void **release_handle_p);
 
 typedef void (*uct_md_mem_elem_release_func_t)(uct_md_h md,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -39,6 +39,7 @@
 typedef struct {
     const void *mapped_addr;
     CUdevice   cu_dev;
+    int        cache_enabled;
 } uct_cuda_ipc_rkey_handle_t;
 
 typedef struct {
@@ -493,7 +494,7 @@ static ucs_status_t
 uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *component,
                                 uct_cuda_ipc_unpacked_rkey_t *rkey,
                                 uct_cuda_ipc_rkey_handle_t *rkey_handle,
-                                CUdevice cu_dev)
+                                CUdevice cu_dev, int bound_lifetime)
 {
     ucs_status_t status;
     void *d_mapped;
@@ -515,8 +516,8 @@ uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *component,
      * stream sequentialization */
     rkey->stream_id = cache->dev_num;
     accessible      = &cache->accessible[cu_dev];
-    if (ucs_unlikely(*accessible == UCS_TRY)) { /* unchecked, add to cache */
-
+    if (ucs_unlikely(*accessible == UCS_TRY) || /* unchecked, add to cache */
+        (bound_lifetime && (*accessible == UCS_YES))) {
         /* Check if peer is reachable by trying to open memory handle. This is
          * necessary when the device is not visible through CUDA_VISIBLE_DEVICES
          * and checking peer accessibility through CUDA driver API is not
@@ -539,8 +540,12 @@ uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *component,
             rkey_handle->mapped_addr = d_mapped;
         }
 
-        *accessible = ((status == UCS_OK) || (status == UCS_ERR_ALREADY_EXISTS))
-                      ? UCS_YES : UCS_NO;
+        if (*accessible == UCS_TRY) {
+            *accessible = ((status == UCS_OK) ||
+                           (status == UCS_ERR_ALREADY_EXISTS)) ?
+                                  UCS_YES :
+                                  UCS_NO;
+        }
     }
 
     status = (*accessible == UCS_YES) ? UCS_OK : UCS_ERR_UNREACHABLE;
@@ -548,6 +553,13 @@ uct_cuda_ipc_is_peer_accessible(uct_cuda_ipc_component_t *component,
 err:
     pthread_mutex_unlock(&component->lock);
     return status;
+}
+
+static int
+uct_cuda_ipc_rkey_unpack_bound_lifetime(const uct_rkey_unpack_params_t *params)
+{
+    return !!(UCS_PARAM_VALUE(UCT_RKEY_UNPACK_FIELD, params, flags, FLAGS, 0) &
+              UCT_RKEY_UNPACK_FLAG_BOUND_LIFETIME);
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_rkey_unpack,
@@ -562,6 +574,7 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_rkey_unpack,
     uct_cuda_ipc_unpacked_rkey_t *unpacked;
     uct_cuda_ipc_rkey_handle_t *rkey_handle;
     ucs_sys_device_t sys_dev;
+    int bound_lifetime;
     CUdevice cuda_device;
     CUdevice avail_cuda_device;
     ucs_status_t status;
@@ -569,6 +582,8 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_rkey_unpack,
 
     sys_dev = UCS_PARAM_VALUE(UCT_RKEY_UNPACK_FIELD, params, sys_device,
                               SYS_DEVICE, UCS_SYS_DEVICE_ID_UNKNOWN);
+
+    bound_lifetime = uct_cuda_ipc_rkey_unpack_bound_lifetime(params);
 
     unpacked = ucs_malloc(sizeof(*unpacked), "uct_cuda_ipc_unpacked_rkey_t");
     if (NULL == unpacked) {
@@ -605,13 +620,16 @@ UCS_PROFILE_FUNC(ucs_status_t, uct_cuda_ipc_rkey_unpack,
     /* Check if peer is accessible, and if that check required mapping a memory
      * handle, save it in the rkey handle */
     status = uct_cuda_ipc_is_peer_accessible(com, unpacked, rkey_handle,
-                                             avail_cuda_device);
+                                             avail_cuda_device, bound_lifetime);
     if (cuda_device != avail_cuda_device) {
         uct_cuda_ctx_primary_pop_and_release(avail_cuda_device);
     }
     if (status != UCS_OK) {
         goto err_free_rkey_handle;
     }
+
+    rkey_handle->cache_enabled =
+            bound_lifetime ? 0 : uct_cuda_ipc_component.enable_remote_cache;
 
     *handle_p = rkey_handle;
     *rkey_p   = (uintptr_t) unpacked;
@@ -644,7 +662,7 @@ static void uct_cuda_ipc_rkey_release_unmap_memhandle(uct_rkey_t uct_rkey,
 
     uct_cuda_ipc_unmap_memhandle(rkey->pid, extended_rkey->pid_ns, rkey->d_bptr,
                                  rkey_handle->mapped_addr, rkey_handle->cu_dev,
-                                 uct_cuda_ipc_component.enable_remote_cache);
+                                 rkey_handle->cache_enabled);
 }
 
 static ucs_status_t uct_cuda_ipc_rkey_release(uct_component_t *component,

--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -48,6 +48,7 @@ typedef struct {
     uintptr_t    d_bptr;
     void         *mapped_addr;
     CUdevice     cu_dev;
+    int          cache_enabled;
 } uct_cuda_ipc_mem_elem_release_handle_t;
 
 static ucs_config_field_t uct_cuda_ipc_md_config_table[] = {
@@ -785,16 +786,22 @@ static void uct_cuda_ipc_md_close(uct_md_h md)
 
 static ucs_status_t
 uct_cuda_ipc_md_mem_elem_pack(uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
+                              void *rkey_release_handle,
                               uct_device_mem_elem_t *mem_elem,
                               void **release_handle_p)
 {
     uct_cuda_ipc_unpacked_rkey_t *key = (uct_cuda_ipc_unpacked_rkey_t*)rkey;
     uct_cuda_ipc_md_device_mem_element_t *cuda_ipc_md_mem_element =
             (uct_cuda_ipc_md_device_mem_element_t*)mem_elem;
+    uct_cuda_ipc_rkey_handle_t *cuda_ipc_rkey_handle = rkey_release_handle;
     uct_cuda_ipc_mem_elem_release_handle_t *release_handle;
     ucs_status_t status;
     CUdevice cuda_device;
     void *mapped_addr;
+
+    if ((rkey == UCT_INVALID_RKEY) || (rkey_release_handle == NULL)) {
+        return UCS_ERR_INVALID_PARAM;
+    }
 
     if (UCT_CUDADRV_FUNC_LOG_DEBUG(cuCtxGetDevice(&cuda_device)) != UCS_OK) {
         return UCS_ERR_UNREACHABLE;
@@ -816,12 +823,13 @@ uct_cuda_ipc_md_mem_elem_pack(uct_md_h md, uct_mem_h memh, uct_rkey_t rkey,
     cuda_ipc_md_mem_element->mapped_offset =
             UCS_PTR_BYTE_DIFF(key->super.super.d_bptr, mapped_addr);
 
-    release_handle->pid         = key->super.super.pid;
-    release_handle->pid_ns      = key->super.pid_ns;
-    release_handle->d_bptr      = key->super.super.d_bptr;
-    release_handle->mapped_addr = mapped_addr;
-    release_handle->cu_dev      = cuda_device;
-    *release_handle_p           = release_handle;
+    release_handle->pid           = key->super.super.pid;
+    release_handle->pid_ns        = key->super.pid_ns;
+    release_handle->d_bptr        = key->super.super.d_bptr;
+    release_handle->mapped_addr   = mapped_addr;
+    release_handle->cu_dev        = cuda_device;
+    release_handle->cache_enabled = cuda_ipc_rkey_handle->cache_enabled;
+    *release_handle_p             = release_handle;
 
     return UCS_OK;
 }
@@ -832,7 +840,7 @@ static void uct_cuda_ipc_md_mem_elem_release(uct_md_h md, void *release_handle)
 
     uct_cuda_ipc_unmap_memhandle(handle->pid, handle->pid_ns, handle->d_bptr,
                                  handle->mapped_addr, handle->cu_dev,
-                                 uct_cuda_ipc_component.enable_remote_cache);
+                                 handle->cache_enabled);
     ucs_free(handle);
 }
 

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -3202,7 +3202,7 @@ uct_ib_mlx5_devx_md_open(struct ibv_device *ibv_device,
 
 static ucs_status_t
 uct_ib_md_mlx5_devx_md_mem_elem_pack(uct_md_h md, uct_mem_h memh,
-                                     uct_rkey_t rkey,
+                                     uct_rkey_t rkey, void *rkey_release_handle,
                                      uct_device_mem_elem_t *mem_elem_p,
                                      void **pack_resources_p)
 {

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -126,6 +126,7 @@ uct_rocm_ipc_mem_dereg(uct_md_h md,
 
 static ucs_status_t
 uct_rocm_ipc_md_mem_elem_pack(uct_md_h md_h, uct_mem_h memh, uct_rkey_t rkey,
+                              void *rkey_handle,
                               uct_device_mem_elem_t *mem_elem_p,
                               void **release_handle_p)
 {

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -50,7 +50,7 @@ UCS_TEST_F(test_obj_size, size) {
     UCS_TEST_SKIP_R("Assert enabled");
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
-    EXPECTED_SIZE(ucp_ep_ext_t, 216);
+    EXPECTED_SIZE(ucp_ep_ext_t, 224);
 #if ENABLE_PARAMS_CHECK
     EXPECTED_SIZE(ucp_rkey_t, 24 + sizeof(ucp_ep_h));
 #else

--- a/test/gtest/uct/cuda/test_cuda_ipc_device.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_device.cc
@@ -193,7 +193,7 @@ UCS_TEST_P(test_cuda_ipc_rma, get_mem_elem_pack)
     uct_device_mem_elem_t mem_elem_host;
     void *release_handle;
     EXPECT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
-                                       recvbuf.rkey(), &mem_elem_host,
+                                       recvbuf.rkey_bundle(), &mem_elem_host,
                                        &release_handle));
     uct_md_mem_elem_release(m_sender->md(), release_handle);
 }
@@ -228,7 +228,7 @@ UCS_TEST_P(test_cuda_ipc_rma_device, put_device)
     uct_device_mem_elem_t src_elem_host;
     void *release_handle;
     ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
-                                       recvbuf.rkey(), &src_elem_host,
+                                       recvbuf.rkey_bundle(), &src_elem_host,
                                        &release_handle));
 
 
@@ -281,8 +281,9 @@ UCS_TEST_P(test_cuda_ipc_rma_device, atomic_add_device)
     uct_device_mem_elem_t mem_elem_host;
     void *release_handle;
     ASSERT_EQ(CUDA_SUCCESS, cuMemAlloc((CUdeviceptr*)&mem_elem, mem_elem_size));
-    ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), nullptr, signal.rkey(),
-                                       &mem_elem_host, &release_handle));
+    ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), nullptr,
+                                       signal.rkey_bundle(), &mem_elem_host,
+                                       &release_handle));
     ASSERT_EQ(CUDA_SUCCESS, cuMemcpyHtoD((CUdeviceptr)mem_elem, &mem_elem_host,
                                          mem_elem_size));
 

--- a/test/gtest/uct/rocm/test_rocm_ipc_device.hip
+++ b/test/gtest/uct/rocm/test_rocm_ipc_device.hip
@@ -184,7 +184,7 @@ UCS_TEST_P(test_rocm_ipc_rma, get_mem_elem_pack)
     ASSERT_NE(nullptr, mem_elem);
     void *release_handle;
     EXPECT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
-                                       recvbuf.rkey(), mem_elem,
+                                       recvbuf.rkey_bundle(), mem_elem,
                                        &release_handle));
     uct_md_mem_elem_release(m_sender->md(), release_handle);
     free(mem_elem);
@@ -223,7 +223,7 @@ UCS_TEST_P(test_rocm_ipc_rma_device, device_put)
             src_elem_host = {};
     void *release_handle;
     ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
-                                       recvbuf.rkey(),
+                                       recvbuf.rkey_bundle(),
                                        &src_elem_host.tl, &release_handle));
 
     uct_device_local_mem_elem_t *src_elem;

--- a/test/gtest/uct/test_device.cc
+++ b/test/gtest/uct/test_device.cc
@@ -157,7 +157,7 @@ UCS_TEST_P(test_device, put)
     uct_device_mem_elem_t src_elem_host;
     void *release_handle;
     ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), sendbuf.memh(),
-                                       recvbuf.rkey(), &src_elem_host,
+                                       recvbuf.rkey_bundle(), &src_elem_host,
                                        &release_handle));
 
     mapped_buffer src_elembuf(sizeof(src_elem_host), 0, *m_sender, 0,
@@ -203,8 +203,9 @@ UCS_TEST_P(test_device, atomic)
                                                    elembuf_host.ptr();
     uct_device_mem_elem_t *mem_elem = (uct_device_mem_elem_t*)elembuf.ptr();
     void *release_handle;
-    ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), nullptr, signal.rkey(),
-                                       mem_elem_host, &release_handle));
+    ASSERT_UCS_OK(uct_md_mem_elem_pack(m_sender->md(), nullptr,
+                                       signal.rkey_bundle(), mem_elem_host,
+                                       &release_handle));
     ASSERT_EQ(CUDA_SUCCESS, cuMemcpyHtoD((CUdeviceptr)mem_elem, mem_elem_host,
                                          sizeof(uct_device_mem_elem_t)));
 

--- a/test/gtest/uct/uct_test.cc
+++ b/test/gtest/uct/uct_test.cc
@@ -1558,6 +1558,11 @@ void *uct_test::mapped_buffer::reg_addr() const
     return m_mem.address;
 }
 
+const uct_rkey_bundle_t *uct_test::mapped_buffer::rkey_bundle() const
+{
+    return &m_rkey;
+}
+
 uct_rkey_t uct_test::mapped_buffer::rkey() const {
     return m_rkey.rkey;
 }

--- a/test/gtest/uct/uct_test.h
+++ b/test/gtest/uct/uct_test.h
@@ -267,6 +267,7 @@ protected:
         uct_mem_h memh() const;
         ucs_memory_type_t mem_type() const;
         void *reg_addr() const;
+        const uct_rkey_bundle_t *rkey_bundle() const;
         uct_rkey_t rkey() const;
         const uct_iov_t* iov() const;
 

--- a/test/mpi/test_rma_cuda.c
+++ b/test/mpi/test_rma_cuda.c
@@ -167,7 +167,7 @@ int main(int argc, char **argv)
         return -1;
     }
 
-    xfer_args.ucp = create_ucp(0);
+    xfer_args.ucp = create_ucp(UCP_FEATURE_RMA, 0);
 
     for (operation_idx = 0; operation_idx < ucs_static_array_size(operations);
          ++operation_idx) {

--- a/test/mpi/test_rma_cuda.c
+++ b/test/mpi/test_rma_cuda.c
@@ -167,7 +167,7 @@ int main(int argc, char **argv)
         return -1;
     }
 
-    xfer_args.ucp = create_ucp();
+    xfer_args.ucp = create_ucp(0);
 
     for (operation_idx = 0; operation_idx < ucs_static_array_size(operations);
          ++operation_idx) {

--- a/test/mpi/test_ucp.c
+++ b/test/mpi/test_ucp.c
@@ -77,7 +77,7 @@ static void *recv_worker_address(int sender_rank)
     return worker_address;
 }
 
-static ucp_ep_h create_ucp_ep(ucp_worker_h worker)
+static ucp_ep_h create_ucp_ep(ucp_worker_h worker, unsigned ep_flags)
 {
     int rank;
     void *worker_address;
@@ -93,8 +93,10 @@ static ucp_ep_h create_ucp_ep(ucp_worker_h worker)
         send_worker_address(0, worker);
     }
 
-    ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
+    ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS |
+                           UCP_EP_PARAM_FIELD_FLAGS;
     ep_params.address    = (ucp_address_t*)worker_address;
+    ep_params.flags      = ep_flags;
 
     UCX_CHECK(ucp_ep_create(worker, &ep_params, &ep));
     free(worker_address);
@@ -124,12 +126,12 @@ create_ucp_mem(void *buffer, size_t size, ucp_context_h context)
     return mem;
 }
 
-ucp_t create_ucp()
+ucp_t create_ucp(unsigned ep_flags)
 {
     ucp_t ucp;
     ucp.context = create_ucp_context();
     ucp.worker  = create_ucp_worker(ucp.context);
-    ucp.ep      = create_ucp_ep(ucp.worker);
+    ucp.ep      = create_ucp_ep(ucp.worker, ep_flags);
     return ucp;
 }
 

--- a/test/mpi/test_ucp.c
+++ b/test/mpi/test_ucp.c
@@ -11,14 +11,14 @@
 
 #include <mpi.h>
 
-static ucp_context_h create_ucp_context()
+static ucp_context_h create_ucp_context(uint64_t features)
 {
     ucp_params_t params;
     ucp_config_t *config;
     ucp_context_h context;
 
     params.field_mask = UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_NAME;
-    params.features   = UCP_FEATURE_RMA | UCP_FEATURE_WAKEUP;
+    params.features   = features;
     params.name       = "test_context";
     UCX_CHECK(ucp_config_read(NULL, NULL, &config));
     UCX_CHECK(ucp_init(&params, config, &context));
@@ -126,10 +126,10 @@ create_ucp_mem(void *buffer, size_t size, ucp_context_h context)
     return mem;
 }
 
-ucp_t create_ucp(unsigned ep_flags)
+ucp_t create_ucp(uint64_t features, unsigned ep_flags)
 {
     ucp_t ucp;
-    ucp.context = create_ucp_context();
+    ucp.context = create_ucp_context(features);
     ucp.worker  = create_ucp_worker(ucp.context);
     ucp.ep      = create_ucp_ep(ucp.worker, ep_flags);
     return ucp;

--- a/test/mpi/test_ucp.h
+++ b/test/mpi/test_ucp.h
@@ -22,7 +22,7 @@ typedef struct {
 } rkey_t;
 
 
-ucp_t create_ucp(unsigned ep_flags);
+ucp_t create_ucp(uint64_t features, unsigned ep_flags);
 
 
 void destroy_ucp(ucp_t);

--- a/test/mpi/test_ucp.h
+++ b/test/mpi/test_ucp.h
@@ -22,7 +22,7 @@ typedef struct {
 } rkey_t;
 
 
-ucp_t create_ucp();
+ucp_t create_ucp(unsigned ep_flags);
 
 
 void destroy_ucp(ucp_t);

--- a/test/mpi/test_ucp_rkey_destroy.c
+++ b/test/mpi/test_ucp_rkey_destroy.c
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
     CUDA_CHECK(cuDevicePrimaryCtxRetain(&cu_ctx, cu_dev));
     CUDA_CHECK(cuCtxSetCurrent(cu_ctx));
 
-    ucp = create_ucp();
+    ucp = create_ucp(UCP_EP_PARAMS_FLAGS_RKEY_BOUND_LIFETIME);
 
     if (rank == 0) {
         exit_status = rank0(ucp.context);

--- a/test/mpi/test_ucp_rkey_destroy.c
+++ b/test/mpi/test_ucp_rkey_destroy.c
@@ -13,6 +13,8 @@
 #include "test_ucp.h"
 #include "test_ucx_check_def.h"
 
+#include <ucp/api/device/ucp_host.h>
+
 #include <cuda.h>
 #include <mpi.h>
 
@@ -23,7 +25,64 @@
 #define MPI_COMM_SIZE 2
 #define SIZE          (1024 * 1024 * 1024)
 
-static int rank0(ucp_context_h ucp_context)
+static void mpi_barrier(void)
+{
+    MPI_Request request;
+
+    MPI_Ibarrier(MPI_COMM_WORLD, &request);
+    MPI_Wait(&request, MPI_STATUS_IGNORE);
+}
+
+/* Progress the worker while waiting, to serve the peer's wireup messages */
+static void mpi_barrier_progress(ucp_worker_h worker)
+{
+    int done = 0;
+    MPI_Request request;
+
+    MPI_Ibarrier(MPI_COMM_WORLD, &request);
+    while (!done) {
+        ucp_worker_progress(worker);
+        MPI_Test(&request, &done, MPI_STATUS_IGNORE);
+    }
+}
+
+static ucp_device_remote_mem_list_h
+create_remote_mem_list(ucp_worker_h worker, ucp_ep_h ep, rkey_t rkey)
+{
+    ucp_device_mem_list_elem_t elem;
+    ucp_device_mem_list_params_t params;
+    ucp_device_remote_mem_list_h mem_list_h;
+    ucs_status_t status;
+
+    elem.field_mask  = UCP_DEVICE_MEM_LIST_ELEM_FIELD_EP |
+                       UCP_DEVICE_MEM_LIST_ELEM_FIELD_REMOTE_ADDR |
+                       UCP_DEVICE_MEM_LIST_ELEM_FIELD_RKEY;
+    elem.ep          = ep;
+    elem.remote_addr = rkey.remote_address;
+    elem.rkey        = rkey.rkey;
+
+    params.field_mask   = UCP_DEVICE_MEM_LIST_PARAMS_FIELD_ELEMENTS |
+                          UCP_DEVICE_MEM_LIST_PARAMS_FIELD_ELEMENT_SIZE |
+                          UCP_DEVICE_MEM_LIST_PARAMS_FIELD_NUM_ELEMENTS;
+    params.element_size = sizeof(elem);
+    params.num_elements = 1;
+    params.elements     = &elem;
+
+    do {
+        ucp_worker_progress(worker);
+        status = ucp_device_remote_mem_list_create(&params, &mem_list_h);
+    } while (status == UCS_ERR_NOT_CONNECTED);
+
+    if (status != UCS_OK) {
+        fprintf(stderr, "ucp_device_remote_mem_list_create failed: %s\n",
+                ucs_status_string(status));
+        exit(status);
+    }
+
+    return mem_list_h;
+}
+
+static int rank0(ucp_t ucp)
 {
     CUdeviceptr ptr;
     ucp_mem_h ucp_mem;
@@ -32,11 +91,11 @@ static int rank0(ucp_context_h ucp_context)
     CUDA_CHECK(cuMemGetInfo(&free_bytes_before, &total_bytes));
     CUDA_CHECK(cuMemAlloc(&ptr, SIZE));
 
-    ucp_mem = send_rkey(1, (void*)ptr, SIZE, ucp_context);
+    ucp_mem = send_rkey(1, (void*)ptr, SIZE, ucp.context);
 
-    MPI_Barrier(MPI_COMM_WORLD);
+    mpi_barrier_progress(ucp.worker);
 
-    UCX_CHECK(ucp_mem_unmap(ucp_context, ucp_mem));
+    UCX_CHECK(ucp_mem_unmap(ucp.context, ucp_mem));
     CUDA_CHECK(cuMemFree(ptr));
     CUDA_CHECK(cuCtxSynchronize());
 
@@ -47,17 +106,21 @@ static int rank0(ucp_context_h ucp_context)
     return (unreleased_memory == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
-static void rank1(ucp_ep_h ucp_ep)
+static void rank1(ucp_t ucp)
 {
     rkey_t rkey;
+    ucp_device_remote_mem_list_h remote_mem_list;
     void *ptr;
 
-    rkey = recv_rkey(0, ucp_ep);
+    rkey            = recv_rkey(0, ucp.ep);
+    remote_mem_list = create_remote_mem_list(ucp.worker, ucp.ep, rkey);
 
     UCX_CHECK(ucp_rkey_ptr(rkey.rkey, rkey.remote_address, &ptr));
+
+    ucp_device_mem_list_release(remote_mem_list);
     ucp_rkey_destroy(rkey.rkey);
 
-    MPI_Barrier(MPI_COMM_WORLD);
+    mpi_barrier();
 }
 
 int main(int argc, char **argv)
@@ -88,12 +151,13 @@ int main(int argc, char **argv)
     CUDA_CHECK(cuDevicePrimaryCtxRetain(&cu_ctx, cu_dev));
     CUDA_CHECK(cuCtxSetCurrent(cu_ctx));
 
-    ucp = create_ucp(UCP_EP_PARAMS_FLAGS_RKEY_BOUND_LIFETIME);
+    ucp = create_ucp(UCP_FEATURE_RMA | UCP_FEATURE_DEVICE,
+                     UCP_EP_PARAMS_FLAGS_RKEY_BOUND_LIFETIME);
 
     if (rank == 0) {
-        exit_status = rank0(ucp.context);
+        exit_status = rank0(ucp);
     } else {
-        rank1(ucp.ep);
+        rank1(ucp);
     }
 
     MPI_Bcast(&exit_status, 1, MPI_INT, 0, MPI_COMM_WORLD);


### PR DESCRIPTION
## What?
Added a new UCP endpoint creation parameter. This parameter allows to manage the lifetime of resources used to work with a UCP remote key.
Added a new UCT remote key unpacking parameter. This parameter allows to manage the lifetime of resources used to work with the remote key.

## Why?
This is another attempt to solve the problem of unclosed interprocessor memory descriptors that prevent the memory from being released by the remote side.

https://github.com/openucx/ucx/pull/11335
https://github.com/openucx/ucx/pull/11288
https://github.com/openucx/ucx/pull/11730

At the moment the only way to close the handles is to disable UCT CUDA IPC remote cache. So behavior can only be controlled at the level of the whole process. The new parameters adds the possibility of more detailed control over the lifetime of objects.