### PR TITLE
UCT/CUDA: Add localized memory detection

### DIFF
--- a/config/m4/cuda.m4
+++ b/config/m4/cuda.m4
@@ -252,6 +252,9 @@ AS_IF([test "x$cuda_checked" != "xyes"],
          AC_CHECK_DECLS([CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED],
                         [], [], [[#include <cuda.h>]])
 
+         AC_CHECK_DECLS([CU_MEM_LOCATION_TYPE_DEVICE_LOCALITY_DOMAIN],
+                        [], [], [[#include <cuda.h>]])
+
          CPPFLAGS="$save_CPPFLAGS"
          LDFLAGS="$save_LDFLAGS"
          LIBS="$save_LIBS"

--- a/src/uct/cuda/cuda_copy/cuda_copy_md.c
+++ b/src/uct/cuda/cuda_copy/cuda_copy_md.c
@@ -533,6 +533,12 @@ static int uct_cuda_copy_detect_vmm(const void *address,
 #endif
     if (prop.location.type == CU_MEM_LOCATION_TYPE_DEVICE) {
         *vmm_mem_type = UCS_MEMORY_TYPE_CUDA;
+#if HAVE_DECL_CU_MEM_LOCATION_TYPE_DEVICE_LOCALITY_DOMAIN
+    } else if (prop.location.type ==
+               CU_MEM_LOCATION_TYPE_DEVICE_LOCALITY_DOMAIN) {
+        *cuda_device  = (CUdevice)prop.location.localized.deviceId;
+        *vmm_mem_type = UCS_MEMORY_TYPE_CUDA;
+#endif
     }
 
 out:

--- a/test/gtest/uct/cuda/cuda_vmm_mem_buffer.h
+++ b/test/gtest/uct/cuda/cuda_vmm_mem_buffer.h
@@ -36,7 +36,8 @@ public:
     cuda_vmm_mem_buffer(size_t size, ucs_memory_type_t mem_type,
                         size_t num_chunks = 1)
     {
-        init(size, 0, CU_MEM_LOCATION_TYPE_DEVICE, num_chunks);
+        skip_unless_ok(alloc(size, 0, CU_MEM_LOCATION_TYPE_DEVICE,
+                             num_chunks));
     }
 
     virtual ~cuda_vmm_mem_buffer()
@@ -55,16 +56,17 @@ public:
         return m_size;
     }
 
-protected:
-    void init(size_t size, unsigned handle_type,
-              CUmemLocationType location_type = CU_MEM_LOCATION_TYPE_DEVICE,
-              size_t num_chunks               = 1)
+    CUresult alloc(size_t size, unsigned handle_type,
+                   CUmemLocationType location_type  = CU_MEM_LOCATION_TYPE_DEVICE,
+                   size_t num_chunks                = 1,
+                   unsigned char locality_domain_id = 0)
     {
         size_t granularity             = 0;
         CUmemAllocationProp prop       = {};
         CUmemAccessDesc access_desc[2] = {};
         unsigned num_access            = 1;
-        bool host_located = (location_type != CU_MEM_LOCATION_TYPE_DEVICE);
+        bool host_located              = false;
+        CUresult ret;
         CUdevice device;
         if (cuCtxGetDevice(&device) != CUDA_SUCCESS) {
             UCS_TEST_ABORT("failed to get the device handle for the current "
@@ -73,20 +75,31 @@ protected:
 
         prop.type          = CU_MEM_ALLOCATION_TYPE_PINNED;
         prop.location.type = location_type;
-        prop.location.id   = host_located ? 0 : device;
+#if HAVE_DECL_CU_MEM_LOCATION_TYPE_DEVICE_LOCALITY_DOMAIN
+        if (location_type == CU_MEM_LOCATION_TYPE_DEVICE_LOCALITY_DOMAIN) {
+            prop.location.localized.deviceId         = (unsigned char)device;
+            prop.location.localized.localityDomainId = locality_domain_id;
+        } else
+#endif
+        {
+            host_located      = (location_type != CU_MEM_LOCATION_TYPE_DEVICE);
+            prop.location.id = host_located ? 0 : device;
+        }
         if (handle_type != 0) {
             prop.requestedHandleTypes = (CUmemAllocationHandleType)handle_type;
         }
-        if (cuMemGetAllocationGranularity(&granularity, &prop,
-                                          CU_MEM_ALLOC_GRANULARITY_MINIMUM) !=
-            CUDA_SUCCESS) {
+
+        ret = cuMemGetAllocationGranularity(&granularity, &prop,
+                                            CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+        if (ret != CUDA_SUCCESS) {
             goto err;
         }
 
         m_chunk_size = ucs_align_up(size, granularity);
         m_size       = m_chunk_size * num_chunks;
 
-        if (cuMemAddressReserve(&m_ptr, m_size, 0, 0, 0) != CUDA_SUCCESS) {
+        ret = cuMemAddressReserve(&m_ptr, m_size, 0, 0, 0);
+        if (ret != CUDA_SUCCESS) {
             m_ptr = 0;
             goto err;
         }
@@ -94,15 +107,16 @@ protected:
         for (size_t i = 0; i < num_chunks; ++i) {
             CUmemGenericAllocationHandle alloc_handle;
 
-            if (cuMemCreate(&alloc_handle, m_chunk_size, &prop, 0) !=
-                CUDA_SUCCESS) {
+            ret = cuMemCreate(&alloc_handle, m_chunk_size, &prop, 0);
+            if (ret != CUDA_SUCCESS) {
                 goto err;
             }
 
             m_alloc_handles.push_back(alloc_handle);
 
-            if (cuMemMap(m_ptr + (i * m_chunk_size), m_chunk_size, 0,
-                         alloc_handle, 0) != CUDA_SUCCESS) {
+            ret = cuMemMap(m_ptr + (i * m_chunk_size), m_chunk_size, 0,
+                           alloc_handle, 0);
+            if (ret != CUDA_SUCCESS) {
                 goto err;
             }
 
@@ -118,21 +132,30 @@ protected:
             access_desc[1].flags         = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
             num_access                   = 2;
         }
-        if (cuMemSetAccess(m_ptr, m_size, access_desc, num_access) !=
-            CUDA_SUCCESS) {
+
+        ret = cuMemSetAccess(m_ptr, m_size, access_desc, num_access);
+        if (ret != CUDA_SUCCESS) {
             goto err;
         }
 
-        return;
+        return CUDA_SUCCESS;
 
     err:
         cleanup();
-        UCS_TEST_SKIP_R("failed to allocate CUDA VMM memory");
+        return ret;
+    }
+
+protected:
+    static void skip_unless_ok(CUresult result)
+    {
+        if (result != CUDA_SUCCESS) {
+            UCS_TEST_SKIP_R("failed to allocate CUDA VMM memory");
+        }
     }
 
 private:
     /* Unmap only the chunks which were actually mapped, so this is also the
-     * unwind path of a partially completed init() */
+     * unwind path of a partially completed alloc() */
     void cleanup()
     {
         for (size_t i = 0; i < m_num_mapped; ++i) {
@@ -164,7 +187,7 @@ class cuda_fabric_mem_buffer : public cuda_vmm_mem_buffer {
 public:
     cuda_fabric_mem_buffer(size_t size, ucs_memory_type_t mem_type)
     {
-        init(size, CU_MEM_HANDLE_TYPE_FABRIC);
+        skip_unless_ok(alloc(size, CU_MEM_HANDLE_TYPE_FABRIC));
     }
 };
 #endif
@@ -173,7 +196,7 @@ class cuda_posix_fd_mem_buffer : public cuda_vmm_mem_buffer {
 public:
     cuda_posix_fd_mem_buffer(size_t size, ucs_memory_type_t mem_type)
     {
-        init(size, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+        skip_unless_ok(alloc(size, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR));
     }
 };
 
@@ -182,7 +205,7 @@ class cuda_host_vmm_mem_buffer : public cuda_vmm_mem_buffer {
 public:
     cuda_host_vmm_mem_buffer(size_t size, ucs_memory_type_t mem_type)
     {
-        init(size, 0, CU_MEM_LOCATION_TYPE_HOST_NUMA);
+        skip_unless_ok(alloc(size, 0, CU_MEM_LOCATION_TYPE_HOST_NUMA));
     }
 };
 #endif

--- a/test/gtest/uct/cuda/test_cuda_ipc_md.cc
+++ b/test/gtest/uct/cuda/test_cuda_ipc_md.cc
@@ -4,8 +4,13 @@
  * See file LICENSE for terms.
  */
 
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
 #include "cuda_vmm_mem_buffer.h"
 
+#include <cuda_runtime.h>
 #include <thread>
 #include <vector>
 
@@ -732,6 +737,49 @@ UCS_TEST_P(test_cuda_copy_md, vmm_multi_handle_range) {
 
     EXPECT_EQ(UCS_MEMORY_TYPE_CUDA, mem_attr.mem_type);
     EXPECT_GE(mem_attr.alloc_length, buffer.size());
+}
+
+UCS_TEST_P(test_cuda_copy_md, vmm_locality_domain_mem_type) {
+#if HAVE_DECL_CU_MEM_LOCATION_TYPE_DEVICE_LOCALITY_DOMAIN
+    ASSERT_EQ(cudaSuccess, cudaSetDevice(0));
+
+    auto check_domain = [this](unsigned char domain_id,
+                               ucs_sys_device_t &sys_dev) {
+        cuda_vmm_mem_buffer buffer;
+        CUresult ret = buffer.alloc(64, 0,
+                                    CU_MEM_LOCATION_TYPE_DEVICE_LOCALITY_DOMAIN,
+                                    1, domain_id);
+        if (ret != CUDA_SUCCESS) {
+            return false;
+        }
+
+        uct_md_mem_attr_t mem_attr;
+        mem_attr.field_mask = UCT_MD_MEM_ATTR_FIELD_MEM_TYPE |
+                              UCT_MD_MEM_ATTR_FIELD_SYS_DEV;
+
+        ASSERT_UCS_OK(uct_md_mem_query(md(), buffer.ptr(), buffer.size(),
+                                       &mem_attr));
+        EXPECT_EQ(UCS_MEMORY_TYPE_CUDA, mem_attr.mem_type);
+        EXPECT_NE(UCS_SYS_DEVICE_ID_UNKNOWN, mem_attr.sys_dev);
+        sys_dev = mem_attr.sys_dev;
+        return true;
+    };
+
+    ucs_sys_device_t sys_dev0, sys_dev1;
+    if (!check_domain(0, sys_dev0)) {
+        UCS_TEST_SKIP_R("failed to allocate locality-domain 0 VMM memory");
+    }
+
+    if (!check_domain(1, sys_dev1)) {
+        ADD_FAILURE() << "locality domain 1 allocation failed even though "
+                         "domain 0 succeeded";
+        return;
+    }
+
+    EXPECT_EQ(sys_dev0, sys_dev1);
+#else
+    UCS_TEST_SKIP_R("built without locality-domain support");
+#endif
 }
 
 _UCT_MD_INSTANTIATE_TEST_CASE(test_cuda_copy_md, cuda_cpy);


### PR DESCRIPTION
## What?
Detect CUDA localized memory.
## Why?
Without detection, CUDA localized memory cannot be used for transfers.
## How?
Add recognition of localized flag.