### PR TITLE
CI: add ROCm 7.14 (Ubuntu 24.04) and ROCm 10.0 (Ubuntu 26.04) builds

### DIFF
--- a/.ci/pipeline/build_matrix.yaml
+++ b/.ci/pipeline/build_matrix.yaml
@@ -37,6 +37,8 @@ runs_on_dockers:
   - { name: "tencentos44-mofed26.04", url: "harbor.mellanox.com/hpcx/x86_64/tencentos4.4/builder:mofed-26.04-0.7.6.0", arch: x86_64 }
   - { name: "ubuntu2004-rocm5.4", url: "harbor.mellanox.com/ucx/x86_64/ubuntu2004:rocm_5_4_0", arch: x86_64 }
   - { name: "ubuntu2204-rocm6.0", url: "harbor.mellanox.com/ucx/x86_64/ubuntu2204:rocm-6.0.0", arch: x86_64 }
+  - { name: "ubuntu2404-rocm7.14", url: "rocm/dev-ubuntu-24.04:7.14.0-full", arch: x86_64 }
+  - { name: "ubuntu2604-rocm10.0", url: "rocm/dev-ubuntu-26.04:10.0.0-full", arch: x86_64 }
   # aarch64
   - { name: "ubuntu2404-doca2.9", url: "harbor.mellanox.com/hpcx/aarch64/ubuntu24.04/builder:doca-2.9.0", arch: aarch64 }
   - { name: "ubuntu2604-mofed26.04", url: "harbor.mellanox.com/hpcx/aarch64/ubuntu26.04/builder:mofed-26.04-0.7.6.0", arch: aarch64 }

--- a/buildlib/pr/build_job.yml
+++ b/buildlib/pr/build_job.yml
@@ -87,6 +87,12 @@ jobs:
           ubuntu2204_rocm:
             CONTAINER: ubuntu2204_rocm_6_0_0
             build_mode: short
+          ubuntu2404_rocm:
+            CONTAINER: ubuntu2404_rocm_7_14_0
+            build_mode: short
+          ubuntu2604_rocm:
+            CONTAINER: ubuntu2604_rocm_10_0_0
+            build_mode: short
           kylin10sp3:
             CONTAINER: kylin10sp3
             build_mode: short

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -254,6 +254,12 @@ resources:
     - container: ubuntu2204_rocm_6_0_0
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu2204:rocm-6.0.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: ubuntu2404_rocm_7_14_0
+      image: rocm/dev-ubuntu-24.04:7.14.0-full
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: ubuntu2604_rocm_10_0_0
+      image: rocm/dev-ubuntu-26.04:10.0.0-full
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: kylin10sp3
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/kylin10sp3/builder:doca-2.9.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)


### PR DESCRIPTION

## What?
Add ubuntu2404_rocm_7_14_0 and ubuntu2604_rocm_10_0_0 container entries to the Azure Pipelines and Jenkins/Blossom CI pipelines, using the upstream rocm/dev-ubuntu-24.04:7.14.0-full and rocm/dev-ubuntu-26.04:10.0.0-full images respectively.

## Why?
test newer distros and rocm releases with UCX


