### PR TITLE
UCT/API: improve purge callback doc

### DIFF
--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -573,9 +573,6 @@ typedef ucs_status_t (*uct_pending_callback_t)(uct_pending_req_t *self);
  * @param [in]  status   Status indicating error.
  *
  * @return @ref UCS_OK         - The error was handled successfully.
- *         @ref UCS_INPROGRESS - The error handling is in progress and the
- *                               transport should not purge outstanding
- *                               operations.
  *         Otherwise           - The error was not handled and is returned back
  *                               to the transport.
  */

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1916,6 +1916,13 @@ typedef struct uct_ep_op_info {
 /**
  * @ingroup UCT_RESOURCE
  * @brief Callback invoked for each undelivered outstanding operation.
+ *
+ * @param [in] op_info  Descriptor of the undelivered operation. The descriptor
+ *                      is valid only for the duration of the callback. The user
+ *                      must copy it, and any callback-lifetime data it
+ *                      references, if they are needed after the callback
+ *                      returns.
+ * @param [in] arg      User-defined argument.
  */
 typedef void (*uct_ep_outstanding_purge_callback_t)(
         const uct_ep_op_info_t *op_info, void *arg);

--- a/src/uct/api/v2/uct_v2.h
+++ b/src/uct/api/v2/uct_v2.h
@@ -1918,10 +1918,7 @@ typedef struct uct_ep_op_info {
  * @brief Callback invoked for each undelivered outstanding operation.
  *
  * @param [in] op_info  Descriptor of the undelivered operation. The descriptor
- *                      is valid only for the duration of the callback. The user
- *                      must copy it, and any callback-lifetime data it
- *                      references, if they are needed after the callback
- *                      returns.
+ *                      is valid only for the duration of the callback.
  * @param [in] arg      User-defined argument.
  */
 typedef void (*uct_ep_outstanding_purge_callback_t)(


### PR DESCRIPTION
## What?
Improve doc for UCT purge API.

## Why?
The lifetime of undelivered op descriptor is not described in doc.

## How?
Add details in purge API doc.