### PR TITLE
[DNM] UCT/IB/MLX5: wqe parser for uct am zcopy

### DIFF
--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -858,6 +858,11 @@ void *uct_ib_mlx5_txwq_get_wqe(const uct_ib_mlx5_txwq_t *txwq, uint16_t pi)
     return UCS_PTR_BYTE_OFFSET(txwq->qstart, (pi % num_bb) * MLX5_SEND_WQE_BB);
 }
 
+uint8_t uct_ib_mlx5_wqe_opcode(const struct mlx5_wqe_ctrl_seg *ctrl)
+{
+    return ctrl->opmod_idx_opcode >> 24;
+}
+
 uint16_t uct_ib_mlx5_txwq_num_posted_wqes(const uct_ib_mlx5_txwq_t *txwq,
                                           uint16_t outstanding)
 {

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -863,6 +863,18 @@ uint8_t uct_ib_mlx5_wqe_opcode(const struct mlx5_wqe_ctrl_seg *ctrl)
     return ctrl->opmod_idx_opcode >> 24;
 }
 
+void uct_ib_mlx5_txwq_copy_segs(const uct_ib_mlx5_txwq_t *txwq, void *dst,
+                                const void *src, size_t length)
+{
+    size_t copy_len = ucs_min(length, UCS_PTR_BYTE_DIFF(src, txwq->qend));
+
+    memcpy(dst, src, copy_len);
+    if (copy_len < length) {
+        memcpy(UCS_PTR_BYTE_OFFSET(dst, copy_len), txwq->qstart,
+               length - copy_len);
+    }
+}
+
 uint16_t uct_ib_mlx5_txwq_num_posted_wqes(const uct_ib_mlx5_txwq_t *txwq,
                                           uint16_t outstanding)
 {

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -866,8 +866,12 @@ uint8_t uct_ib_mlx5_wqe_opcode(const struct mlx5_wqe_ctrl_seg *ctrl)
 void uct_ib_mlx5_txwq_copy_segs(const uct_ib_mlx5_txwq_t *txwq, void *dst,
                                 const void *src, size_t length)
 {
-    size_t copy_len = ucs_min(length, UCS_PTR_BYTE_DIFF(src, txwq->qend));
+    size_t copy_len;
 
+    ucs_assertv((src >= txwq->qstart) && (src < txwq->qend),
+                "src=%p qstart=%p qend=%p", src, txwq->qstart, txwq->qend);
+
+    copy_len = ucs_min(length, UCS_PTR_BYTE_DIFF(src, txwq->qend));
     memcpy(dst, src, copy_len);
     if (copy_len < length) {
         memcpy(UCS_PTR_BYTE_OFFSET(dst, copy_len), txwq->qstart,

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -917,6 +917,8 @@ ucs_status_t uct_ib_mlx5_txwq_init(uct_priv_worker_t *worker,
 /* Get pointer to a WQE by producer index */
 void *uct_ib_mlx5_txwq_get_wqe(const uct_ib_mlx5_txwq_t *txwq, uint16_t pi);
 
+uint8_t uct_ib_mlx5_wqe_opcode(const struct mlx5_wqe_ctrl_seg *ctrl);
+
 /* Count how many WQEs are currently posted */
 uint16_t uct_ib_mlx5_txwq_num_posted_wqes(const uct_ib_mlx5_txwq_t *txwq,
                                           uint16_t outstanding);

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -919,6 +919,10 @@ void *uct_ib_mlx5_txwq_get_wqe(const uct_ib_mlx5_txwq_t *txwq, uint16_t pi);
 
 uint8_t uct_ib_mlx5_wqe_opcode(const struct mlx5_wqe_ctrl_seg *ctrl);
 
+/* Copy length bytes out of the WQ starting at src, wrapping around at qend */
+void uct_ib_mlx5_txwq_copy_segs(const uct_ib_mlx5_txwq_t *txwq, void *dst,
+                                const void *src, size_t length);
+
 /* Count how many WQEs are currently posted */
 uint16_t uct_ib_mlx5_txwq_num_posted_wqes(const uct_ib_mlx5_txwq_t *txwq,
                                           uint16_t outstanding);

--- a/src/uct/ib/mlx5/ib_mlx5.inl
+++ b/src/uct/ib/mlx5/ib_mlx5.inl
@@ -283,14 +283,23 @@ uct_ib_mlx5_inline_iov_copy(void *restrict dest, const uct_iov_t *iov,
 }
 
 
-/* wrapping of 'seg' should not happen */
-static UCS_F_ALWAYS_INLINE void*
-uct_ib_mlx5_txwq_wrap_none(uct_ib_mlx5_txwq_t *txwq, void *seg)
+/* Const-safe version of uct_ib_mlx5_txwq_wrap_none() */
+static UCS_F_ALWAYS_INLINE const void *
+uct_ib_mlx5_txwq_wrap_none_const(const uct_ib_mlx5_txwq_t *txwq,
+                                 const void *seg)
 {
     ucs_assertv(((unsigned long)seg % UCT_IB_MLX5_WQE_SEG_SIZE) == 0, "seg=%p", seg);
     ucs_assertv(seg >= txwq->qstart, "seg=%p qstart=%p", seg, txwq->qstart);
     ucs_assertv(seg <  txwq->qend,   "seg=%p qend=%p",   seg, txwq->qend);
     return seg;
+}
+
+
+/* wrapping of 'seg' should not happen */
+static UCS_F_ALWAYS_INLINE void*
+uct_ib_mlx5_txwq_wrap_none(uct_ib_mlx5_txwq_t *txwq, void *seg)
+{
+    return (void*)uct_ib_mlx5_txwq_wrap_none_const(txwq, seg);
 }
 
 
@@ -306,15 +315,23 @@ uct_ib_mlx5_txwq_wrap_exact(uct_ib_mlx5_txwq_t *txwq, void *seg)
 }
 
 
-/* wrapping of 'seg' could happen, even past 'qend' boundary */
-static UCS_F_ALWAYS_INLINE void *
-uct_ib_mlx5_txwq_wrap_any(uct_ib_mlx5_txwq_t *txwq, void *seg)
+/* Const-safe version of uct_ib_mlx5_txwq_wrap_any() */
+static UCS_F_ALWAYS_INLINE const void *
+uct_ib_mlx5_txwq_wrap_any_const(const uct_ib_mlx5_txwq_t *txwq, const void *seg)
 {
     if (ucs_unlikely(seg >= txwq->qend)) {
         seg = UCS_PTR_BYTE_OFFSET(seg, -UCS_PTR_BYTE_DIFF(txwq->qstart,
                                                           txwq->qend));
     }
-    return uct_ib_mlx5_txwq_wrap_none(txwq, seg);
+    return uct_ib_mlx5_txwq_wrap_none_const(txwq, seg);
+}
+
+
+/* wrapping of 'seg' could happen, even past 'qend' boundary */
+static UCS_F_ALWAYS_INLINE void *
+uct_ib_mlx5_txwq_wrap_any(uct_ib_mlx5_txwq_t *txwq, void *seg)
+{
+    return (void*)uct_ib_mlx5_txwq_wrap_any_const(txwq, seg);
 }
 
 

--- a/src/uct/ib/mlx5/ib_mlx5_log.c
+++ b/src/uct/ib/mlx5/ib_mlx5_log.c
@@ -305,7 +305,7 @@ static void uct_ib_mlx5_wqe_dump(uct_ib_iface_t *iface, void *wqe, void *qstart,
     };
 
     struct mlx5_wqe_ctrl_seg *ctrl = wqe;
-    uint8_t opcode                 = ctrl->opmod_idx_opcode >> 24;
+    uint8_t opcode                 = uct_ib_mlx5_wqe_opcode(ctrl);
     uint8_t opmod                  = ctrl->opmod_idx_opcode & 0xff;
     uint32_t qp_num                = ntohl(ctrl->qpn_ds) >> 8;
     int ds                         = ctrl->qpn_ds >> 24;

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -131,6 +131,79 @@ static ucs_status_t uct_rc_mlx5_op_info_fill_put(
               ucs_debug_get_symbol_name((void*)op->handler));
 }
 
+static void uct_rc_mlx5_op_info_fill_am_zcopy(
+        uct_ep_op_info_t *info, const uct_ib_mlx5_txwq_t *txwq,
+        uct_rc_iface_send_op_t *op, const struct mlx5_wqe_inl_data_seg *inl,
+        size_t inline_length, const struct mlx5_wqe_data_seg *dptr,
+        size_t iovcnt, uct_rc_mlx5_op_callback_data_t *callback_data)
+{
+    const uct_rc_mlx5_hdr_t *rch;
+
+    info->field_mask = UCT_EP_OP_INFO_FIELD_OPERATION | UCT_EP_OP_INFO_FIELD_AM;
+    info->operation  = UCT_EP_OP_AM_ZCOPY;
+
+    uct_ib_mlx5_txwq_copy_segs(txwq, callback_data->data, inl + 1,
+                               inline_length);
+    rch = (const uct_rc_mlx5_hdr_t*)callback_data->data;
+
+    info->am.field_mask         |= UCT_EP_OP_INFO_AM_FIELD_AM_ID |
+                                   UCT_EP_OP_INFO_AM_FIELD_FLAGS |
+                                   UCT_EP_OP_INFO_AM_FIELD_HEADER_ZCOPY;
+    info->am.am_id               = rch->rc_hdr.am_id & ~UCT_RC_EP_FC_MASK;
+    info->am.flags               = 0;
+    info->am.header.zcopy.buffer = rch + 1;
+    info->am.header.zcopy.length = inline_length - sizeof(*rch);
+
+    uct_rc_mlx5_callback_data_fill_iov(callback_data, txwq, dptr, iovcnt);
+
+    info->am.field_mask          |= UCT_EP_OP_INFO_AM_FIELD_PAYLOAD_ZCOPY;
+    info->am.payload.zcopy.iov    = callback_data->iov;
+    info->am.payload.zcopy.iovcnt = iovcnt;
+
+    uct_rc_mlx5_op_info_fill_user_comp(info, op);
+}
+
+static ucs_status_t uct_rc_mlx5_op_info_fill_am_send(
+        uct_ep_op_info_t *info, const uct_ib_mlx5_txwq_t *txwq,
+        uct_rc_iface_send_op_t *op, const struct mlx5_wqe_ctrl_seg *ctrl,
+        size_t wqe_size, uct_rc_mlx5_op_callback_data_t *callback_data)
+{
+    const struct mlx5_wqe_inl_data_seg *inl;
+    const struct mlx5_wqe_data_seg *dptr;
+    size_t inline_length, inline_seg_size, iovcnt;
+
+    ucs_assert(wqe_size >= (sizeof(*ctrl) + sizeof(*inl)));
+    ucs_assert(wqe_size <= UCT_IB_MLX5_MAX_SEND_WQE_SIZE);
+
+    inl = uct_ib_mlx5_txwq_wrap_any_const(txwq, (ctrl + 1));
+    if (!(inl->byte_count & htonl(MLX5_INLINE_SEG))) {
+        ucs_fatal("unsupported am send with non-inline data");
+    }
+
+    inline_length   = ntohl(inl->byte_count) & ~MLX5_INLINE_SEG;
+    inline_seg_size = ucs_align_up_pow2(sizeof(*inl) + inline_length,
+                                        UCT_IB_MLX5_WQE_SEG_SIZE);
+    ucs_assert(inline_length >= sizeof(uct_rc_mlx5_hdr_t));
+    ucs_assert(inline_length <= sizeof(callback_data->data));
+    ucs_assert(wqe_size >= (sizeof(*ctrl) + inline_seg_size));
+
+    if ((op != NULL) && (op->handler != uct_rc_ep_send_op_completion_handler)) {
+        ucs_fatal("unsupported am send op %p handler %p", op,
+                  (void*)op->handler);
+    }
+
+    if ((op == NULL) && (wqe_size == (sizeof(*ctrl) + inline_seg_size))) {
+        ucs_fatal("unsupported am short send");
+    }
+
+    dptr   = uct_ib_mlx5_txwq_wrap_any_const(
+            txwq, UCS_PTR_BYTE_OFFSET((void*)inl, inline_seg_size));
+    iovcnt = (wqe_size - sizeof(*ctrl) - inline_seg_size) / sizeof(*dptr);
+    uct_rc_mlx5_op_info_fill_am_zcopy(info, txwq, op, inl, inline_length, dptr,
+                                      iovcnt, callback_data);
+    return UCS_OK;
+}
+
 ucs_status_t
 uct_rc_mlx5_op_info_fill(uct_ep_op_info_t *info, const uct_ib_mlx5_txwq_t *txwq,
                          uct_rc_iface_send_op_t *op,
@@ -145,6 +218,9 @@ uct_rc_mlx5_op_info_fill(uct_ep_op_info_t *info, const uct_ib_mlx5_txwq_t *txwq,
     case MLX5_OPCODE_RDMA_WRITE:
         return uct_rc_mlx5_op_info_fill_put(info, txwq, op, ctrl, wqe_size,
                                             callback_data);
+    case MLX5_OPCODE_SEND:
+        return uct_rc_mlx5_op_info_fill_am_send(info, txwq, op, ctrl, wqe_size,
+                                                callback_data);
     default:
         ucs_fatal("unsupported op %d", opcode);
     }

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -197,7 +197,7 @@ static ucs_status_t uct_rc_mlx5_op_info_fill_am_send(
     }
 
     dptr   = uct_ib_mlx5_txwq_wrap_any_const(
-            txwq, UCS_PTR_BYTE_OFFSET((void*)inl, inline_seg_size));
+            txwq, UCS_PTR_BYTE_OFFSET(inl, inline_seg_size));
     iovcnt = (wqe_size - sizeof(*ctrl) - inline_seg_size) / sizeof(*dptr);
     uct_rc_mlx5_op_info_fill_am_zcopy(info, txwq, op, inl, inline_length, dptr,
                                       iovcnt, callback_data);

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -188,8 +188,8 @@ static ucs_status_t uct_rc_mlx5_op_info_fill_am_send(
     ucs_assert(wqe_size >= (sizeof(*ctrl) + inline_seg_size));
 
     if ((op != NULL) && (op->handler != uct_rc_ep_send_op_completion_handler)) {
-        ucs_fatal("unsupported am send op %p handler %p", op,
-                  (void*)op->handler);
+        ucs_fatal("unsupported am send op %p handler %s", op,
+                  ucs_debug_get_symbol_name((void*)op->handler));
     }
 
     if ((op == NULL) && (wqe_size == (sizeof(*ctrl) + inline_seg_size))) {

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.c
@@ -16,6 +16,140 @@
 #include <ucs/arch/bitops.h>
 #include <ucs/profile/profile.h>
 
+static void uct_rc_mlx5_op_info_fill_user_comp(uct_ep_op_info_t *info,
+                                               uct_rc_iface_send_op_t *op)
+{
+    if ((op == NULL) || (op->user_comp == NULL)) {
+        return;
+    }
+
+    info->field_mask |= UCT_EP_OP_INFO_FIELD_COMP;
+    info->comp        = op->user_comp;
+}
+
+static void
+uct_rc_mlx5_op_info_fill_rma_raddr(uct_ep_op_info_t *info,
+                                   const struct mlx5_wqe_raddr_seg *raddr)
+{
+    ucs_assert(info->field_mask & UCT_EP_OP_INFO_FIELD_RMA);
+
+    info->rma.field_mask |= UCT_EP_OP_INFO_RMA_FIELD_REMOTE_ADDR |
+                            UCT_EP_OP_INFO_RMA_FIELD_RKEY;
+    info->rma.remote_addr = be64toh(raddr->raddr);
+    uct_ib_md_pack_rkey(ntohl(raddr->rkey), UCT_IB_INVALID_MKEY,
+                        &info->rma.rkey);
+}
+
+static void uct_rc_mlx5_op_info_fill_rma_zcopy_iov(uct_ep_op_info_t *info,
+                                                   const uct_iov_t *iov,
+                                                   size_t iovcnt)
+{
+    ucs_assert(info->field_mask & UCT_EP_OP_INFO_FIELD_RMA);
+
+    info->rma.field_mask          |= UCT_EP_OP_INFO_RMA_FIELD_PAYLOAD_ZCOPY;
+    info->rma.payload.zcopy.iov    = iov;
+    info->rma.payload.zcopy.iovcnt = iovcnt;
+}
+
+static void uct_rc_mlx5_callback_data_fill_iov(
+        uct_rc_mlx5_op_callback_data_t *callback_data,
+        const uct_ib_mlx5_txwq_t *txwq, const struct mlx5_wqe_data_seg *dptr,
+        size_t iovcnt)
+{
+    uint32_t byte_count;
+    size_t i;
+
+    ucs_assert(iovcnt <= ucs_static_array_size(callback_data->iov));
+
+    for (i = 0; i < iovcnt; ++i) {
+        byte_count = ntohl(dptr->byte_count);
+        ucs_assertv_always(!(byte_count & MLX5_INLINE_SEG),
+                           "put_short is not supported yet");
+
+        callback_data->memh[i].lkey  = ntohl(dptr->lkey);
+        callback_data->memh[i].rkey  = UCT_IB_INVALID_MKEY;
+        callback_data->memh[i].flags = 0;
+        callback_data->iov[i].buffer = (void*)(uintptr_t)be64toh(dptr->addr);
+        callback_data->iov[i].length = byte_count;
+        callback_data->iov[i].memh   = &callback_data->memh[i];
+        callback_data->iov[i].stride = 0;
+        callback_data->iov[i].count  = 1;
+
+        dptr = uct_ib_mlx5_txwq_wrap_any_const(txwq, (dptr + 1));
+    }
+}
+
+static void uct_rc_mlx5_op_info_fill_put_zcopy(
+        uct_ep_op_info_t *info, const uct_ib_mlx5_txwq_t *txwq,
+        uct_rc_iface_send_op_t *op, const struct mlx5_wqe_raddr_seg *raddr,
+        size_t seg_size, uct_rc_mlx5_op_callback_data_t *callback_data)
+{
+    const struct mlx5_wqe_data_seg *dptr;
+    size_t iovcnt;
+
+    info->field_mask |= UCT_EP_OP_INFO_FIELD_OPERATION |
+                        UCT_EP_OP_INFO_FIELD_RMA;
+    info->operation   = UCT_EP_OP_PUT_ZCOPY;
+
+    uct_rc_mlx5_op_info_fill_rma_raddr(info, raddr);
+    uct_rc_mlx5_op_info_fill_user_comp(info, op);
+
+    if (seg_size == 0) {
+        uct_rc_mlx5_op_info_fill_rma_zcopy_iov(info, NULL, 0);
+        return;
+    }
+
+    ucs_assert((seg_size % sizeof(*dptr)) == 0);
+
+    dptr   = uct_ib_mlx5_txwq_wrap_any_const(txwq, (raddr + 1));
+    iovcnt = seg_size / sizeof(*dptr);
+    uct_rc_mlx5_callback_data_fill_iov(callback_data, txwq, dptr, iovcnt);
+    uct_rc_mlx5_op_info_fill_rma_zcopy_iov(info, callback_data->iov, iovcnt);
+}
+
+static ucs_status_t uct_rc_mlx5_op_info_fill_put(
+        uct_ep_op_info_t *info, const uct_ib_mlx5_txwq_t *txwq,
+        uct_rc_iface_send_op_t *op, const struct mlx5_wqe_ctrl_seg *ctrl,
+        size_t wqe_size, uct_rc_mlx5_op_callback_data_t *callback_data)
+{
+    size_t header_size = sizeof(*ctrl) + sizeof(struct mlx5_wqe_raddr_seg);
+    const struct mlx5_wqe_raddr_seg *raddr;
+
+    ucs_assert(wqe_size >= header_size);
+
+    raddr = uct_ib_mlx5_txwq_wrap_any_const(txwq, (ctrl + 1));
+
+    if ((op == NULL) || (op->handler == uct_rc_ep_send_op_completion_handler)) {
+        uct_rc_mlx5_op_info_fill_put_zcopy(info, txwq, op, raddr,
+                                           wqe_size - header_size,
+                                           callback_data);
+
+        return UCS_OK;
+    }
+
+    ucs_fatal("unsupported put op %p handler %s", op,
+              ucs_debug_get_symbol_name((void*)op->handler));
+}
+
+ucs_status_t
+uct_rc_mlx5_op_info_fill(uct_ep_op_info_t *info, const uct_ib_mlx5_txwq_t *txwq,
+                         uct_rc_iface_send_op_t *op,
+                         const struct mlx5_wqe_ctrl_seg *ctrl, size_t wqe_size,
+                         uct_rc_mlx5_op_callback_data_t *callback_data)
+{
+    uint8_t opcode = uct_ib_mlx5_wqe_opcode(ctrl);
+
+    memset(info, 0, sizeof(*info));
+
+    switch (opcode) {
+    case MLX5_OPCODE_RDMA_WRITE:
+        return uct_rc_mlx5_op_info_fill_put(info, txwq, op, ctrl, wqe_size,
+                                            callback_data);
+    default:
+        ucs_fatal("unsupported op %d", opcode);
+    }
+}
+
 
 ucs_config_field_t uct_rc_mlx5_common_config_table[] = {
   {UCT_IB_CONFIG_PREFIX, "", NULL,

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -8,6 +8,7 @@
 #define UCT_RC_MLX5_COMMON_H
 
 #include <uct/ib/base/ib_device.h>
+#include <uct/ib/base/ib_md.h>
 #include <uct/ib/rc/base/rc_iface.h>
 #include <uct/ib/rc/base/rc_ep.h>
 #include <uct/ib/mlx5/ib_mlx5.h>
@@ -245,6 +246,17 @@ typedef struct uct_rc_mlx5_mp_hash_key {
     uint64_t                      guid;
     uint32_t                      qp_num;
 } uct_rc_mlx5_mp_hash_key_t;
+
+typedef struct {
+    uct_iov_t    iov[UCT_RC_MLX5_RMA_MAX_IOV(0)];
+    uct_ib_mem_t memh[UCT_RC_MLX5_RMA_MAX_IOV(0)];
+} uct_rc_mlx5_op_callback_data_t;
+
+ucs_status_t
+uct_rc_mlx5_op_info_fill(uct_ep_op_info_t *info, const uct_ib_mlx5_txwq_t *txwq,
+                         uct_rc_iface_send_op_t *op,
+                         const struct mlx5_wqe_ctrl_seg *ctrl, size_t wqe_size,
+                         uct_rc_mlx5_op_callback_data_t *callback_data);
 
 
 static UCS_F_ALWAYS_INLINE int

--- a/src/uct/ib/mlx5/rc/rc_mlx5_common.h
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_common.h
@@ -248,6 +248,7 @@ typedef struct uct_rc_mlx5_mp_hash_key {
 } uct_rc_mlx5_mp_hash_key_t;
 
 typedef struct {
+    uint8_t      data[UCT_IB_MLX5_MAX_SEND_WQE_SIZE];
     uct_iov_t    iov[UCT_RC_MLX5_RMA_MAX_IOV(0)];
     uct_ib_mem_t memh[UCT_RC_MLX5_RMA_MAX_IOV(0)];
 } uct_rc_mlx5_op_callback_data_t;

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -349,6 +349,9 @@ UCT_INSTANTIATE_TEST_CASE(test_uct_peer_failure)
 
 class test_uct_purge_outstanding : public uct_test {
 public:
+    static const uint64_t SEND_SEED = 0xa1a1a1a1a1a1a1a1ul;
+    static const uint64_t RECV_SEED = 0xb2b2b2b2b2b2b2b2ul;
+
     void init() override
     {
         uct_test::init();
@@ -375,9 +378,13 @@ public:
 protected:
     struct purge_ctx {
         test_uct_purge_outstanding *self;
-        uct_completion_t           op_comp;
-        uint32_t                   num_ops_purged;
-        uint32_t                   num_flush_purged;
+        uct_completion_t           op_comp = {completion_cb, 0, UCS_OK};
+        uint32_t                   num_ops_purged = 0;
+        uint32_t                   num_flush_purged = 0;
+        uint64_t                   remote_addr = 0;
+        uct_rkey_t                 rkey = UCT_INVALID_RKEY;
+        const uct_iov_t            *iov = NULL;
+        size_t                     iovcnt = 0;
     };
 
     using send_func_t =
@@ -446,6 +453,9 @@ protected:
     void validate_op(const uct_ep_op_info_t *info, purge_ctx *ctx)
     {
         switch (info->operation) {
+        case UCT_EP_OP_PUT_ZCOPY:
+            validate_put_zcopy(info, ctx);
+            return;
         case UCT_EP_OP_FLUSH:
             validate_flush(info, ctx);
             return;
@@ -454,6 +464,34 @@ protected:
                                                      << " at index "
                                                      << ctx->num_ops_purged);
         }
+    }
+
+    static void validate_put_zcopy(const uct_ep_op_info_t *info, purge_ctx *ctx)
+    {
+        const uint64_t expected_fields = UCT_EP_OP_INFO_FIELD_COMP |
+                                         UCT_EP_OP_INFO_FIELD_RMA;
+        const uint16_t expected_rma_fields =
+                UCT_EP_OP_INFO_RMA_FIELD_REMOTE_ADDR |
+                UCT_EP_OP_INFO_RMA_FIELD_RKEY |
+                UCT_EP_OP_INFO_RMA_FIELD_PAYLOAD_ZCOPY;
+
+        ASSERT_TRUE(ucs_test_all_flags(info->field_mask, expected_fields));
+        ASSERT_TRUE(
+                ucs_test_all_flags(info->rma.field_mask, expected_rma_fields));
+
+        EXPECT_EQ(&ctx->op_comp, info->comp);
+        EXPECT_EQ(ctx->remote_addr, info->rma.remote_addr);
+        /* The reported rkey holds only the direct key part */
+        EXPECT_EQ(uint32_t(ctx->rkey), uint32_t(info->rma.rkey));
+        ASSERT_EQ(ctx->iovcnt, info->rma.payload.zcopy.iovcnt);
+        for (size_t i = 0; i < ctx->iovcnt; ++i) {
+            EXPECT_EQ(ctx->iov[i].buffer,
+                      info->rma.payload.zcopy.iov[i].buffer);
+            EXPECT_EQ(ctx->iov[i].length,
+                      info->rma.payload.zcopy.iov[i].length);
+        }
+
+        ++ctx->num_ops_purged;
     }
 
     static void validate_flush(const uct_ep_op_info_t *info, purge_ctx *ctx)
@@ -533,11 +571,9 @@ protected:
                                                &purge_params));
     }
 
-    void test_purge_outstanding(const send_func_t &send_func)
+    void test_purge_outstanding(const send_func_t &send_func, purge_ctx &ctx)
     {
         uct_ep_invalidate_params_t invalidate_params = {};
-        purge_ctx                   ctx               = {
-                this, {completion_cb, 0, UCS_OK}, 0, 0};
         uint32_t num_posted;
         bool flush_outstanding;
         ucs_status_t status;
@@ -581,6 +617,37 @@ protected:
     entity   *m_receiver;
     unsigned m_err_count = 0;
 };
+
+UCS_TEST_SKIP_COND_P(test_uct_purge_outstanding, put_zcopy,
+                     !check_caps(UCT_IFACE_FLAG_PUT_ZCOPY))
+{
+    const uct_iface_attr_t &attr = m_sender->iface_attr();
+
+    const size_t num_iov = ucs_min(attr.cap.put.max_iov, 2);
+    const size_t size    = ucs_max(attr.cap.put.min_zcopy,
+                                   ucs_min((size_t)4096, attr.cap.put.max_zcopy));
+    mapped_buffer sendbuf(size, SEND_SEED, *m_sender);
+    mapped_buffer recvbuf(size, RECV_SEED, *m_receiver);
+
+    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
+                            sendbuf.memh(), num_iov);
+
+    purge_ctx ctx{};
+    ctx.self        = this;
+    ctx.remote_addr = recvbuf.addr();
+    ctx.rkey        = recvbuf.rkey();
+    ctx.iov         = iov;
+    ctx.iovcnt      = iovcnt;
+
+    send_func_t send_func = [&](uct_ep_h ep, uct_completion_t *comp) {
+        return uct_ep_put_zcopy(ep, iov, iovcnt, ctx.remote_addr, ctx.rkey,
+                                comp);
+    };
+
+    test_purge_outstanding(send_func, ctx);
+}
+
+UCT_INSTANTIATE_TEST_CASE(test_uct_purge_outstanding)
 
 class test_uct_peer_failure_multiple : public test_uct_peer_failure
 {

--- a/test/gtest/uct/test_peer_failure.cc
+++ b/test/gtest/uct/test_peer_failure.cc
@@ -372,10 +372,17 @@ public:
         m_entities.push_back(m_receiver);
         m_sender->connect(0, *m_receiver, 0);
 
+        ASSERT_UCS_OK(uct_iface_set_am_handler(m_receiver->iface(), AM_ID,
+                                               am_dummy_handler, NULL,
+                                               UCT_CB_FLAG_ASYNC));
+
         flush();
     }
 
 protected:
+    static const uint64_t AM_HDR_SEED = 0xc3c3c3c3c3c3c3c3ul;
+    static const uint8_t AM_ID        = 1;
+
     struct purge_ctx {
         test_uct_purge_outstanding *self;
         uct_completion_t           op_comp = {completion_cb, 0, UCS_OK};
@@ -383,12 +390,21 @@ protected:
         uint32_t                   num_flush_purged = 0;
         uint64_t                   remote_addr = 0;
         uct_rkey_t                 rkey = UCT_INVALID_RKEY;
+        uint32_t                   am_id = 0;
+        void                       *am_header = NULL;
+        size_t                     am_header_length = 0;
         const uct_iov_t            *iov = NULL;
         size_t                     iovcnt = 0;
     };
 
     using send_func_t =
             std::function<ucs_status_t(uct_ep_h, uct_completion_t*)>;
+
+    static ucs_status_t
+    am_dummy_handler(void *arg, void *data, size_t length, unsigned flags)
+    {
+        return UCS_OK;
+    }
 
     bool check_caps_v2(uint64_t required_flags)
     {
@@ -456,6 +472,9 @@ protected:
         case UCT_EP_OP_PUT_ZCOPY:
             validate_put_zcopy(info, ctx);
             return;
+        case UCT_EP_OP_AM_ZCOPY:
+            validate_am_zcopy(info, ctx);
+            return;
         case UCT_EP_OP_FLUSH:
             validate_flush(info, ctx);
             return;
@@ -489,6 +508,33 @@ protected:
                       info->rma.payload.zcopy.iov[i].buffer);
             EXPECT_EQ(ctx->iov[i].length,
                       info->rma.payload.zcopy.iov[i].length);
+        }
+
+        ++ctx->num_ops_purged;
+    }
+
+    static void validate_am_zcopy(const uct_ep_op_info_t *info, purge_ctx *ctx)
+    {
+        const uint64_t expected_fields = UCT_EP_OP_INFO_FIELD_AM |
+                                         UCT_EP_OP_INFO_FIELD_COMP;
+        const uint64_t expected_am_fields =
+                UCT_EP_OP_INFO_AM_FIELD_AM_ID | UCT_EP_OP_INFO_AM_FIELD_FLAGS |
+                UCT_EP_OP_INFO_AM_FIELD_HEADER_ZCOPY |
+                UCT_EP_OP_INFO_AM_FIELD_PAYLOAD_ZCOPY;
+
+        ASSERT_TRUE(ucs_test_all_flags(info->field_mask, expected_fields));
+        ASSERT_TRUE(
+                ucs_test_all_flags(info->am.field_mask, expected_am_fields));
+
+        EXPECT_EQ(ctx->am_id, info->am.am_id);
+        EXPECT_EQ(&ctx->op_comp, info->comp);
+        ASSERT_EQ(ctx->am_header_length, info->am.header.zcopy.length);
+        EXPECT_EQ(0, memcmp(ctx->am_header, info->am.header.zcopy.buffer,
+                            ctx->am_header_length));
+        ASSERT_EQ(ctx->iovcnt, info->am.payload.zcopy.iovcnt);
+        for (size_t i = 0; i < ctx->iovcnt; ++i) {
+            EXPECT_EQ(ctx->iov[i].buffer, info->am.payload.zcopy.iov[i].buffer);
+            EXPECT_EQ(ctx->iov[i].length, info->am.payload.zcopy.iov[i].length);
         }
 
         ++ctx->num_ops_purged;
@@ -645,6 +691,38 @@ UCS_TEST_SKIP_COND_P(test_uct_purge_outstanding, put_zcopy,
     };
 
     test_purge_outstanding(send_func, ctx);
+}
+
+UCS_TEST_SKIP_COND_P(test_uct_purge_outstanding, am_zcopy,
+                     !check_caps(UCT_IFACE_FLAG_AM_ZCOPY))
+{
+    const uct_iface_attr_t &attr = m_sender->iface_attr();
+
+    const size_t num_iov  = ucs_min(attr.cap.am.max_iov, 2);
+    const size_t hdr_size = ucs_min((size_t)64, attr.cap.am.max_hdr);
+    const size_t size     = ucs_min((size_t)4096, attr.cap.am.max_zcopy);
+    std::vector<uint8_t> hdr(hdr_size);
+    mapped_buffer sendbuf(size, SEND_SEED, *m_sender);
+
+    mem_buffer::pattern_fill(hdr.data(), hdr.size(), AM_HDR_SEED);
+
+    UCS_TEST_GET_BUFFER_IOV(iov, iovcnt, sendbuf.ptr(), sendbuf.length(),
+                            sendbuf.memh(), num_iov);
+
+    purge_ctx ctx{};
+    ctx.self             = this;
+    ctx.am_id            = AM_ID;
+    ctx.am_header        = hdr.data();
+    ctx.am_header_length = hdr.size();
+    ctx.iov              = iov;
+    ctx.iovcnt           = iovcnt;
+
+    send_func_t am_zcopy = [&](uct_ep_h ep, uct_completion_t *comp) {
+        return uct_ep_am_zcopy(ep, ctx.am_id, ctx.am_header,
+                               ctx.am_header_length, iov, iovcnt, 0, comp);
+    };
+
+    test_purge_outstanding(am_zcopy, ctx);
 }
 
 UCT_INSTANTIATE_TEST_CASE(test_uct_purge_outstanding)


### PR DESCRIPTION
## What?
Add wqe parse support for uct am zcopy.

## Why?
FT need extract info from wqe before replay uct am zcopy.

## How?
Add parser for uct am zcopy.
Need fix conflicts after [PR#11836](https://github.com/openucx/ucx/pull/11836) and [PR#11915](https://github.com/openucx/ucx/pull/11915) merged.