### PR TITLE
AZP/SNAPSHOT: Point JUCX snapshots at Central Portal

### DIFF
--- a/bindings/java/pom.xml.in
+++ b/bindings/java/pom.xml.in
@@ -173,7 +173,7 @@
   <distributionManagement>
     <snapshotRepository>
       <id>central</id>
-      <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
     <repository>
       <id>central</id>

--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -97,7 +97,7 @@ jobs:
               JUCX_VERSION=${MAVEN_VERSION}${SUFFIX}
         displayName: Publish-Maven
         # rc tags carry the final maven version - skip to keep it for GA
-        condition: and(in(variables['Build.Reason'], 'IndividualCI', 'PullRequest'), not(contains(variables['Build.SourceBranch'], '-rc')))
+        condition: and(eq(variables['Build.Reason'], 'IndividualCI'), not(contains(variables['Build.SourceBranch'], '-rc')))
         env:
           GPG_PASSPHRASE: $(GPG_PASSPHRASE)
           SONATYPE_PASSWORD: $(SONATYPE_PASSWORD)

--- a/buildlib/jucx/jucx-build.yml
+++ b/buildlib/jucx/jucx-build.yml
@@ -97,7 +97,7 @@ jobs:
               JUCX_VERSION=${MAVEN_VERSION}${SUFFIX}
         displayName: Publish-Maven
         # rc tags carry the final maven version - skip to keep it for GA
-        condition: and(eq(variables['Build.Reason'], 'IndividualCI'), not(contains(variables['Build.SourceBranch'], '-rc')))
+        condition: and(in(variables['Build.Reason'], 'IndividualCI', 'PullRequest'), not(contains(variables['Build.SourceBranch'], '-rc')))
         env:
           GPG_PASSPHRASE: $(GPG_PASSPHRASE)
           SONATYPE_PASSWORD: $(SONATYPE_PASSWORD)


### PR DESCRIPTION
## What?
Point the JUCX `snapshotRepository` at the Central Portal snapshot repo.

## Why?
Every master snapshot publish fails: the `ossrh-staging-api` shim only serves the staging deploy endpoint and returns 400 for the snapshots path. Releases keep using the staging endpoint and are unaffected.

## How?
One-line URL change in `bindings/java/pom.xml.in`. Verified by letting Publish-Maven run on this PR via a temporary commit (reverted in the same PR): both arches deployed in [build 134127](https://dev.azure.com/ucfconsort/ucx/_build/results?buildId=134127&view=logs&j=63c6b53b-67c9-50a3-0a67-f7e911956bf3&t=cf9a9368-6788-584f-400e-578b0d707aeb&l=505), artifacts live at [maven-snapshots/org/openucx/jucx](https://central.sonatype.com/repository/maven-snapshots/org/openucx/jucx/).