### PR TITLE
Cache IPC handles per peer to avoid cross-peer VA collision - v1.23.x (#11756)

### DIFF
--- a/src/uct/rocm/ipc/rocm_ipc_cache.c
+++ b/src/uct/rocm/ipc/rocm_ipc_cache.c
@@ -22,7 +22,7 @@
 
 
 typedef struct uct_rocm_ipc_cache_hash_key {
-    pid_t        pid;    /* PID of the process that owns the memory */
+    pid_t        pid; /* PID of the process that owns the memory */
     ucs_sys_ns_t pid_ns; /* PID namespace of the owner process */
     int          dev_num; /* Device number the memory was allocated on */
 } uct_rocm_ipc_cache_hash_key_t;
@@ -132,9 +132,9 @@ static void uct_rocm_ipc_cache_invalidate_regions(uct_rocm_ipc_cache_t *cache,
               cache->name, from, to);
 }
 
-static ucs_status_t
-uct_rocm_ipc_cache_map_region(uct_rocm_ipc_cache_t *cache,
-                             uct_rocm_ipc_key_t *key, void **mapped_addr)
+static ucs_status_t uct_rocm_ipc_cache_map_region(uct_rocm_ipc_cache_t *cache,
+                                                  uct_rocm_ipc_key_t *key,
+                                                  void **mapped_addr)
 {
     ucs_status_t status;
     ucs_pgt_region_t *pgt_region;
@@ -311,8 +311,8 @@ uct_rocm_ipc_remote_cache_get(uct_rocm_ipc_cache_hash_key_t key,
     return UCS_OK;
 }
 
-ucs_status_t uct_rocm_ipc_cache_map_memhandle(uct_rocm_ipc_key_t *key,
-                                              void **mapped_addr)
+ucs_status_t
+uct_rocm_ipc_cache_map_memhandle(uct_rocm_ipc_key_t *key, void **mapped_addr)
 {
     uct_rocm_ipc_cache_hash_key_t hash_key = {key->pid, key->pid_ns,
                                               key->dev_num};
@@ -338,17 +338,18 @@ void uct_rocm_ipc_destroy_cache(uct_rocm_ipc_cache_t *cache)
     ucs_free(cache);
 }
 
-UCS_STATIC_INIT {
+UCS_STATIC_INIT
+{
     ucs_rw_spinlock_init(&uct_rocm_ipc_remote_cache.lock);
     kh_init_inplace(rocm_ipc_rem_cache, &uct_rocm_ipc_remote_cache.hash);
 }
 
-UCS_STATIC_CLEANUP {
+UCS_STATIC_CLEANUP
+{
     uct_rocm_ipc_cache_t *cache;
 
-    kh_foreach_value(&uct_rocm_ipc_remote_cache.hash, cache, {
-        uct_rocm_ipc_destroy_cache(cache);
-    })
+    kh_foreach_value(&uct_rocm_ipc_remote_cache.hash, cache,
+                     { uct_rocm_ipc_destroy_cache(cache); })
     kh_destroy_inplace(rocm_ipc_rem_cache, &uct_rocm_ipc_remote_cache.hash);
     ucs_rw_spinlock_cleanup(&uct_rocm_ipc_remote_cache.lock);
 }

--- a/src/uct/rocm/ipc/rocm_ipc_cache.c
+++ b/src/uct/rocm/ipc/rocm_ipc_cache.c
@@ -142,7 +142,9 @@ static ucs_status_t uct_rocm_ipc_cache_map_region(uct_rocm_ipc_cache_t *cache,
     hsa_status_t hsa_status;
     int ret;
 
-    pthread_rwlock_wrlock(&cache->lock);
+    /* A per-cache lock would be needed only if the caller holds no lock or
+     * just a read lock on the global remote-cache lock, allowing concurrent
+     * access to this page table. */
     pgt_region = UCS_PROFILE_CALL(ucs_pgtable_lookup,
                                   &cache->pgtable, key->address);
     if (ucs_likely(pgt_region != NULL)) {
@@ -154,7 +156,6 @@ static ucs_status_t uct_rocm_ipc_cache_map_region(uct_rocm_ipc_cache_t *cache,
                       key->length, UCS_PGT_REGION_ARG(&region->super));
 
             *mapped_addr = region->mapped_addr;
-            pthread_rwlock_unlock(&cache->lock);
             return UCS_OK;
         } else {
             ucs_trace("%s: rocm_ipc cache remove stale region:"
@@ -221,10 +222,8 @@ static ucs_status_t uct_rocm_ipc_cache_map_region(uct_rocm_ipc_cache_t *cache,
     ucs_trace("%s: rocm_ipc cache new region:"UCS_PGT_REGION_FMT" size:%lu",
               cache->name, UCS_PGT_REGION_ARG(&region->super), key->length);
 
-    pthread_rwlock_unlock(&cache->lock);
     return UCS_OK;
 err:
-    pthread_rwlock_unlock(&cache->lock);
     return status;
 }
 
@@ -233,7 +232,6 @@ ucs_status_t uct_rocm_ipc_create_cache(uct_rocm_ipc_cache_t **cache,
 {
     ucs_status_t status;
     uct_rocm_ipc_cache_t *cache_desc;
-    int ret;
 
     cache_desc = ucs_malloc(sizeof(uct_rocm_ipc_cache_t), "uct_rocm_ipc_cache_t");
     if (cache_desc == NULL) {
@@ -241,31 +239,24 @@ ucs_status_t uct_rocm_ipc_create_cache(uct_rocm_ipc_cache_t **cache,
         return UCS_ERR_NO_MEMORY;
     }
 
-    ret = pthread_rwlock_init(&cache_desc->lock, NULL);
-    if (ret) {
-        ucs_error("pthread_rwlock_init() failed: %m");
-        status = UCS_ERR_INVALID_PARAM;
-        goto err;
-    }
-
     status = ucs_pgtable_init(&cache_desc->pgtable,
                               uct_rocm_ipc_cache_pgt_dir_alloc,
                               uct_rocm_ipc_cache_pgt_dir_release);
     if (status != UCS_OK) {
-        goto err_destroy_rwlock;
+        goto err;
     }
 
     cache_desc->name = ucs_strdup(name, "rocm_ipc_cache_name");
     if (cache_desc->name == NULL) {
         status = UCS_ERR_NO_MEMORY;
-        goto err_destroy_rwlock;
+        goto err_cleanup_pgtable;
     }
 
     *cache = cache_desc;
     return UCS_OK;
 
-err_destroy_rwlock:
-    pthread_rwlock_destroy(&cache_desc->lock);
+err_cleanup_pgtable:
+    ucs_pgtable_cleanup(&cache_desc->pgtable);
 err:
     ucs_free(cache_desc);
     return status;
@@ -333,7 +324,6 @@ void uct_rocm_ipc_destroy_cache(uct_rocm_ipc_cache_t *cache)
 {
     uct_rocm_ipc_cache_purge(cache);
     ucs_pgtable_cleanup(&cache->pgtable);
-    pthread_rwlock_destroy(&cache->lock);
     ucs_free(cache->name);
     ucs_free(cache);
 }

--- a/src/uct/rocm/ipc/rocm_ipc_cache.c
+++ b/src/uct/rocm/ipc/rocm_ipc_cache.c
@@ -11,12 +11,49 @@
 
 #include "rocm_ipc_cache.h"
 
+#include <ucs/datastruct/khash.h>
 #include <ucs/debug/log.h>
 #include <ucs/debug/memtrack_int.h>
 #include <ucs/profile/profile.h>
 #include <ucs/sys/ptr_arith.h>
+#include <ucs/sys/string.h>
 #include <ucs/sys/sys.h>
-#include <ucs/type/init_once.h>
+#include <ucs/type/rwlock.h>
+
+
+typedef struct uct_rocm_ipc_cache_hash_key {
+    pid_t        pid;    /* PID of the process that owns the memory */
+    ucs_sys_ns_t pid_ns; /* PID namespace of the owner process */
+    int          dev_num; /* Device number the memory was allocated on */
+} uct_rocm_ipc_cache_hash_key_t;
+
+static UCS_F_ALWAYS_INLINE int
+uct_rocm_ipc_cache_hash_equal(uct_rocm_ipc_cache_hash_key_t key1,
+                              uct_rocm_ipc_cache_hash_key_t key2)
+{
+    return (key1.pid == key2.pid) && (key1.pid_ns == key2.pid_ns) &&
+           (key1.dev_num == key2.dev_num);
+}
+
+static UCS_F_ALWAYS_INLINE khint32_t
+uct_rocm_ipc_cache_hash_func(uct_rocm_ipc_cache_hash_key_t key)
+{
+    uint64_t value = key.pid ^ ((uint64_t)key.pid_ns << 32) ^
+                     ((uint32_t)key.dev_num << 24);
+    return kh_int64_hash_func(value);
+}
+
+KHASH_INIT(rocm_ipc_rem_cache, uct_rocm_ipc_cache_hash_key_t,
+           uct_rocm_ipc_cache_t*, 1, uct_rocm_ipc_cache_hash_func,
+           uct_rocm_ipc_cache_hash_equal);
+
+/* Per-peer IPC handle caches. Caches are kept per (pid, pid_ns, dev_num). */
+typedef struct uct_rocm_ipc_remote_cache {
+    khash_t(rocm_ipc_rem_cache) hash;
+    ucs_rw_spinlock_t           lock;
+} uct_rocm_ipc_remote_cache_t;
+
+static uct_rocm_ipc_remote_cache_t uct_rocm_ipc_remote_cache;
 
 static ucs_pgt_dir_t *uct_rocm_ipc_cache_pgt_dir_alloc(const ucs_pgtable_t *pgtable)
 {
@@ -95,19 +132,16 @@ static void uct_rocm_ipc_cache_invalidate_regions(uct_rocm_ipc_cache_t *cache,
               cache->name, from, to);
 }
 
-ucs_status_t uct_rocm_ipc_cache_map_memhandle(void *arg, uct_rocm_ipc_key_t *key,
-                                              void **mapped_addr)
+static ucs_status_t
+uct_rocm_ipc_cache_map_region(uct_rocm_ipc_cache_t *cache,
+                             uct_rocm_ipc_key_t *key, void **mapped_addr)
 {
-    uct_rocm_ipc_cache_t *cache = (uct_rocm_ipc_cache_t *)arg;
     ucs_status_t status;
     ucs_pgt_region_t *pgt_region;
     uct_rocm_ipc_cache_region_t *region;
     hsa_status_t hsa_status;
     int ret;
 
-    /* Take the write lock unconditionally: the page table may be mutated below
-     * (remove a stale region, attach and insert a new region), so a shared read
-     * lock would allow concurrent mutation and corrupt the table. */
     pthread_rwlock_wrlock(&cache->lock);
     pgt_region = UCS_PROFILE_CALL(ucs_pgtable_lookup,
                                   &cache->pgtable, key->address);
@@ -237,30 +271,62 @@ err:
     return status;
 }
 
-ucs_status_t uct_rocm_ipc_component_init_cache(void)
+/* Look up the per-peer cache for the given hash key, creating it on first use.
+ * Caller must hold the remote cache write lock. */
+static ucs_status_t
+uct_rocm_ipc_remote_cache_get(uct_rocm_ipc_cache_hash_key_t key,
+                              uct_rocm_ipc_cache_t **cache_p)
 {
-    static ucs_init_once_t cache_init_once = UCS_INIT_ONCE_INITIALIZER;
+    khash_t(rocm_ipc_rem_cache) *hash = &uct_rocm_ipc_remote_cache.hash;
+    uct_rocm_ipc_cache_t *cache;
+    char target_name[64];
     ucs_status_t status;
+    khint_t it;
+    int ret;
 
-    UCS_INIT_ONCE(&cache_init_once) {
-        status = uct_rocm_ipc_create_cache(&uct_rocm_ipc_component.ipc_cache,
-                                           "rocm_ipc_component");
-        if (status != UCS_OK) {
-            ucs_error("Failed to create ROCm IPC component cache: %s",
-                      ucs_status_string(status));
-            /* Only "continue" is safe to exit a UCS_INIT_ONCE block; a "return"
-             * would leave the internal mutex locked. The failed cache stays
-             * NULL and is detected below. */
-            continue;
-        }
-
-        ucs_debug("ROCm IPC component cache initialized");
+    it = kh_get(rocm_ipc_rem_cache, hash, key);
+    if (ucs_likely(it != kh_end(hash))) {
+        *cache_p = kh_val(hash, it);
+        return UCS_OK;
     }
 
-    /* A prior failed attempt leaves the once-block marked done with a NULL
-     * cache, so check the cache itself rather than the per-call status. */
-    return (uct_rocm_ipc_component.ipc_cache != NULL) ? UCS_OK :
-                                                        UCS_ERR_IO_ERROR;
+    it = kh_put(rocm_ipc_rem_cache, hash, key, &ret);
+    if (ret == UCS_KH_PUT_FAILED) {
+        ucs_error("failed to allocate rocm_ipc remote_cache hash entry");
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    ucs_snprintf_safe(target_name, sizeof(target_name), "dest:%d:%u:%d",
+                      (int)key.pid, key.pid_ns, key.dev_num);
+    status = uct_rocm_ipc_create_cache(&cache, target_name);
+    if (status != UCS_OK) {
+        kh_del(rocm_ipc_rem_cache, hash, it);
+        ucs_error("failed to create rocm ipc cache: %s",
+                  ucs_status_string(status));
+        return status;
+    }
+
+    kh_val(hash, it) = cache;
+    *cache_p         = cache;
+    return UCS_OK;
+}
+
+ucs_status_t uct_rocm_ipc_cache_map_memhandle(uct_rocm_ipc_key_t *key,
+                                              void **mapped_addr)
+{
+    uct_rocm_ipc_cache_hash_key_t hash_key = {key->pid, key->pid_ns,
+                                              key->dev_num};
+    uct_rocm_ipc_cache_t *cache;
+    ucs_status_t status;
+
+    ucs_rw_spinlock_write_lock(&uct_rocm_ipc_remote_cache.lock);
+    status = uct_rocm_ipc_remote_cache_get(hash_key, &cache);
+    if (status == UCS_OK) {
+        status = uct_rocm_ipc_cache_map_region(cache, key, mapped_addr);
+    }
+    ucs_rw_spinlock_write_unlock(&uct_rocm_ipc_remote_cache.lock);
+
+    return status;
 }
 
 void uct_rocm_ipc_destroy_cache(uct_rocm_ipc_cache_t *cache)
@@ -270,4 +336,19 @@ void uct_rocm_ipc_destroy_cache(uct_rocm_ipc_cache_t *cache)
     pthread_rwlock_destroy(&cache->lock);
     ucs_free(cache->name);
     ucs_free(cache);
+}
+
+UCS_STATIC_INIT {
+    ucs_rw_spinlock_init(&uct_rocm_ipc_remote_cache.lock);
+    kh_init_inplace(rocm_ipc_rem_cache, &uct_rocm_ipc_remote_cache.hash);
+}
+
+UCS_STATIC_CLEANUP {
+    uct_rocm_ipc_cache_t *cache;
+
+    kh_foreach_value(&uct_rocm_ipc_remote_cache.hash, cache, {
+        uct_rocm_ipc_destroy_cache(cache);
+    })
+    kh_destroy_inplace(rocm_ipc_rem_cache, &uct_rocm_ipc_remote_cache.hash);
+    ucs_rw_spinlock_cleanup(&uct_rocm_ipc_remote_cache.lock);
 }

--- a/src/uct/rocm/ipc/rocm_ipc_cache.c
+++ b/src/uct/rocm/ipc/rocm_ipc_cache.c
@@ -105,7 +105,10 @@ ucs_status_t uct_rocm_ipc_cache_map_memhandle(void *arg, uct_rocm_ipc_key_t *key
     hsa_status_t hsa_status;
     int ret;
 
-    pthread_rwlock_rdlock(&cache->lock);
+    /* Take the write lock unconditionally: the page table may be mutated below
+     * (remove a stale region, attach and insert a new region), so a shared read
+     * lock would allow concurrent mutation and corrupt the table. */
+    pthread_rwlock_wrlock(&cache->lock);
     pgt_region = UCS_PROFILE_CALL(ucs_pgtable_lookup,
                                   &cache->pgtable, key->address);
     if (ucs_likely(pgt_region != NULL)) {

--- a/src/uct/rocm/ipc/rocm_ipc_cache.h
+++ b/src/uct/rocm/ipc/rocm_ipc_cache.h
@@ -29,10 +29,8 @@ typedef struct uct_rocm_ipc_cache {
 ucs_status_t uct_rocm_ipc_create_cache(uct_rocm_ipc_cache_t **cache,
                                        const char *name);
 
-ucs_status_t uct_rocm_ipc_component_init_cache(void);
-
 void uct_rocm_ipc_destroy_cache(uct_rocm_ipc_cache_t *cache);
 
-ucs_status_t uct_rocm_ipc_cache_map_memhandle(void *arg, uct_rocm_ipc_key_t *key,
+ucs_status_t uct_rocm_ipc_cache_map_memhandle(uct_rocm_ipc_key_t *key,
                                               void **mapped_addr);
 #endif

--- a/src/uct/rocm/ipc/rocm_ipc_cache.h
+++ b/src/uct/rocm/ipc/rocm_ipc_cache.h
@@ -21,7 +21,6 @@ typedef struct uct_cuda_ipc_cache_region {
 } uct_rocm_ipc_cache_region_t;
 
 typedef struct uct_rocm_ipc_cache {
-    pthread_rwlock_t      lock;       /**< protests the page table */
     ucs_pgtable_t         pgtable;    /**< Page table to hold the regions */
     char                  *name;      /**< Name */
 } uct_rocm_ipc_cache_t;

--- a/src/uct/rocm/ipc/rocm_ipc_cache.h
+++ b/src/uct/rocm/ipc/rocm_ipc_cache.h
@@ -31,6 +31,6 @@ ucs_status_t uct_rocm_ipc_create_cache(uct_rocm_ipc_cache_t **cache,
 
 void uct_rocm_ipc_destroy_cache(uct_rocm_ipc_cache_t *cache);
 
-ucs_status_t uct_rocm_ipc_cache_map_memhandle(uct_rocm_ipc_key_t *key,
-                                              void **mapped_addr);
+ucs_status_t
+uct_rocm_ipc_cache_map_memhandle(uct_rocm_ipc_key_t *key, void **mapped_addr);
 #endif

--- a/src/uct/rocm/ipc/rocm_ipc_ep.c
+++ b/src/uct/rocm/ipc/rocm_ipc_ep.c
@@ -86,16 +86,7 @@ ucs_status_t uct_rocm_ipc_ep_zcopy(uct_ep_h tl_ep,
     }
 
     if (iface->config.enable_ipc_handle_cache) {
-        /* Ensure component cache is initialized */
-        ret = uct_rocm_ipc_component_init_cache();
-        if (ucs_unlikely(ret != UCS_OK)) {
-            ucs_error("failed to initialize rocm_ipc component cache\n");
-            return ret;
-        }
-
-        ret = uct_rocm_ipc_cache_map_memhandle(
-                (void*)uct_rocm_ipc_component.ipc_cache, key,
-                &remote_base_addr);
+        ret = uct_rocm_ipc_cache_map_memhandle(key, &remote_base_addr);
         if (ucs_unlikely(ret != UCS_OK)) {
             ucs_error("fail to attach ipc mem %p %d\n", (void*)key->address,
                       ret);

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -240,26 +240,27 @@ ucs_status_t uct_rocm_ipc_rkey_ptr(uct_component_t *component, uct_rkey_t rkey,
 }
 
 uct_rocm_ipc_component_t uct_rocm_ipc_component = {
-    .super = {
-        .query_md_resources = uct_rocm_base_query_md_resources,
-        .md_open            = uct_rocm_ipc_md_open,
-        .cm_open            = (uct_component_cm_open_func_t)ucs_empty_function_return_unsupported,
-        .rkey_unpack        = uct_rocm_ipc_rkey_unpack,
-        .rkey_ptr           = uct_rocm_ipc_rkey_ptr,
-        .rkey_release       = uct_rocm_ipc_rkey_release,
-        .rkey_compare       = uct_base_rkey_compare,
-        .name               = "rocm_ipc",
-        .md_config          = {
-            .name           = "ROCm-IPC memory domain",
-            .prefix         = "ROCM_IPC_MD_",
-            .table          = uct_rocm_ipc_md_config_table,
-            .size           = sizeof(uct_rocm_ipc_md_config_t),
-        },
-        .cm_config          = UCS_CONFIG_EMPTY_GLOBAL_LIST_ENTRY,
-        .tl_list            = UCT_COMPONENT_TL_LIST_INITIALIZER(&uct_rocm_ipc_component.super),
-        .flags              = 0,
-        .md_vfs_init        =
-                (uct_component_md_vfs_init_func_t)ucs_empty_function
-    }
+    .super = {.query_md_resources = uct_rocm_base_query_md_resources,
+              .md_open            = uct_rocm_ipc_md_open,
+              .cm_open            = (uct_component_cm_open_func_t)
+                                 ucs_empty_function_return_unsupported,
+              .rkey_unpack        = uct_rocm_ipc_rkey_unpack,
+              .rkey_ptr           = uct_rocm_ipc_rkey_ptr,
+              .rkey_release       = uct_rocm_ipc_rkey_release,
+              .rkey_compare       = uct_base_rkey_compare,
+              .name               = "rocm_ipc",
+              .md_config =
+                      {
+                              .name   = "ROCm-IPC memory domain",
+                              .prefix = "ROCM_IPC_MD_",
+                              .table  = uct_rocm_ipc_md_config_table,
+                              .size   = sizeof(uct_rocm_ipc_md_config_t),
+                      },
+              .cm_config   = UCS_CONFIG_EMPTY_GLOBAL_LIST_ENTRY,
+              .tl_list     = UCT_COMPONENT_TL_LIST_INITIALIZER(
+                      &uct_rocm_ipc_component.super),
+              .flags       = 0,
+              .md_vfs_init = (uct_component_md_vfs_init_func_t)
+                      ucs_empty_function}
 };
 UCT_COMPONENT_REGISTER(&uct_rocm_ipc_component.super);

--- a/src/uct/rocm/ipc/rocm_ipc_md.c
+++ b/src/uct/rocm/ipc/rocm_ipc_md.c
@@ -15,6 +15,8 @@
 #include <uct/api/v2/uct_v2.h>
 #include <uct/api/device/uct_device_types.h>
 
+#include <unistd.h>
+
 
 static ucs_config_field_t uct_rocm_ipc_md_config_table[] = {
     {"", "", NULL,
@@ -79,6 +81,8 @@ static hsa_status_t uct_rocm_ipc_pack_key(void *address, size_t length,
     key->address = (uintptr_t)base_ptr;
     key->length  = size;
     key->dev_num = uct_rocm_base_get_dev_num(agent);
+    key->pid     = getpid();
+    key->pid_ns  = ucs_sys_get_ns(UCS_SYS_NS_TYPE_PID);
 
     return HSA_STATUS_SUCCESS;
 }
@@ -125,24 +129,13 @@ uct_rocm_ipc_md_mem_elem_pack(uct_md_h md_h, uct_mem_h memh, uct_rkey_t rkey,
                               uct_device_mem_elem_t *mem_elem_p,
                               void **release_handle_p)
 {
-    uct_md_t *md = (uct_md_t*)md_h;
-    uct_rocm_ipc_component_t *rocm_comp =
-            ucs_derived_of(md->component, uct_rocm_ipc_component_t);
     uct_rocm_ipc_key_t *key = (uct_rocm_ipc_key_t*)rkey;
     uct_rocm_ipc_device_mem_element_t *rocm_ipc_mem_element =
             (uct_rocm_ipc_device_mem_element_t*)mem_elem_p;
     void *mapped_addr;
     ucs_status_t status;
 
-    /* Ensure cache is initialized */
-    status = uct_rocm_ipc_component_init_cache();
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    /* Use cache instead of direct attach */
-    status = uct_rocm_ipc_cache_map_memhandle(rocm_comp->ipc_cache, key,
-                                              &mapped_addr);
+    status = uct_rocm_ipc_cache_map_memhandle(key, &mapped_addr);
     if (status != UCS_OK) {
         ucs_error("Failed to map IPC handle: %s", ucs_status_string(status));
         return status;
@@ -225,23 +218,12 @@ static ucs_status_t uct_rocm_ipc_rkey_release(uct_component_t *component,
 ucs_status_t uct_rocm_ipc_rkey_ptr(uct_component_t *component, uct_rkey_t rkey,
                                    void *handle, uint64_t raddr, void **laddr_p)
 {
-    uct_rocm_ipc_component_t *rocm_comp =
-            ucs_derived_of(component, uct_rocm_ipc_component_t);
-
     uct_rocm_ipc_key_t *key = (uct_rocm_ipc_key_t*)rkey;
     void *mapped_addr;
     ptrdiff_t offset;
     ucs_status_t status;
 
-    /* Ensure cache is initialized */
-    status = uct_rocm_ipc_component_init_cache();
-    if (status != UCS_OK) {
-        return status;
-    }
-
-    /* Use cache instead of direct attach */
-    status = uct_rocm_ipc_cache_map_memhandle(rocm_comp->ipc_cache, key,
-                                              &mapped_addr);
+    status = uct_rocm_ipc_cache_map_memhandle(key, &mapped_addr);
     if (status != UCS_OK) {
         ucs_error("Failed to map IPC handle: %s", ucs_status_string(status));
         return status;
@@ -278,18 +260,6 @@ uct_rocm_ipc_component_t uct_rocm_ipc_component = {
         .flags              = 0,
         .md_vfs_init        =
                 (uct_component_md_vfs_init_func_t)ucs_empty_function
-    },
-    .ipc_cache              = NULL,
-    .lock                   = PTHREAD_MUTEX_INITIALIZER
+    }
 };
 UCT_COMPONENT_REGISTER(&uct_rocm_ipc_component.super);
-
-UCS_STATIC_CLEANUP
-{
-    if (uct_rocm_ipc_component.ipc_cache != NULL) {
-        ucs_debug("Destroying ROCm IPC component cache");
-        uct_rocm_ipc_destroy_cache(uct_rocm_ipc_component.ipc_cache);
-        uct_rocm_ipc_component.ipc_cache = NULL;
-    }
-    pthread_mutex_destroy(&uct_rocm_ipc_component.lock);
-}

--- a/src/uct/rocm/ipc/rocm_ipc_md.h
+++ b/src/uct/rocm/ipc/rocm_ipc_md.h
@@ -7,6 +7,7 @@
 #define ROCM_IPC_MD_H
 
 #include <uct/base/uct_md.h>
+#include <ucs/sys/sys.h>
 #include <hsa_ext_amd.h>
 #include <pthread.h>
 
@@ -14,9 +15,7 @@
 typedef struct uct_rocm_ipc_cache uct_rocm_ipc_cache_t;
 
 typedef struct uct_rocm_ipc_component {
-    uct_component_t      super;
-    uct_rocm_ipc_cache_t *ipc_cache;
-    pthread_mutex_t      lock;
+    uct_component_t super;
 } uct_rocm_ipc_component_t;
 
 extern uct_rocm_ipc_component_t uct_rocm_ipc_component;
@@ -31,9 +30,11 @@ typedef struct uct_rocm_ipc_md_config {
 
 typedef struct uct_rocm_ipc_key {
     hsa_amd_ipc_memory_t ipc;
-    uintptr_t address;
-    size_t length;
-    int dev_num;
+    uintptr_t            address;
+    size_t               length;
+    int                  dev_num;
+    pid_t                pid;    /* PID of the process that owns the memory */
+    ucs_sys_ns_t         pid_ns; /* PID namespace of the owner process */
 } uct_rocm_ipc_key_t;
 
 #endif

--- a/src/uct/rocm/ipc/rocm_ipc_md.h
+++ b/src/uct/rocm/ipc/rocm_ipc_md.h
@@ -33,7 +33,7 @@ typedef struct uct_rocm_ipc_key {
     uintptr_t            address;
     size_t               length;
     int                  dev_num;
-    pid_t                pid;    /* PID of the process that owns the memory */
+    pid_t                pid; /* PID of the process that owns the memory */
     ucs_sys_ns_t         pid_ns; /* PID namespace of the owner process */
 } uct_rocm_ipc_key_t;
 


### PR DESCRIPTION
## What?
Cherry-picking a merged PR from the master branch (#11756)

## Why?
Fixes potential cross-peer VA collisions

## How?
Adding per-peer IPC handles cache