### PR TITLE
UCP/FT: Hand token-capable UCT endpoints to failover

### DIFF
--- a/src/ucp/Makefile.am
+++ b/src/ucp/Makefile.am
@@ -32,6 +32,7 @@ noinst_HEADERS = \
 	core/ucp_ep.h \
 	core/ucp_ep.inl \
 	core/ucp_ep_vfs.h \
+	core/ucp_ep_failover.h \
 	core/ucp_listener.h \
 	core/ucp_mm.h \
 	core/ucp_mm.inl \
@@ -114,6 +115,7 @@ libucp_la_SOURCES = \
 	core/ucp_am.c \
 	core/ucp_ep.c \
 	core/ucp_ep_vfs.c \
+	core/ucp_ep_failover.c \
 	core/ucp_listener.c \
 	core/ucp_mm.c \
 	core/ucp_proxy_ep.c \

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -552,7 +552,7 @@ void ucp_ep_destroy_base(ucp_ep_h ep)
     ucp_worker_keepalive_remove_ep(ep);
     ucp_ep_release_id(ep);
     ucs_list_del(&ep->ext->ep_list);
-    if (!ucp_ep_has_cm_lane(ep) && (ep->ext->recovery_arg != NULL)) {
+    if (ucp_ep_get_recovery_arg(ep) != NULL) {
         ucp_ep_recovery_arg_free(ep);
     }
 

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -18,6 +18,7 @@
 
 #include <ucp/wireup/wireup_ep.h>
 #include <ucp/wireup/wireup.h>
+#include <ucp/core/ucp_ep_failover.h>
 #include <ucp/wireup/wireup_cm.h>
 #include <ucp/tag/eager.h>
 #include <ucp/tag/offload.h>
@@ -223,6 +224,7 @@ void ucp_ep_config_key_reset(ucp_ep_config_key_t *key)
 
 static void ucp_ep_deallocate(ucp_ep_h ep)
 {
+    ucp_ep_failover_cleanup(ep);
     UCS_STATS_NODE_FREE(ep->stats);
     ucs_free(ep->ext->uct_eps);
     ucs_free(ep->ext);
@@ -1536,12 +1538,14 @@ static void ucp_ep_failed_destroy(uct_ep_h ep)
 
 static void ucp_ep_discard_lanes(ucp_ep_h ep, ucp_lane_map_t lanes,
                                  ucs_status_t discard_status,
-                                 ucp_worker_cfg_index_t old_cfg_index)
+                                 ucp_worker_cfg_index_t old_cfg_index,
+                                 ucp_lane_map_t *failover_lanes_p)
 {
     unsigned ep_flush_flags         = ucp_ep_config_err_handling_enabled(ep) ?
                                       UCT_FLUSH_FLAG_CANCEL :
                                       UCT_FLUSH_FLAG_LOCAL;
     uct_ep_h uct_eps[UCP_MAX_LANES] = { NULL };
+    ucp_lane_map_t discard_lanes    = lanes;
     ucp_ep_discard_lanes_arg_t *discard_arg;
     ucs_status_t status;
     ucp_lane_index_t lane;
@@ -1584,7 +1588,27 @@ static void ucp_ep_discard_lanes(ucp_ep_h ep, ucp_lane_map_t lanes,
 
     ucs_debug("ep %p: discarding lanes", ep);
     ucp_ep_extract_failed_lanes(ep, lanes, &discard_arg->failed_ep, uct_eps);
-    ucs_for_each_bit(lane, lanes) {
+
+    if (failover_lanes_p != NULL) {
+        status = ucp_ep_failover_add_lanes(ep, lanes, uct_eps,
+                                           ucp_ep_discard_lanes_callback,
+                                           discard_arg, failover_lanes_p);
+        if ((status != UCS_OK) && (status != UCS_ERR_UNSUPPORTED)) {
+            ucs_debug("ep %p: failed to start failover for lanes 0x%lx: %s", ep,
+                      lanes, ucs_status_string(status));
+        }
+
+        ucs_assert((*failover_lanes_p == 0) || (*failover_lanes_p == lanes));
+
+        if (*failover_lanes_p != 0) {
+            /* Keep discard refs until abort (this PR) or extract/replay. */
+            discard_arg->discard_counter += ucs_popcount(*failover_lanes_p);
+            discard_lanes                ^= *failover_lanes_p;
+            ucp_ep_failover_schedule_abort(ep, discard_status);
+        }
+    }
+
+    ucs_for_each_bit(lane, discard_lanes) {
         uct_ep = uct_eps[lane];
         if (uct_ep == NULL) {
             continue;
@@ -1632,12 +1656,15 @@ ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane, ucs_status_t status)
         return UCS_OK;
     }
 
+    /* Drop in-flight failover so worker flush_ops can drain. */
+    ucp_ep_failover_abort(ucp_ep, status);
+
     ++ucp_ep->worker->counters.ep_failures;
 
     /* The EP is unrecoverable - discard ALL lanes, including those already
      * marked UCP_LANE_TYPE_FAILED. */
     ucp_ep_discard_lanes(ucp_ep, UCS_MASK(ucp_ep_num_lanes(ucp_ep)), status,
-                         ucp_ep->cfg_index);
+                         ucp_ep->cfg_index, NULL);
     ucp_stream_ep_cleanup(ucp_ep, status);
 
     if (ucp_ep->flags & UCP_EP_FLAG_USED) {
@@ -2045,15 +2072,20 @@ static void ucp_ep_recovery_arg_free(ucp_ep_h ep)
 {
     ucs_assert(ep->ext->recovery_arg != NULL);
     ucp_ep_refcount_assert(ep, probe, ==, 0);
+    ucp_ep_failover_cleanup(ep);
     ucs_free(ep->ext->recovery_arg);
     ep->ext->recovery_arg = NULL;
 }
 
 static void ucp_ep_recovery_probe_complete(ucp_ep_h ep, ucs_status_t status)
 {
-    if ((status == UCS_OK) && (ep->ext->recovery_arg != NULL)) {
-        ep->ext->recovery_arg->state = UCP_EP_RECOVERY_STATE_PROBE_OK;
+    ucp_ep_recovery_arg_t *arg = ep->ext->recovery_arg;
+
+    if ((status != UCS_OK) || (arg == NULL)) {
+        return;
     }
+
+    arg->recovery.state = UCP_EP_RECOVERY_STATE_PROBE_OK;
 }
 
 static void ucp_ep_recovery_probe_comp(uct_completion_t *self)
@@ -2072,7 +2104,7 @@ static void ucp_ep_recovery_probe_comp(uct_completion_t *self)
 static ucs_status_t
 ucp_ep_recovery_arm_probe(ucp_ep_h ep, ucp_lane_index_t lane, uct_ep_h aux_ep)
 {
-    ucp_ep_recovery_probe_t *probe = &ep->ext->recovery_arg->probe[lane];
+    ucp_ep_recovery_probe_t *probe = &ep->ext->recovery_arg->recovery.probe[lane];
     ucs_status_t status;
 
     ucs_assert(aux_ep != NULL);
@@ -2144,7 +2176,7 @@ ucp_ep_recovery_rebuild_p2p_lane(
 
     wireup_ep = ucp_wireup_ep(ucp_ep_get_lane(ep, lane));
     ucs_assert(wireup_ep != NULL);
-    probe = &ep->ext->recovery_arg->probe[lane];
+    probe = &ep->ext->recovery_arg->recovery.probe[lane];
 
     status = ucp_ep_recovery_probe_status(probe);
     if (status == UCS_INPROGRESS) {
@@ -2337,8 +2369,8 @@ ucs_status_t ucp_ep_recovery_arm(ucp_ep_h ep)
     }
 
     /* Reset counter by new event. */
-    arg->retries_left = context->config.ext.recovery_retries;
-    arg->state        = UCP_EP_RECOVERY_STATE_IDLE;
+    arg->recovery.retries_left = context->config.ext.recovery_retries;
+    arg->recovery.state        = UCP_EP_RECOVERY_STATE_IDLE;
     return UCS_OK;
 }
 
@@ -2350,15 +2382,16 @@ void ucp_ep_recovery_on_reply_received(ucp_ep_h ep)
         return;
     }
 
-    if (arg->state == UCP_EP_RECOVERY_STATE_WAIT_REPLY) {
-        arg->state = UCP_EP_RECOVERY_STATE_PROBING;
+    if (arg->recovery.state == UCP_EP_RECOVERY_STATE_WAIT_REPLY) {
+        arg->recovery.state = UCP_EP_RECOVERY_STATE_PROBING;
     }
 }
 
 int ucp_ep_recovery_progress(ucp_ep_h ep)
 {
-    ucp_worker_h worker = ep->worker;
-    int ret             = 0;
+    ucp_worker_h worker        = ep->worker;
+    int ret                    = 0;
+    ucp_ep_recovery_arg_t *arg;
     ucp_lane_map_t failed, recovered;
     ucp_lane_index_t lane;
     ucp_wireup_ep_t *wireup_ep;
@@ -2385,11 +2418,19 @@ int ucp_ep_recovery_progress(ucp_ep_h ep)
         goto done;
     }
 
-    if (ep->ext->recovery_arg == NULL) {
+    arg = ep->ext->recovery_arg;
+    if (arg == NULL) {
         goto done;
     }
 
-    ucs_assert(ep->ext->recovery_arg->retries_left > 0);
+    if (arg->failover.lane_map != 0) {
+        goto done;
+    }
+
+    if (arg->recovery.retries_left == 0) {
+        ucp_ep_recovery_arg_free(ep);
+        goto done;
+    }
 
     recovered = ucp_ep_recovery_get_ready_lanes(ep, failed);
     status    = ucp_ep_reconfig_clear_failed_lanes(ep, recovered);
@@ -2410,10 +2451,10 @@ int ucp_ep_recovery_progress(ucp_ep_h ep)
         goto done;
     }
 
-    if (ep->ext->recovery_arg->state == UCP_EP_RECOVERY_STATE_WAIT_REPLY) {
+    if (arg->recovery.state == UCP_EP_RECOVERY_STATE_WAIT_REPLY) {
         /* No reply within a keepalive interval - count as a failed round. */
-        ep->ext->recovery_arg->state = UCP_EP_RECOVERY_STATE_IDLE;
-        if (--ep->ext->recovery_arg->retries_left == 0) {
+        arg->recovery.state = UCP_EP_RECOVERY_STATE_IDLE;
+        if (--arg->recovery.retries_left == 0) {
             goto exhausted;
         }
 
@@ -2421,11 +2462,10 @@ int ucp_ep_recovery_progress(ucp_ep_h ep)
         goto done;
     }
 
-    if ((ep->ext->recovery_arg->state == UCP_EP_RECOVERY_STATE_PROBING) ||
-        (ep->ext->recovery_arg->state == UCP_EP_RECOVERY_STATE_PROBE_OK)) {
+    if ((arg->recovery.state == UCP_EP_RECOVERY_STATE_PROBING) ||
+        (arg->recovery.state == UCP_EP_RECOVERY_STATE_PROBE_OK)) {
         for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-            status = ucp_ep_recovery_probe_status(
-                    &ep->ext->recovery_arg->probe[lane]);
+            status = ucp_ep_recovery_probe_status(&arg->recovery.probe[lane]);
             if (status == UCS_INPROGRESS) {
                 ret = 1;
                 goto done;
@@ -2445,16 +2485,16 @@ int ucp_ep_recovery_progress(ucp_ep_h ep)
             }
         }
 
-        if (ep->ext->recovery_arg->state == UCP_EP_RECOVERY_STATE_PROBE_OK) {
+        if (arg->recovery.state == UCP_EP_RECOVERY_STATE_PROBE_OK) {
             /* Consume a successful probe without burning a retry. The next
              * IDLE round re-enters address exchange so rebuild can connect. */
-            ep->ext->recovery_arg->state = UCP_EP_RECOVERY_STATE_IDLE;
-            ret                          = 1;
+            arg->recovery.state = UCP_EP_RECOVERY_STATE_IDLE;
+            ret                 = 1;
             goto done;
         }
 
-        ep->ext->recovery_arg->state = UCP_EP_RECOVERY_STATE_IDLE;
-        if (--ep->ext->recovery_arg->retries_left == 0) {
+        arg->recovery.state = UCP_EP_RECOVERY_STATE_IDLE;
+        if (--arg->recovery.retries_left == 0) {
             goto exhausted;
         }
 
@@ -2463,14 +2503,14 @@ int ucp_ep_recovery_progress(ucp_ep_h ep)
     }
 
     ucs_debug("ep %p: recovery round (retries_left=%u, failed=0x%" PRIx64 ")",
-              ep, ep->ext->recovery_arg->retries_left, (uint64_t)failed);
+              ep, arg->recovery.retries_left, (uint64_t)failed);
 
-    ucs_assert(ep->ext->recovery_arg->state == UCP_EP_RECOVERY_STATE_IDLE);
-    ep->ext->recovery_arg->state = UCP_EP_RECOVERY_STATE_WAIT_REPLY;
+    ucs_assert(arg->recovery.state == UCP_EP_RECOVERY_STATE_IDLE);
+    arg->recovery.state = UCP_EP_RECOVERY_STATE_WAIT_REPLY;
     if (ucp_ep_recovery_send_request(ep)) {
         ret = 1;
     } else {
-        ep->ext->recovery_arg->state = UCP_EP_RECOVERY_STATE_IDLE;
+        arg->recovery.state = UCP_EP_RECOVERY_STATE_IDLE;
     }
 
     goto done;
@@ -2484,7 +2524,7 @@ exhausted:
         ucs_diag("ep %p: recovery retries exhausted, giving up on "
                     "failed lanes 0x%" PRIx64, ep, (uint64_t)failed);
         ucp_ep_discard_lanes(ep, failed, UCS_ERR_ENDPOINT_TIMEOUT,
-                             ep->cfg_index);
+                             ep->cfg_index, NULL);
         ucp_ep_recovery_arg_free(ep);
         ret = 1;
     }
@@ -2499,6 +2539,7 @@ ucp_ep_failover_reconfig(ucp_ep_h ucp_ep, ucp_lane_map_t failed_lanes,
                          ucs_status_t discard_status)
 {
     ucp_worker_cfg_index_t old_cfg_index = ucp_ep->cfg_index;
+    ucp_lane_map_t failover_lanes        = 0;
     ucs_status_t status;
 
     if (ucp_ep->flags & UCP_EP_FLAG_FAILED) {
@@ -2516,11 +2557,19 @@ ucp_ep_failover_reconfig(ucp_ep_h ucp_ep, ucp_lane_map_t failed_lanes,
                     ucp_ep, old_cfg_index, ucp_ep->cfg_index,
                     ucs_status_string(status));
         /* No AM lane (or other reconfig failure): fail the whole EP so all
-         * lanes are discarded and flush can complete. Do not arm recovery. */
+         * lanes are discarded and flush can complete. Do not arm recovery.
+         * Abort any already-armed failover from earlier lane failures. */
+        ucp_ep_failover_abort(ucp_ep, status);
         return status;
     }
 
-    ucp_ep_discard_lanes(ucp_ep, failed_lanes, discard_status, old_cfg_index);
+    ucp_ep_discard_lanes(ucp_ep, failed_lanes, discard_status, old_cfg_index,
+                         &failover_lanes);
+    if (failover_lanes != 0) {
+        /* Token failover owns the UCT eps; arm ADDR recovery after abort. */
+        return UCS_OK;
+    }
+
     return ucp_ep_recovery_arm(ucp_ep);
 }
 
@@ -2753,7 +2802,7 @@ ucs_status_ptr_t ucp_ep_close_nbx(ucp_ep_h ep, const ucp_request_param_t *param)
 
     if (ucp_request_param_flags(param) & UCP_EP_CLOSE_FLAG_FORCE) {
         ucp_ep_discard_lanes(ep, UCS_MASK(ucp_ep_num_lanes(ep)),
-                             UCS_ERR_CANCELED, ep->cfg_index);
+                             UCS_ERR_CANCELED, ep->cfg_index, NULL);
         ucp_ep_disconnected(ep, 1);
     } else {
         request = ucp_ep_flush_internal(ep, 0, param, NULL,

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1535,19 +1535,13 @@ static void ucp_ep_failed_destroy(uct_ep_h ep)
     ucp_ep_release_discard_arg(arg);
 }
 
-static void ucp_ep_discard_lanes(ucp_ep_h ep, ucp_lane_map_t lanes,
-                                 ucs_status_t discard_status,
-                                 ucp_worker_cfg_index_t old_cfg_index,
-                                 ucp_lane_map_t *failover_lanes_p)
+static ucp_ep_discard_lanes_arg_t *
+ucp_ep_discard_lanes_begin(ucp_ep_h ep, ucp_lane_map_t lanes,
+                           ucs_status_t discard_status,
+                           ucp_worker_cfg_index_t old_cfg_index,
+                           uct_ep_h *uct_eps)
 {
-    unsigned ep_flush_flags         = ucp_ep_config_err_handling_enabled(ep) ?
-                                      UCT_FLUSH_FLAG_CANCEL :
-                                      UCT_FLUSH_FLAG_LOCAL;
-    uct_ep_h uct_eps[UCP_MAX_LANES] = { NULL };
     ucp_ep_discard_lanes_arg_t *discard_arg;
-    ucs_status_t status;
-    ucp_lane_index_t lane;
-    uct_ep_h uct_ep;
 
     if (ep->flags & UCP_EP_FLAG_FAILED) {
         /* Avoid calling ucp_ep_discard_lanes_callback() that will purge UCP
@@ -1556,7 +1550,7 @@ static void ucp_ep_discard_lanes(ucp_ep_h ep, ucp_lane_map_t lanes,
          * using them are flushed and destroyed. */
         ucp_ep_config_reactivate_worker_ifaces(ep->worker, old_cfg_index,
                                                ep->cfg_index);
-        return;
+        return NULL;
     }
 
     discard_arg = ucs_malloc(sizeof(*discard_arg), "discard_lanes_arg");
@@ -1565,7 +1559,7 @@ static void ucp_ep_discard_lanes(ucp_ep_h ep, ucp_lane_map_t lanes,
                   " argument", ep);
         ucp_ep_cleanup_lanes(ep); /* Just close all UCT endpoints */
         ucp_ep_reqs_purge(ep, discard_status);
-        return;
+        return NULL;
     }
 
     discard_arg->failed_ep.iface      = ucp_failed_tl_iface_get();
@@ -1586,43 +1580,57 @@ static void ucp_ep_discard_lanes(ucp_ep_h ep, ucp_lane_map_t lanes,
 
     ucs_debug("ep %p: discarding lanes", ep);
     ucp_ep_extract_failed_lanes(ep, lanes, &discard_arg->failed_ep, uct_eps);
+    return discard_arg;
+}
 
-    if (failover_lanes_p != NULL) {
-        *failover_lanes_p = 0;
-        status            = ucp_ep_failover_add_lanes(
-                ep, lanes, uct_eps, ucp_ep_discard_lanes_callback,
-                discard_arg);
-        if (status == UCS_OK) {
-            /* Keep discard refs until abort or extract/replay. */
-            *failover_lanes_p             = lanes;
-            discard_arg->discard_counter += ucs_popcount(lanes);
-        } else if (status != UCS_ERR_UNSUPPORTED) {
-            ucs_debug("ep %p: failed to start failover for lanes 0x%lx: %s", ep,
-                      lanes, ucs_status_string(status));
+static void
+ucp_ep_discard_extracted_uct_eps(ucp_ep_h ep, ucp_lane_map_t lanes,
+                                 uct_ep_h *uct_eps, unsigned ep_flush_flags,
+                                 ucs_status_t discard_status,
+                                 ucp_ep_discard_lanes_arg_t *discard_arg)
+{
+    ucp_lane_index_t lane;
+    uct_ep_h uct_ep;
+    ucs_status_t status;
+
+    ucs_for_each_bit(lane, lanes) {
+        uct_ep = uct_eps[lane];
+        if (uct_ep == NULL) {
+            continue;
+        }
+
+        ucs_debug("ep %p: discard uct_ep[%d]=%p", ep, lane, uct_ep);
+        status = ucp_worker_discard_uct_ep(ep, uct_ep,
+                                           ucp_ep_get_rsc_index(ep, lane),
+                                           ep_flush_flags,
+                                           ucp_ep_err_pending_purge,
+                                           UCS_STATUS_PTR(discard_status),
+                                           ucp_ep_discard_lanes_callback,
+                                           discard_arg);
+        if (status == UCS_INPROGRESS) {
+            ++discard_arg->discard_counter;
         }
     }
+}
 
-    if ((failover_lanes_p == NULL) || (*failover_lanes_p == 0)) {
-        ucs_for_each_bit(lane, lanes) {
-            uct_ep = uct_eps[lane];
-            if (uct_ep == NULL) {
-                continue;
-            }
+static void ucp_ep_discard_lanes(ucp_ep_h ep, ucp_lane_map_t lanes,
+                                 ucs_status_t discard_status,
+                                 ucp_worker_cfg_index_t old_cfg_index)
+{
+    unsigned ep_flush_flags         = ucp_ep_config_err_handling_enabled(ep) ?
+                                      UCT_FLUSH_FLAG_CANCEL :
+                                      UCT_FLUSH_FLAG_LOCAL;
+    uct_ep_h uct_eps[UCP_MAX_LANES] = { NULL };
+    ucp_ep_discard_lanes_arg_t *discard_arg;
 
-            ucs_debug("ep %p: discard uct_ep[%d]=%p", ep, lane, uct_ep);
-            status = ucp_worker_discard_uct_ep(ep, uct_ep,
-                                               ucp_ep_get_rsc_index(ep, lane),
-                                               ep_flush_flags,
-                                               ucp_ep_err_pending_purge,
-                                               UCS_STATUS_PTR(discard_status),
-                                               ucp_ep_discard_lanes_callback,
-                                               discard_arg);
-            if (status == UCS_INPROGRESS) {
-                ++discard_arg->discard_counter;
-            }
-        }
+    discard_arg = ucp_ep_discard_lanes_begin(ep, lanes, discard_status,
+                                             old_cfg_index, uct_eps);
+    if (discard_arg == NULL) {
+        return;
     }
 
+    ucp_ep_discard_extracted_uct_eps(ep, lanes, uct_eps, ep_flush_flags,
+                                     discard_status, discard_arg);
     ucp_ep_discard_lanes_callback(NULL, UCS_OK, discard_arg);
 }
 
@@ -1660,7 +1668,7 @@ ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane, ucs_status_t status)
     /* The EP is unrecoverable - discard ALL lanes, including those already
      * marked UCP_LANE_TYPE_FAILED. */
     ucp_ep_discard_lanes(ucp_ep, UCS_MASK(ucp_ep_num_lanes(ucp_ep)), status,
-                         ucp_ep->cfg_index, NULL);
+                         ucp_ep->cfg_index);
     ucp_stream_ep_cleanup(ucp_ep, status);
 
     if (ucp_ep->flags & UCP_EP_FLAG_USED) {
@@ -2520,7 +2528,7 @@ exhausted:
         ucs_diag("ep %p: recovery retries exhausted, giving up on "
                     "failed lanes 0x%" PRIx64, ep, (uint64_t)failed);
         ucp_ep_discard_lanes(ep, failed, UCS_ERR_ENDPOINT_TIMEOUT,
-                             ep->cfg_index, NULL);
+                             ep->cfg_index);
         ucp_ep_recovery_arg_free(ep);
         ret = 1;
     }
@@ -2534,8 +2542,10 @@ ucs_status_t
 ucp_ep_failover_reconfig(ucp_ep_h ucp_ep, ucp_lane_map_t failed_lanes,
                          ucs_status_t discard_status)
 {
+    uct_ep_h uct_eps[UCP_MAX_LANES]      = { NULL };
     ucp_worker_cfg_index_t old_cfg_index = ucp_ep->cfg_index;
-    ucp_lane_map_t failover_lanes        = 0;
+    unsigned ep_flush_flags;
+    ucp_ep_discard_lanes_arg_t *discard_arg;
     ucs_status_t status;
 
     if (ucp_ep->flags & UCP_EP_FLAG_FAILED) {
@@ -2559,14 +2569,36 @@ ucp_ep_failover_reconfig(ucp_ep_h ucp_ep, ucp_lane_map_t failed_lanes,
         return status;
     }
 
-    ucp_ep_discard_lanes(ucp_ep, failed_lanes, discard_status, old_cfg_index,
-                         &failover_lanes);
-    if (failover_lanes != 0) {
+    discard_arg = ucp_ep_discard_lanes_begin(ucp_ep, failed_lanes,
+                                             discard_status, old_cfg_index,
+                                             uct_eps);
+    if (discard_arg == NULL) {
+        return UCS_OK;
+    }
+
+    status = ucp_ep_failover_add_lanes(ucp_ep, failed_lanes, uct_eps,
+                                       ucp_ep_discard_lanes_callback,
+                                       discard_arg);
+    if (status == UCS_OK) {
+        /* Keep discard refs until abort or extract/replay. */
+        discard_arg->discard_counter += ucs_popcount(failed_lanes);
+        ucp_ep_discard_lanes_callback(NULL, UCS_OK, discard_arg);
         /* Token failover owns the UCT eps; arm ADDR recovery after abort. */
         ucp_ep_failover_schedule_abort(ucp_ep, discard_status);
         return UCS_OK;
     }
 
+    if (status != UCS_ERR_UNSUPPORTED) {
+        ucs_debug("ep %p: failed to start failover for lanes 0x%lx: %s",
+                  ucp_ep, failed_lanes, ucs_status_string(status));
+    }
+
+    ep_flush_flags = ucp_ep_config_err_handling_enabled(ucp_ep) ?
+                     UCT_FLUSH_FLAG_CANCEL : UCT_FLUSH_FLAG_LOCAL;
+    ucp_ep_discard_extracted_uct_eps(ucp_ep, failed_lanes, uct_eps,
+                                     ep_flush_flags, discard_status,
+                                     discard_arg);
+    ucp_ep_discard_lanes_callback(NULL, UCS_OK, discard_arg);
     return ucp_ep_recovery_arm(ucp_ep);
 }
 
@@ -2799,7 +2831,7 @@ ucs_status_ptr_t ucp_ep_close_nbx(ucp_ep_h ep, const ucp_request_param_t *param)
 
     if (ucp_request_param_flags(param) & UCP_EP_CLOSE_FLAG_FORCE) {
         ucp_ep_discard_lanes(ep, UCS_MASK(ucp_ep_num_lanes(ep)),
-                             UCS_ERR_CANCELED, ep->cfg_index, NULL);
+                             UCS_ERR_CANCELED, ep->cfg_index);
         ucp_ep_disconnected(ep, 1);
     } else {
         request = ucp_ep_flush_internal(ep, 0, param, NULL,

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -224,7 +224,6 @@ void ucp_ep_config_key_reset(ucp_ep_config_key_t *key)
 
 static void ucp_ep_deallocate(ucp_ep_h ep)
 {
-    ucp_ep_failover_cleanup(ep);
     UCS_STATS_NODE_FREE(ep->stats);
     ucs_free(ep->ext->uct_eps);
     ucs_free(ep->ext);
@@ -1545,7 +1544,6 @@ static void ucp_ep_discard_lanes(ucp_ep_h ep, ucp_lane_map_t lanes,
                                       UCT_FLUSH_FLAG_CANCEL :
                                       UCT_FLUSH_FLAG_LOCAL;
     uct_ep_h uct_eps[UCP_MAX_LANES] = { NULL };
-    ucp_lane_map_t discard_lanes    = lanes;
     ucp_ep_discard_lanes_arg_t *discard_arg;
     ucs_status_t status;
     ucp_lane_index_t lane;
@@ -1590,40 +1588,38 @@ static void ucp_ep_discard_lanes(ucp_ep_h ep, ucp_lane_map_t lanes,
     ucp_ep_extract_failed_lanes(ep, lanes, &discard_arg->failed_ep, uct_eps);
 
     if (failover_lanes_p != NULL) {
-        status = ucp_ep_failover_add_lanes(ep, lanes, uct_eps,
-                                           ucp_ep_discard_lanes_callback,
-                                           discard_arg, failover_lanes_p);
-        if ((status != UCS_OK) && (status != UCS_ERR_UNSUPPORTED)) {
+        *failover_lanes_p = 0;
+        status            = ucp_ep_failover_add_lanes(
+                ep, lanes, uct_eps, ucp_ep_discard_lanes_callback,
+                discard_arg);
+        if (status == UCS_OK) {
+            /* Keep discard refs until abort or extract/replay. */
+            *failover_lanes_p             = lanes;
+            discard_arg->discard_counter += ucs_popcount(lanes);
+        } else if (status != UCS_ERR_UNSUPPORTED) {
             ucs_debug("ep %p: failed to start failover for lanes 0x%lx: %s", ep,
                       lanes, ucs_status_string(status));
         }
-
-        ucs_assert((*failover_lanes_p == 0) || (*failover_lanes_p == lanes));
-
-        if (*failover_lanes_p != 0) {
-            /* Keep discard refs until abort (this PR) or extract/replay. */
-            discard_arg->discard_counter += ucs_popcount(*failover_lanes_p);
-            discard_lanes                ^= *failover_lanes_p;
-            ucp_ep_failover_schedule_abort(ep, discard_status);
-        }
     }
 
-    ucs_for_each_bit(lane, discard_lanes) {
-        uct_ep = uct_eps[lane];
-        if (uct_ep == NULL) {
-            continue;
-        }
+    if ((failover_lanes_p == NULL) || (*failover_lanes_p == 0)) {
+        ucs_for_each_bit(lane, lanes) {
+            uct_ep = uct_eps[lane];
+            if (uct_ep == NULL) {
+                continue;
+            }
 
-        ucs_debug("ep %p: discard uct_ep[%d]=%p", ep, lane, uct_ep);
-        status = ucp_worker_discard_uct_ep(ep, uct_ep,
-                                           ucp_ep_get_rsc_index(ep, lane),
-                                           ep_flush_flags,
-                                           ucp_ep_err_pending_purge,
-                                           UCS_STATUS_PTR(discard_status),
-                                           ucp_ep_discard_lanes_callback,
-                                           discard_arg);
-        if (status == UCS_INPROGRESS) {
-            ++discard_arg->discard_counter;
+            ucs_debug("ep %p: discard uct_ep[%d]=%p", ep, lane, uct_ep);
+            status = ucp_worker_discard_uct_ep(ep, uct_ep,
+                                               ucp_ep_get_rsc_index(ep, lane),
+                                               ep_flush_flags,
+                                               ucp_ep_err_pending_purge,
+                                               UCS_STATUS_PTR(discard_status),
+                                               ucp_ep_discard_lanes_callback,
+                                               discard_arg);
+            if (status == UCS_INPROGRESS) {
+                ++discard_arg->discard_counter;
+            }
         }
     }
 
@@ -2567,6 +2563,7 @@ ucp_ep_failover_reconfig(ucp_ep_h ucp_ep, ucp_lane_map_t failed_lanes,
                          &failover_lanes);
     if (failover_lanes != 0) {
         /* Token failover owns the UCT eps; arm ADDR recovery after abort. */
+        ucp_ep_failover_schedule_abort(ucp_ep, discard_status);
         return UCS_OK;
     }
 

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -508,12 +508,27 @@ enum {
 };
 
 
-/* Per-EP recovery retry state. */
+/* Per failed-lane context while failover owns the UCT endpoint. */
+typedef struct ucp_ep_failover_lane {
+    uct_ep_h                uct_ep;
+    ucp_rsc_index_t         rsc_index;
+    ucp_send_nbx_callback_t done_cb;
+    void                    *done_arg;
+} ucp_ep_failover_lane_t;
+
+
+/* Per-EP recovery and token-failover state. */
 typedef struct ucp_ep_recovery_arg {
-    /* number of retries left before giving up */
-    unsigned                retries_left;
-    uint8_t                 state;
-    ucp_ep_recovery_probe_t probe[UCP_MAX_LANES];
+    struct {
+        uint8_t                 state;
+        unsigned                retries_left;
+        ucp_ep_recovery_probe_t probe[UCP_MAX_LANES];
+    } recovery;
+    struct {
+        ucp_lane_map_t         lane_map;
+        ucs_status_t           status;
+        ucp_ep_failover_lane_t lanes[UCP_MAX_LANES];
+    } failover;
 } ucp_ep_recovery_arg_t;
 
 
@@ -530,10 +545,14 @@ typedef struct ucp_ep_ext {
     ucp_err_handler_cb_t          err_cb;        /* Error handler */
     union {
         ucp_request_t             *close_req;    /* Close protocol request */
-        ucp_ep_recovery_arg_t     *recovery_arg; /* Lanes recovery state object.
-                                                    United with close request since:
-                                                    1) recovery is not supported for connected to sockaddr EPs
-                                                    2) it does not make sense to recover lanes during close protocol */
+        ucp_ep_recovery_arg_t     *recovery_arg; /* Recovery and token-failover
+                                                    state. United with close
+                                                    request since:
+                                                    1) recovery is not supported
+                                                       for sockaddr EPs
+                                                    2) it does not make sense to
+                                                       recover or failover during
+                                                       close */
     };
     khash_t(ucp_ep_peer_mem_hash) *peer_mem;     /* Hash of remote memory segments
                                                     used by 2-stage ppln rndv proto */

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -272,6 +272,18 @@ static inline int ucp_ep_has_cm_lane(ucp_ep_h ep)
            ucp_ep_config_key_has_cm_lane(&ucp_ep_config(ep)->key);
 }
 
+/* recovery_arg shares a union with close_req. Sockaddr EPs store close_req
+ * there, so recovery/failover must not dereference the pointer. */
+static UCS_F_ALWAYS_INLINE ucp_ep_recovery_arg_t *
+ucp_ep_get_recovery_arg(ucp_ep_h ep)
+{
+    if (ucp_ep_has_cm_lane(ep)) {
+        return NULL;
+    }
+
+    return ep->ext->recovery_arg;
+}
+
 static UCS_F_ALWAYS_INLINE ucp_lane_index_t ucp_ep_get_cm_lane(ucp_ep_h ep)
 {
     return ucp_ep_config(ep)->key.cm_lane;

--- a/src/ucp/core/ucp_ep_failover.c
+++ b/src/ucp/core/ucp_ep_failover.c
@@ -40,20 +40,20 @@ static int ucp_ep_failover_is_token_supported(uct_ep_h uct_ep)
            (attr.tx_token_length > 0) && (attr.tx_token_length <= UINT8_MAX);
 }
 
-int ucp_ep_failover_in_progress(ucp_ep_h ep)
+int ucp_ep_failover_in_progress(ucp_ep_h ep, ucp_lane_index_t lane)
 {
     const ucp_ep_recovery_arg_t *rec;
 
     ucs_assert(ep->ext != NULL);
-    rec = ep->ext->recovery_arg;
-    return (rec != NULL) && (rec->failover.lane_map != 0);
+    rec = ucp_ep_get_recovery_arg(ep);
+    return (rec != NULL) && (rec->failover.lane_map & UCS_BIT(lane));
 }
 
 static void ucp_ep_failover_lane_close(ucp_ep_h ep,
                                        ucp_lane_index_t lane_index,
                                        ucs_status_t discard_status)
 {
-    ucp_ep_recovery_arg_t *arg = ep->ext->recovery_arg;
+    ucp_ep_recovery_arg_t *arg = ucp_ep_get_recovery_arg(ep);
     ucp_worker_h worker        = ep->worker;
     ucp_ep_failover_lane_t *lane;
     ucp_send_nbx_callback_t done_cb;
@@ -108,13 +108,12 @@ static unsigned ucp_ep_failover_progress_cb(void *arg)
     ucp_ep_recovery_arg_t *rec;
 
     UCS_ASYNC_BLOCK(&worker->async);
-    rec = ep->ext->recovery_arg;
+    rec = ucp_ep_get_recovery_arg(ep);
     if ((rec != NULL) && (rec->failover.lane_map != 0)) {
         ucp_ep_failover_abort(ep, rec->failover.status);
         if (!(ep->flags & UCP_EP_FLAG_FAILED)) {
             ucp_ep_recovery_arm(ep);
         }
-
     }
 
     UCS_ASYNC_UNBLOCK(&worker->async);
@@ -135,9 +134,10 @@ ucp_ep_failover_add_lanes(ucp_ep_h ep, ucp_lane_map_t lane_map,
 
     ucs_assert(ep->ext != NULL);
     ucs_assert(ucp_ep_err_mode_eq(ep, UCP_ERR_HANDLING_MODE_FAILOVER));
+    ucs_assert(!ucp_ep_has_cm_lane(ep));
     ucs_assert(lane_map != 0);
 
-    rec = ep->ext->recovery_arg;
+    rec = ucp_ep_get_recovery_arg(ep);
     ucs_for_each_bit(lane, lane_map) {
         uct_ep = uct_eps[lane];
         if ((ucp_ep_get_rsc_index(ep, lane) == UCP_NULL_RESOURCE) ||
@@ -189,9 +189,11 @@ ucp_ep_failover_add_lanes(ucp_ep_h ep, ucp_lane_map_t lane_map,
 
 void ucp_ep_failover_cleanup(ucp_ep_h ep)
 {
+    const ucp_ep_recovery_arg_t *rec;
+
     ucs_assert(ep->ext != NULL);
-    ucs_assert((ep->ext->recovery_arg == NULL) ||
-               (ep->ext->recovery_arg->failover.lane_map == 0));
+    rec = ucp_ep_get_recovery_arg(ep);
+    ucs_assert((rec == NULL) || (rec->failover.lane_map == 0));
 
     ucs_callbackq_remove_oneshot(&ep->worker->uct->progress_q, ep,
                                  ucp_ep_failover_progress_remove_filter, ep);
@@ -206,7 +208,7 @@ void ucp_ep_failover_abort(ucp_ep_h ep, ucs_status_t status)
     ucs_assert(status != UCS_OK);
     ucs_assert(ep->ext != NULL);
 
-    rec = ep->ext->recovery_arg;
+    rec = ucp_ep_get_recovery_arg(ep);
     if ((rec == NULL) || (rec->failover.lane_map == 0)) {
         return;
     }
@@ -229,16 +231,14 @@ void ucp_ep_failover_schedule_abort(ucp_ep_h ep, ucs_status_t status)
     ucs_assert(status != UCS_OK);
     ucs_assert(ep->ext != NULL);
 
-    rec = ep->ext->recovery_arg;
+    rec = ucp_ep_get_recovery_arg(ep);
     ucs_assert(rec != NULL);
     ucs_assert(rec->failover.lane_map != 0);
 
-    if (rec->failover.status != UCS_OK) {
-        rec->failover.status = status;
-        return;
+    if (rec->failover.status == UCS_OK) {
+        ucs_callbackq_add_oneshot(&ep->worker->uct->progress_q, ep,
+                                  ucp_ep_failover_progress_cb, ep);
     }
 
     rec->failover.status = status;
-    ucs_callbackq_add_oneshot(&ep->worker->uct->progress_q, ep,
-                              ucp_ep_failover_progress_cb, ep);
 }

--- a/src/ucp/core/ucp_ep_failover.c
+++ b/src/ucp/core/ucp_ep_failover.c
@@ -20,7 +20,7 @@
 static unsigned ucp_ep_failover_progress_cb(void *arg);
 
 
-int ucp_ep_failover_is_token_supported(uct_ep_h uct_ep)
+static int ucp_ep_failover_is_token_supported(uct_ep_h uct_ep)
 {
     uct_iface_attr_v2_t attr;
     ucs_status_t status;
@@ -38,6 +38,15 @@ int ucp_ep_failover_is_token_supported(uct_ep_h uct_ep)
 
     return (attr.cap.flags & UCT_IFACE_FLAG_V2_QUERY_TOKEN) &&
            (attr.tx_token_length > 0) && (attr.tx_token_length <= UINT8_MAX);
+}
+
+int ucp_ep_failover_in_progress(ucp_ep_h ep)
+{
+    const ucp_ep_recovery_arg_t *rec;
+
+    ucs_assert(ep->ext != NULL);
+    rec = ep->ext->recovery_arg;
+    return (rec != NULL) && (rec->failover.lane_map != 0);
 }
 
 static void ucp_ep_failover_lane_close(ucp_ep_h ep,

--- a/src/ucp/core/ucp_ep_failover.c
+++ b/src/ucp/core/ucp_ep_failover.c
@@ -1,0 +1,263 @@
+/**
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "ucp_ep_failover.h"
+
+#include <ucp/core/ucp_ep.inl>
+#include <ucp/core/ucp_worker.h>
+#include <ucp/wireup/wireup_ep.h>
+#include <uct/api/v2/uct_v2.h>
+#include <inttypes.h>
+
+
+static unsigned ucp_ep_failover_progress_cb(void *arg);
+
+
+int ucp_ep_failover_is_token_supported(uct_ep_h uct_ep)
+{
+    uct_iface_attr_v2_t attr;
+    ucs_status_t status;
+
+    if ((uct_ep == NULL) || ucp_wireup_ep_test(uct_ep)) {
+        return 0;
+    }
+
+    attr.field_mask = UCT_IFACE_ATTR_FIELD_CAP_FLAGS |
+                      UCT_IFACE_ATTR_FIELD_TX_TOKEN_LENGTH;
+    status          = uct_iface_query_v2(uct_ep->iface, &attr);
+    if (status != UCS_OK) {
+        return 0;
+    }
+
+    return (attr.cap.flags & UCT_IFACE_FLAG_V2_QUERY_TOKEN) &&
+           (attr.tx_token_length > 0) && (attr.tx_token_length <= UINT8_MAX);
+}
+
+static int ucp_ep_failover_lane_token_supported(ucp_ep_h ep, uct_ep_h uct_ep,
+                                                ucp_lane_index_t lane)
+{
+    if (ucp_ep_get_rsc_index(ep, lane) == UCP_NULL_RESOURCE) {
+        return 0;
+    }
+
+    return ucp_ep_failover_is_token_supported(uct_ep);
+}
+
+static void ucp_ep_failover_lane_close(ucp_ep_h ep,
+                                       ucp_lane_index_t lane_index,
+                                       ucs_status_t discard_status)
+{
+    ucp_ep_recovery_arg_t *arg = ep->ext->recovery_arg;
+    ucp_worker_h worker        = ep->worker;
+    ucp_ep_failover_lane_t *lane;
+    ucp_send_nbx_callback_t done_cb;
+    ucp_rsc_index_t rsc_index;
+    uct_ep_h uct_ep;
+    void *done_arg;
+
+    if ((arg == NULL) || !(arg->failover.lane_map & UCS_BIT(lane_index))) {
+        return;
+    }
+
+    lane      = &arg->failover.lanes[lane_index];
+    uct_ep    = lane->uct_ep;
+    rsc_index = lane->rsc_index;
+    done_cb   = lane->done_cb;
+    done_arg  = lane->done_arg;
+
+    ucs_assert(discard_status != UCS_OK);
+    ucs_assert(uct_ep != NULL);
+    ucs_debug("ep %p: closing failover lane %u status %s", ep, lane_index,
+              ucs_status_string(discard_status));
+
+    memset(lane, 0, sizeof(*lane));
+    arg->failover.lane_map &= ~UCS_BIT(lane_index);
+    if (arg->failover.lane_map == 0) {
+        arg->failover.status = UCS_OK;
+    }
+
+    uct_ep_pending_purge(uct_ep, ucp_ep_err_pending_purge,
+                         UCS_STATUS_PTR(discard_status));
+    ucp_ep_unprogress_uct_ep(ep, uct_ep, rsc_index);
+    uct_ep_destroy(uct_ep);
+
+    if (done_cb != NULL) {
+        done_cb(NULL, discard_status, done_arg);
+    }
+
+    ucp_worker_flush_ops_count_add(worker, -1);
+    ucp_ep_refcount_remove(ep, discard);
+}
+
+static int
+ucp_ep_failover_progress_remove_filter(const ucs_callbackq_elem_t *elem,
+                                       void *arg)
+{
+    return (elem->cb == ucp_ep_failover_progress_cb) && (elem->arg == arg);
+}
+
+static unsigned ucp_ep_failover_progress_cb(void *arg)
+{
+    ucp_ep_h ep         = arg;
+    ucp_worker_h worker = ep->worker;
+    ucp_ep_recovery_arg_t *rec;
+
+    UCS_ASYNC_BLOCK(&worker->async);
+    rec = ep->ext->recovery_arg;
+    if ((rec != NULL) && (rec->failover.lane_map != 0)) {
+        ucp_ep_failover_abort(ep, rec->failover.status);
+        if (!(ep->flags & UCP_EP_FLAG_FAILED)) {
+            ucp_ep_recovery_arm(ep);
+        }
+    }
+
+    UCS_ASYNC_UNBLOCK(&worker->async);
+    return 1;
+}
+
+ucs_status_t
+ucp_ep_failover_add_lanes(ucp_ep_h ep, ucp_lane_map_t lane_map,
+                          uct_ep_h *uct_eps, ucp_send_nbx_callback_t cb,
+                          void *arg, ucp_lane_map_t *failover_lanes_p)
+{
+    uct_ep_invalidate_params_t inv_params = {0};
+    ucp_ep_recovery_arg_t *rec;
+    ucp_ep_failover_lane_t *lane_ctx;
+    ucp_lane_index_t lane;
+    uct_ep_h uct_ep;
+    ucs_status_t inv_status;
+
+    *failover_lanes_p = 0;
+    ucs_assert(ep->ext != NULL);
+    ucs_assert(ucp_ep_err_mode_eq(ep, UCP_ERR_HANDLING_MODE_FAILOVER));
+    ucs_assert(lane_map != 0);
+
+    rec = ep->ext->recovery_arg;
+    ucs_for_each_bit(lane, lane_map) {
+        uct_ep = uct_eps[lane];
+        if (!ucp_ep_failover_lane_token_supported(ep, uct_ep, lane) ||
+            ((rec != NULL) && (rec->failover.lane_map & UCS_BIT(lane)))) {
+            return UCS_ERR_UNSUPPORTED;
+        }
+    }
+
+    if (rec == NULL) {
+        rec = ucs_calloc(1, sizeof(*rec), "ucp_ep_recovery_arg");
+        if (rec == NULL) {
+            return UCS_ERR_NO_MEMORY;
+        }
+
+        ep->ext->recovery_arg = rec;
+    }
+
+    ucs_for_each_bit(lane, lane_map) {
+        uct_ep              = uct_eps[lane];
+        lane_ctx            = &rec->failover.lanes[lane];
+        lane_ctx->uct_ep    = uct_ep;
+        lane_ctx->rsc_index = ucp_ep_get_rsc_index(ep, lane);
+        lane_ctx->done_cb   = cb;
+        lane_ctx->done_arg  = arg;
+
+        ucp_ep_refcount_add(ep, discard);
+        ucp_worker_flush_ops_count_add(ep->worker, +1);
+
+        ucs_trace("ep %p: lane %u failover armed", ep, lane);
+        rec->failover.lane_map |= UCS_BIT(lane);
+        *failover_lanes_p      |= UCS_BIT(lane);
+
+        /* Take ownership of the UCT ep so the error handler returns
+         * UCS_INPROGRESS. Invalidate so an unaware peer also gets an
+         * error CQE. Already-ERR QPs may fail modify_qp; that is not
+         * fatal. */
+        inv_status = uct_ep_invalidate(uct_ep, &inv_params);
+        if ((inv_status != UCS_OK) && (inv_status != UCS_ERR_UNSUPPORTED)) {
+            ucs_debug("ep %p: lane %u invalidate: %s", ep, lane,
+                      ucs_status_string(inv_status));
+        }
+    }
+
+    ucs_debug("ep %p: started failover for lanes 0x%" PRIx64, ep,
+              (uint64_t)*failover_lanes_p);
+
+    return UCS_OK;
+}
+
+void ucp_ep_failover_cleanup(ucp_ep_h ep)
+{
+    ucp_ep_recovery_arg_t *rec;
+    ucp_ep_failover_lane_t *lane_ctx;
+    ucp_lane_index_t lane;
+
+    ucs_assert(ep->ext != NULL);
+
+    ucs_callbackq_remove_oneshot(&ep->worker->uct->progress_q, ep,
+                                 ucp_ep_failover_progress_remove_filter, ep);
+
+    rec = ep->ext->recovery_arg;
+    if (rec == NULL) {
+        return;
+    }
+
+    ucs_for_each_bit(lane, rec->failover.lane_map) {
+        lane_ctx = &rec->failover.lanes[lane];
+        ucp_ep_unprogress_uct_ep(ep, lane_ctx->uct_ep, lane_ctx->rsc_index);
+        uct_ep_destroy(lane_ctx->uct_ep);
+        ucp_worker_flush_ops_count_add(ep->worker, -1);
+    }
+
+    rec->failover.lane_map = 0;
+    rec->failover.status   = UCS_OK;
+}
+
+void ucp_ep_failover_abort(ucp_ep_h ep, ucs_status_t status)
+{
+    ucp_ep_recovery_arg_t *rec;
+    ucp_lane_map_t lane_map;
+    ucp_lane_index_t lane;
+
+    ucs_assert(status != UCS_OK);
+    ucs_assert(ep->ext != NULL);
+
+    rec = ep->ext->recovery_arg;
+    if ((rec == NULL) || (rec->failover.lane_map == 0)) {
+        return;
+    }
+
+    rec->failover.status = status;
+    lane_map             = rec->failover.lane_map;
+
+    ucs_debug("ep %p: aborting failover for lanes 0x%" PRIx64 " status %s", ep,
+              (uint64_t)lane_map, ucs_status_string(status));
+
+    ucs_for_each_bit(lane, lane_map) {
+        ucp_ep_failover_lane_close(ep, lane, status);
+    }
+}
+
+void ucp_ep_failover_schedule_abort(ucp_ep_h ep, ucs_status_t status)
+{
+    ucp_ep_recovery_arg_t *rec;
+
+    ucs_assert(status != UCS_OK);
+    ucs_assert(ep->ext != NULL);
+
+    rec = ep->ext->recovery_arg;
+    ucs_assert(rec != NULL);
+    ucs_assert(rec->failover.lane_map != 0);
+
+    if (rec->failover.status != UCS_OK) {
+        rec->failover.status = status;
+        return;
+    }
+
+    rec->failover.status = status;
+    ucs_callbackq_add_oneshot(&ep->worker->uct->progress_q, ep,
+                              ucp_ep_failover_progress_cb, ep);
+}

--- a/src/ucp/core/ucp_ep_failover.c
+++ b/src/ucp/core/ucp_ep_failover.c
@@ -40,16 +40,6 @@ int ucp_ep_failover_is_token_supported(uct_ep_h uct_ep)
            (attr.tx_token_length > 0) && (attr.tx_token_length <= UINT8_MAX);
 }
 
-static int ucp_ep_failover_lane_token_supported(ucp_ep_h ep, uct_ep_h uct_ep,
-                                                ucp_lane_index_t lane)
-{
-    if (ucp_ep_get_rsc_index(ep, lane) == UCP_NULL_RESOURCE) {
-        return 0;
-    }
-
-    return ucp_ep_failover_is_token_supported(uct_ep);
-}
-
 static void ucp_ep_failover_lane_close(ucp_ep_h ep,
                                        ucp_lane_index_t lane_index,
                                        ucs_status_t discard_status)
@@ -62,9 +52,9 @@ static void ucp_ep_failover_lane_close(ucp_ep_h ep,
     uct_ep_h uct_ep;
     void *done_arg;
 
-    if ((arg == NULL) || !(arg->failover.lane_map & UCS_BIT(lane_index))) {
-        return;
-    }
+    ucs_assert(arg != NULL);
+    ucs_assert(arg->failover.lane_map & UCS_BIT(lane_index));
+    ucs_assert(discard_status != UCS_OK);
 
     lane      = &arg->failover.lanes[lane_index];
     uct_ep    = lane->uct_ep;
@@ -72,7 +62,6 @@ static void ucp_ep_failover_lane_close(ucp_ep_h ep,
     done_cb   = lane->done_cb;
     done_arg  = lane->done_arg;
 
-    ucs_assert(discard_status != UCS_OK);
     ucs_assert(uct_ep != NULL);
     ucs_debug("ep %p: closing failover lane %u status %s", ep, lane_index,
               ucs_status_string(discard_status));
@@ -116,6 +105,7 @@ static unsigned ucp_ep_failover_progress_cb(void *arg)
         if (!(ep->flags & UCP_EP_FLAG_FAILED)) {
             ucp_ep_recovery_arm(ep);
         }
+
     }
 
     UCS_ASYNC_UNBLOCK(&worker->async);
@@ -125,7 +115,7 @@ static unsigned ucp_ep_failover_progress_cb(void *arg)
 ucs_status_t
 ucp_ep_failover_add_lanes(ucp_ep_h ep, ucp_lane_map_t lane_map,
                           uct_ep_h *uct_eps, ucp_send_nbx_callback_t cb,
-                          void *arg, ucp_lane_map_t *failover_lanes_p)
+                          void *arg)
 {
     uct_ep_invalidate_params_t inv_params = {0};
     ucp_ep_recovery_arg_t *rec;
@@ -134,7 +124,6 @@ ucp_ep_failover_add_lanes(ucp_ep_h ep, ucp_lane_map_t lane_map,
     uct_ep_h uct_ep;
     ucs_status_t inv_status;
 
-    *failover_lanes_p = 0;
     ucs_assert(ep->ext != NULL);
     ucs_assert(ucp_ep_err_mode_eq(ep, UCP_ERR_HANDLING_MODE_FAILOVER));
     ucs_assert(lane_map != 0);
@@ -142,10 +131,13 @@ ucp_ep_failover_add_lanes(ucp_ep_h ep, ucp_lane_map_t lane_map,
     rec = ep->ext->recovery_arg;
     ucs_for_each_bit(lane, lane_map) {
         uct_ep = uct_eps[lane];
-        if (!ucp_ep_failover_lane_token_supported(ep, uct_ep, lane) ||
-            ((rec != NULL) && (rec->failover.lane_map & UCS_BIT(lane)))) {
+        if ((ucp_ep_get_rsc_index(ep, lane) == UCP_NULL_RESOURCE) ||
+            !ucp_ep_failover_is_token_supported(uct_ep)) {
             return UCS_ERR_UNSUPPORTED;
         }
+
+        ucs_assert((rec == NULL) ||
+                   !(rec->failover.lane_map & UCS_BIT(lane)));
     }
 
     if (rec == NULL) {
@@ -170,12 +162,9 @@ ucp_ep_failover_add_lanes(ucp_ep_h ep, ucp_lane_map_t lane_map,
 
         ucs_trace("ep %p: lane %u failover armed", ep, lane);
         rec->failover.lane_map |= UCS_BIT(lane);
-        *failover_lanes_p      |= UCS_BIT(lane);
 
-        /* Take ownership of the UCT ep so the error handler returns
-         * UCS_INPROGRESS. Invalidate so an unaware peer also gets an
-         * error CQE. Already-ERR QPs may fail modify_qp; that is not
-         * fatal. */
+        /* Invalidate so an unaware peer also gets an error CQE.
+         * Already-ERR QPs may fail modify_qp; that is not fatal. */
         inv_status = uct_ep_invalidate(uct_ep, &inv_params);
         if ((inv_status != UCS_OK) && (inv_status != UCS_ERR_UNSUPPORTED)) {
             ucs_debug("ep %p: lane %u invalidate: %s", ep, lane,
@@ -184,36 +173,19 @@ ucp_ep_failover_add_lanes(ucp_ep_h ep, ucp_lane_map_t lane_map,
     }
 
     ucs_debug("ep %p: started failover for lanes 0x%" PRIx64, ep,
-              (uint64_t)*failover_lanes_p);
+              (uint64_t)lane_map);
 
     return UCS_OK;
 }
 
 void ucp_ep_failover_cleanup(ucp_ep_h ep)
 {
-    ucp_ep_recovery_arg_t *rec;
-    ucp_ep_failover_lane_t *lane_ctx;
-    ucp_lane_index_t lane;
-
     ucs_assert(ep->ext != NULL);
+    ucs_assert((ep->ext->recovery_arg == NULL) ||
+               (ep->ext->recovery_arg->failover.lane_map == 0));
 
     ucs_callbackq_remove_oneshot(&ep->worker->uct->progress_q, ep,
                                  ucp_ep_failover_progress_remove_filter, ep);
-
-    rec = ep->ext->recovery_arg;
-    if (rec == NULL) {
-        return;
-    }
-
-    ucs_for_each_bit(lane, rec->failover.lane_map) {
-        lane_ctx = &rec->failover.lanes[lane];
-        ucp_ep_unprogress_uct_ep(ep, lane_ctx->uct_ep, lane_ctx->rsc_index);
-        uct_ep_destroy(lane_ctx->uct_ep);
-        ucp_worker_flush_ops_count_add(ep->worker, -1);
-    }
-
-    rec->failover.lane_map = 0;
-    rec->failover.status   = UCS_OK;
 }
 
 void ucp_ep_failover_abort(ucp_ep_h ep, ucs_status_t status)

--- a/src/ucp/core/ucp_ep_failover.c
+++ b/src/ucp/core/ucp_ep_failover.c
@@ -189,12 +189,6 @@ ucp_ep_failover_add_lanes(ucp_ep_h ep, ucp_lane_map_t lane_map,
 
 void ucp_ep_failover_cleanup(ucp_ep_h ep)
 {
-    const ucp_ep_recovery_arg_t *rec;
-
-    ucs_assert(ep->ext != NULL);
-    rec = ucp_ep_get_recovery_arg(ep);
-    ucs_assert((rec == NULL) || (rec->failover.lane_map == 0));
-
     ucs_callbackq_remove_oneshot(&ep->worker->uct->progress_q, ep,
                                  ucp_ep_failover_progress_remove_filter, ep);
 }

--- a/src/ucp/core/ucp_ep_failover.h
+++ b/src/ucp/core/ucp_ep_failover.h
@@ -19,14 +19,15 @@ void ucp_ep_failover_cleanup(ucp_ep_h ep);
 int ucp_ep_failover_is_token_supported(uct_ep_h uct_ep);
 
 /**
- * Arm the lanes of @a lane_map for token-based failover. @a cb is invoked with
- * @a arg once per lane when its failover completes or is aborted, exactly like
- * the discard completion callback of ucp_worker_discard_uct_ep().
+ * Take ownership of every UCT ep in @a lane_map for token-based failover.
+ * Returns UCS_OK only if all lanes support QUERY_TOKEN and were armed.
+ * @a cb is invoked with @a arg once per lane when failover is aborted,
+ * matching ucp_worker_discard_uct_ep() completion.
  */
 ucs_status_t
 ucp_ep_failover_add_lanes(ucp_ep_h ep, ucp_lane_map_t lane_map,
                           uct_ep_h *uct_eps, ucp_send_nbx_callback_t cb,
-                          void *arg, ucp_lane_map_t *failover_lanes_p);
+                          void *arg);
 
 /** Abort in-progress failover and release owned UCT endpoints. */
 void ucp_ep_failover_abort(ucp_ep_h ep, ucs_status_t status);

--- a/src/ucp/core/ucp_ep_failover.h
+++ b/src/ucp/core/ucp_ep_failover.h
@@ -13,10 +13,10 @@
 void ucp_ep_failover_cleanup(ucp_ep_h ep);
 
 /**
- * Whether this UCT ep's iface can keep outstanding ops for token-based
- * failover (@c UCT_IFACE_FLAG_V2_QUERY_TOKEN and a valid TX token length).
+ * Non-zero while token failover owns UCT endpoints
+ * (@c ucp_ep_recovery_arg_t::failover.lane_map).
  */
-int ucp_ep_failover_is_token_supported(uct_ep_h uct_ep);
+int ucp_ep_failover_in_progress(ucp_ep_h ep);
 
 /**
  * Take ownership of every UCT ep in @a lane_map for token-based failover.

--- a/src/ucp/core/ucp_ep_failover.h
+++ b/src/ucp/core/ucp_ep_failover.h
@@ -13,10 +13,10 @@
 void ucp_ep_failover_cleanup(ucp_ep_h ep);
 
 /**
- * Non-zero while token failover owns UCT endpoints
+ * Non-zero while token failover owns the UCT endpoint of @a lane
  * (@c ucp_ep_recovery_arg_t::failover.lane_map).
  */
-int ucp_ep_failover_in_progress(ucp_ep_h ep);
+int ucp_ep_failover_in_progress(ucp_ep_h ep, ucp_lane_index_t lane);
 
 /**
  * Take ownership of every UCT ep in @a lane_map for token-based failover.

--- a/src/ucp/core/ucp_ep_failover.h
+++ b/src/ucp/core/ucp_ep_failover.h
@@ -1,0 +1,40 @@
+/**
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCP_EP_FAILOVER_H_
+#define UCP_EP_FAILOVER_H_
+
+#include <ucp/core/ucp_ep.h>
+
+
+void ucp_ep_failover_cleanup(ucp_ep_h ep);
+
+/**
+ * Whether this UCT ep's iface can keep outstanding ops for token-based
+ * failover (@c UCT_IFACE_FLAG_V2_QUERY_TOKEN and a valid TX token length).
+ */
+int ucp_ep_failover_is_token_supported(uct_ep_h uct_ep);
+
+/**
+ * Arm the lanes of @a lane_map for token-based failover. @a cb is invoked with
+ * @a arg once per lane when its failover completes or is aborted, exactly like
+ * the discard completion callback of ucp_worker_discard_uct_ep().
+ */
+ucs_status_t
+ucp_ep_failover_add_lanes(ucp_ep_h ep, ucp_lane_map_t lane_map,
+                          uct_ep_h *uct_eps, ucp_send_nbx_callback_t cb,
+                          void *arg, ucp_lane_map_t *failover_lanes_p);
+
+/** Abort in-progress failover and release owned UCT endpoints. */
+void ucp_ep_failover_abort(ucp_ep_h ep, ucs_status_t status);
+
+/**
+ * Abort from worker progress so UCT can finish its failure handler first.
+ * Used until extract/replay takes over outstanding ops.
+ */
+void ucp_ep_failover_schedule_abort(ucp_ep_h ep, ucs_status_t status);
+
+#endif

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -16,6 +16,7 @@
 #include "ucp_request.inl"
 
 #include <ucp/core/ucp_context.h>
+#include <ucp/core/ucp_ep_failover.h>
 #include <ucp/proto/proto_common.inl>
 #include <ucp/wireup/address.h>
 #include <ucp/wireup/wireup_cm.h>
@@ -473,7 +474,9 @@ ucp_worker_iface_handle_uct_ep_failure(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
         /* Failure on NON-AUX EP or failure on AUX EP before it sent its address
          * means failure on the UCP EP */
         ucp_ep_set_lanes_failed(ucp_ep, UCS_BIT(lane), status);
-        return UCS_OK;
+        /* Token iface: UCT must not complete; UCP will outstanding_purge. */
+        return ucp_ep_failover_is_token_supported(uct_ep) ?
+               UCS_INPROGRESS : UCS_OK;
     }
 
     if (wireup_ep->flags & UCP_WIREUP_EP_FLAG_READY) {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -476,7 +476,7 @@ ucp_worker_iface_handle_uct_ep_failure(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
         ucp_ep_set_lanes_failed(ucp_ep, UCS_BIT(lane), status);
         /* Token failover owns the UCT ep: UCT must not complete outstanding
          * ops. */
-        return ucp_ep_failover_in_progress(ucp_ep) ? UCS_INPROGRESS :
+        return ucp_ep_failover_in_progress(ucp_ep, lane) ? UCS_INPROGRESS :
                UCS_OK;
     }
 

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -474,9 +474,10 @@ ucp_worker_iface_handle_uct_ep_failure(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
         /* Failure on NON-AUX EP or failure on AUX EP before it sent its address
          * means failure on the UCP EP */
         ucp_ep_set_lanes_failed(ucp_ep, UCS_BIT(lane), status);
-        /* Token iface: UCT must not complete outstanding ops. */
-        return ucp_ep_failover_is_token_supported(uct_ep) ?
-               UCS_INPROGRESS : UCS_OK;
+        /* Token failover owns the UCT ep: UCT must not complete outstanding
+         * ops. */
+        return ucp_ep_failover_in_progress(ucp_ep) ? UCS_INPROGRESS :
+               UCS_OK;
     }
 
     if (wireup_ep->flags & UCP_WIREUP_EP_FLAG_READY) {

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -474,7 +474,7 @@ ucp_worker_iface_handle_uct_ep_failure(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
         /* Failure on NON-AUX EP or failure on AUX EP before it sent its address
          * means failure on the UCP EP */
         ucp_ep_set_lanes_failed(ucp_ep, UCS_BIT(lane), status);
-        /* Token iface: UCT must not complete; UCP will outstanding_purge. */
+        /* Token iface: UCT must not complete outstanding ops. */
         return ucp_ep_failover_is_token_supported(uct_ep) ?
                UCS_INPROGRESS : UCS_OK;
     }

--- a/test/gtest/ucp/test_ucp_fault_tolerance.cc
+++ b/test/gtest/ucp/test_ucp_fault_tolerance.cc
@@ -864,7 +864,7 @@ protected:
             }
 
             for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-                if (arg->probe[lane].comp.count != 0) {
+                if (arg->recovery.probe[lane].comp.count != 0) {
                     return true;
                 }
             }
@@ -926,7 +926,7 @@ UCS_TEST_P(test_ucp_fault_tolerance, probe_gated_recovery, "MAX_EAGER_LANES=8",
 
         if (arg != NULL) {
             for (lane = 0; lane < ucp_ep_num_lanes(ep); ++lane) {
-                if (arg->probe[lane].comp.func != NULL) {
+                if (arg->recovery.probe[lane].comp.func != NULL) {
                     probe_armed = true;
                     break;
                 }


### PR DESCRIPTION
## What?
When a lane fails, token-capable UCT endpoints are handed to UCP token failover instead of software discard. The UCT error handler returns `UCS_INPROGRESS` only after failover owns those endpoints, so UCT does not complete outstanding operations.

This PR takes ownership and then aborts. Extract/replay of outstanding ops is not included.

## Why?
Token-capable transports can keep outstanding ops on a failed UCT endpoint so UCP can later extract and replay them on a new path. Software discard would complete or cancel those ops first.

## How?
- After `ucp_ep_set_lanes_failed()`, `ucp_ep_failover_reconfig()` reconfigures, then either takes every extracted UCT ep (`ucp_ep_failover_add_lanes`) or falls back to software `ucp_ep_discard_lanes`.
- Token handoff is all-or-nothing. Mixed token/non-token lanes stay on software discard and must not return `UCS_INPROGRESS`.
- `ucp_worker_iface_handle_uct_ep_failure()` reports `UCS_INPROGRESS` iff `ucp_ep_failover_in_progress()` (`failover.lane_map != 0`).
- Abort still uses `pending_purge` and `uct_ep_destroy` (not `uct_ep_outstanding_purge`). Recovery is armed after abort, not while token lanes are owned.

Tested: `shm_ib` + `rcx` `*failure*` 40/40, `*fault_tolerance*` 100/100.
