### PR TITLE
UCP/RMA: Fragment SGL put elements larger than max_zcopy - v1.23.x

### DIFF
--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -244,6 +244,11 @@ struct ucp_request {
                 struct {
                     uint64_t   remote_addr; /* Remote address */
                     ucp_rkey_h rkey; /* Remote memory key */
+
+                    struct {
+                        const uint64_t   *remote_addrs;
+                        ucp_rkey_h const *rkeys;
+                    } sgl;
                 } rma;
 
                 struct {

--- a/src/ucp/dt/datatype_iter.c
+++ b/src/ucp/dt/datatype_iter.c
@@ -295,13 +295,12 @@ ucs_status_t ucp_datatype_iter_sgl_init(ucp_context_h context,
     /* For Coverity */
     ucs_assert(remote != NULL);
 
-    dt_iter->dt_class              = UCP_DATATYPE_SGL;
-    dt_iter->length                = count;
-    dt_iter->offset                = 0;
-    dt_iter->type.sgl.buffers      = local->buffers;
-    dt_iter->type.sgl.lengths      = local->lengths;
-    dt_iter->type.sgl.remote_addrs = remote->remote_addrs;
-    dt_iter->type.sgl.rkeys        = remote->rkeys;
+    dt_iter->dt_class             = UCP_DATATYPE_SGL;
+    dt_iter->length               = count;
+    dt_iter->offset               = 0;
+    dt_iter->type.sgl.buffers     = local->buffers;
+    dt_iter->type.sgl.lengths     = local->lengths;
+    dt_iter->type.sgl.frag_offset = 0;
 
     if (ucs_unlikely(count == 0)) {
         dt_iter->type.sgl.memhs = NULL;

--- a/src/ucp/dt/datatype_iter.h
+++ b/src/ucp/dt/datatype_iter.h
@@ -77,8 +77,7 @@ typedef struct {
             void * const     *buffers;
             const size_t     *lengths;
             ucp_mem_h        *memhs;
-            const uint64_t   *remote_addrs;
-            ucp_rkey_h const *rkeys;
+            size_t           frag_offset; /* Offset in the current element */
             /* length = element count, offset = current element index */
         } sgl;
     } type;

--- a/src/ucp/dt/datatype_iter.inl
+++ b/src/ucp/dt/datatype_iter.inl
@@ -377,6 +377,24 @@ ucp_datatype_iter_iov_check(const ucp_datatype_iter_t *dt_iter)
                 dt_iter->type.iov.iov_count);
 }
 
+static UCS_F_ALWAYS_INLINE void
+ucp_datatype_iter_sgl_check(const ucp_datatype_iter_t *dt_iter)
+{
+    size_t UCS_V_UNUSED elem_length;
+
+    ucs_assertv(dt_iter->offset <= dt_iter->length,
+                "offset=%zu length=%zu", dt_iter->offset, dt_iter->length);
+    if (dt_iter->offset < dt_iter->length) {
+        elem_length = dt_iter->type.sgl.lengths[dt_iter->offset];
+        ucs_assertv((elem_length > 0) ?
+                    (dt_iter->type.sgl.frag_offset < elem_length) :
+                    (dt_iter->type.sgl.frag_offset == 0),
+                    "offset=%zu frag_offset=%zu elem_length=%zu",
+                    dt_iter->offset, dt_iter->type.sgl.frag_offset,
+                    elem_length);
+    }
+}
+
 /*
  * Pack data and set some fields of next_iter as next iterator state
  */
@@ -619,20 +637,67 @@ ucp_datatype_iter_next_iov(const ucp_datatype_iter_t *dt_iter,
 }
 
 static UCS_F_ALWAYS_INLINE size_t
-ucp_datatype_iter_next_sgl(const ucp_datatype_iter_t *dt_iter,
-                           size_t max_elem_count,
-                           ucp_datatype_iter_t *next_iter)
+ucp_datatype_iter_next_sgl_frags(const ucp_datatype_iter_t *dt_iter,
+                                 const uint64_t *remote_addrs,
+                                 size_t max_frag_count,
+                                 size_t max_frag_length,
+                                 ucp_datatype_iter_t *next_iter,
+                                 void **out_buffers, size_t *out_lengths,
+                                 uint64_t *out_remote_addrs,
+                                 size_t *out_elem_indices)
 {
+    size_t elem_index  = dt_iter->offset;
+    size_t frag_offset = dt_iter->type.sgl.frag_offset;
+    size_t desc_count  = 0;
+    size_t elem_length, frag_length;
+
     ucs_assert(dt_iter->dt_class == UCP_DATATYPE_SGL);
-    return ucp_datatype_iter_next(dt_iter, max_elem_count, next_iter);
+    ucs_assert(max_frag_count >= 1);
+    ucs_assert(max_frag_length > 0);
+    ucp_datatype_iter_sgl_check(dt_iter);
+
+    while ((desc_count < max_frag_count) && (elem_index < dt_iter->length)) {
+        elem_length = dt_iter->type.sgl.lengths[elem_index];
+        if (elem_length > 0) {
+            ucs_assert(elem_length > frag_offset);
+            frag_length = ucs_min(elem_length - frag_offset, max_frag_length);
+
+            out_buffers[desc_count]      = UCS_PTR_BYTE_OFFSET(
+                    dt_iter->type.sgl.buffers[elem_index], frag_offset);
+            out_lengths[desc_count]      = frag_length;
+            out_remote_addrs[desc_count] = remote_addrs[elem_index] +
+                                           frag_offset;
+            out_elem_indices[desc_count] = elem_index;
+            ++desc_count;
+
+            frag_offset += frag_length;
+            if (frag_offset < elem_length) {
+                continue;
+            }
+        }
+
+        ++elem_index;
+        frag_offset = 0;
+    }
+
+    ucs_assertv((elem_index == dt_iter->length) || (desc_count > 0),
+                "dt_iter=%p offset=%zu length=%zu frag_offset=%zu "
+                "desc_count=%zu",
+                dt_iter, dt_iter->offset, dt_iter->length,
+                dt_iter->type.sgl.frag_offset, desc_count);
+
+    next_iter->offset               = elem_index;
+    next_iter->type.sgl.frag_offset = frag_offset;
+
+    return desc_count;
 }
 
 /*
  * Copy iterator position only.
  * 'src_dt_iter' must be initialized from the same datatype object as 'dt_iter',
  * or returned as 'next_iter' from @ref ucp_datatype_iter_next_pack
- * @ref ucp_datatype_iter_next_unpack or @ref ucp_datatype_iter_next_iov that
- * were used on 'dt_iter'.
+ * @ref ucp_datatype_iter_next_unpack, @ref ucp_datatype_iter_next_iov or
+ * @ref ucp_datatype_iter_next_sgl_frags that were used on 'dt_iter'.
  */
 static UCS_F_ALWAYS_INLINE void
 ucp_datatype_iter_copy_position(ucp_datatype_iter_t *dt_iter,
@@ -643,6 +708,8 @@ ucp_datatype_iter_copy_position(ucp_datatype_iter_t *dt_iter,
     if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_IOV, dt_mask)) {
         dt_iter->type.iov.iov_index  = src_dt_iter->type.iov.iov_index;
         dt_iter->type.iov.iov_offset = src_dt_iter->type.iov.iov_offset;
+    } else if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_SGL, dt_mask)) {
+        dt_iter->type.sgl.frag_offset = src_dt_iter->type.sgl.frag_offset;
     }
 }
 
@@ -655,6 +722,7 @@ ucp_datatype_iter_is_end(const ucp_datatype_iter_t *dt_iter)
     ucs_assertv(dt_iter->offset <= dt_iter->length,
                 "dt_iter=%p dt_iter->offset=%zu dt_iter->length=%zu", dt_iter,
                 dt_iter->offset, dt_iter->length);
+
     return dt_iter->offset == dt_iter->length;
 }
 
@@ -665,6 +733,8 @@ ucp_datatype_iter_rewind(ucp_datatype_iter_t *dt_iter, unsigned dt_mask)
     if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_IOV, dt_mask)) {
         dt_iter->type.iov.iov_index  = 0;
         dt_iter->type.iov.iov_offset = 0;
+    } else if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_SGL, dt_mask)) {
+        dt_iter->type.sgl.frag_offset = 0;
     }
 }
 
@@ -677,6 +747,9 @@ ucp_datatype_iter_seek(ucp_datatype_iter_t *dt_iter, size_t offset,
                 offset, dt_iter->length);
     if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_IOV, dt_mask)) {
         ucp_datatype_iter_iov_seek(dt_iter, offset);
+    } else if (ucp_datatype_iter_is_class(dt_iter, UCP_DATATYPE_SGL, dt_mask)) {
+        dt_iter->type.sgl.frag_offset = 0;
+        dt_iter->offset               = offset;
     } else {
         dt_iter->offset = offset;
     }

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -365,6 +365,71 @@ ucp_proto_put_sgl_offload_probe(const ucp_proto_init_params_t *init_params)
 }
 
 static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_put_sgl_offload_post(ucp_request_t *req,
+                               const ucp_proto_multi_lane_priv_t *lpriv,
+                               void *const *buffers, const size_t *lengths,
+                               uct_mem_h const *memhs,
+                               const uint64_t *remote_addrs,
+                               uct_rkey_t const *rkeys, size_t count)
+{
+    ucp_ep_t *ep    = req->send.ep;
+    uct_ep_h uct_ep = ucp_ep_get_lane(ep, lpriv->super.lane);
+    ucs_status_t status;
+
+    status = uct_ep_put_sgl_zcopy(uct_ep, buffers, lengths, memhs, remote_addrs,
+                                  rkeys, NULL, NULL, count,
+                                  &req->send.state.uct_comp);
+    if (!UCS_STATUS_IS_ERR(status)) {
+        ucp_proto_put_offload_update_remote_flush(ep, lpriv->flush_sys_dev_mask,
+                                                  rkeys[0], uct_ep,
+                                                  remote_addrs[0]);
+    }
+
+    return status;
+}
+
+static UCS_F_ALWAYS_INLINE int
+ucp_proto_put_sgl_elem_fits(size_t length, size_t max_frag_length)
+{
+    return (length > 0) && (length <= max_frag_length);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_proto_put_sgl_offload_send_frag(ucp_request_t *req,
+                                    const ucp_proto_multi_lane_priv_t *lpriv,
+                                    size_t max_frag_length,
+                                    ucp_datatype_iter_t *next_iter)
+{
+    ucp_ep_t *ep                 = req->send.ep;
+    ucp_datatype_iter_t *dt_iter = &req->send.state.dt_iter;
+    ucp_md_index_t md_index      = ucp_ep_md_index(ep, lpriv->super.lane);
+    ucp_mem_h *sgl_memhs         = dt_iter->type.sgl.memhs;
+    void *buffer                 = NULL;
+    size_t length                = 0;
+    size_t elem_index            = 0;
+    uint64_t remote_addr         = 0;
+    uct_mem_h uct_memh;
+    uct_rkey_t uct_rkey;
+
+    if (ucp_datatype_iter_next_sgl_frags(dt_iter,
+                                         req->send.rma.sgl.remote_addrs, 1,
+                                         max_frag_length, next_iter, &buffer,
+                                         &length, &remote_addr,
+                                         &elem_index) == 0) {
+        return UCS_OK;
+    }
+
+    uct_memh = (sgl_memhs != NULL) ? sgl_memhs[elem_index]->uct[md_index] :
+                                     UCT_MEM_HANDLE_NULL;
+    uct_rkey = ucp_rkey_get_tl_rkey(req->send.rma.sgl.rkeys[elem_index],
+                                    lpriv->super.rkey_index);
+
+    return ucp_proto_put_sgl_offload_post(req, lpriv, &buffer, &length,
+                                          &uct_memh, &remote_addr, &uct_rkey,
+                                          1);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_proto_put_sgl_offload_send_func(ucp_request_t *req,
                                     const ucp_proto_multi_lane_priv_t *lpriv,
                                     ucp_datatype_iter_t *next_iter,
@@ -372,63 +437,72 @@ ucp_proto_put_sgl_offload_send_func(ucp_request_t *req,
 {
     ucp_ep_t *ep                 = req->send.ep;
     ucp_datatype_iter_t *dt_iter = &req->send.state.dt_iter;
-    ucp_lane_index_t lane        = lpriv->super.lane;
-    uct_ep_h uct_ep              = ucp_ep_get_lane(ep, lane);
-    ucp_md_index_t md_index      = ucp_ep_md_index(ep, lane);
+    ucp_md_index_t md_index      = ucp_ep_md_index(ep, lpriv->super.lane);
     ucp_rsc_index_t rkey_index   = lpriv->super.rkey_index;
-    size_t start_index           = dt_iter->offset;
-    size_t max_sgl_count         = lpriv->max_sgl_zcopy_count;
-    size_t elem_count            = ucp_datatype_iter_next_sgl(dt_iter,
-                                                              max_sgl_count,
-                                                              next_iter);
-    size_t rkeys_size            = elem_count * sizeof(uct_rkey_t);
-    size_t memhs_size            = elem_count * sizeof(uct_mem_h);
+    size_t max_frag_length       = lpriv->max_frag;
     ucp_mem_h *sgl_memhs         = dt_iter->type.sgl.memhs;
-    uct_mem_h *uct_memhs;
+    ucp_rkey_h const *sgl_rkeys  = req->send.rma.sgl.rkeys;
+    void *const *buffers         = dt_iter->type.sgl.buffers;
+    const size_t *lengths        = dt_iter->type.sgl.lengths;
+    const uint64_t *remote_addrs = req->send.rma.sgl.remote_addrs;
+    size_t start_index           = dt_iter->offset;
+    size_t max_elem_count        = ucs_min(lpriv->max_sgl_zcopy_count,
+                                           dt_iter->length - start_index);
+    size_t uct_rkeys_size        = max_elem_count * sizeof(uct_rkey_t);
+    size_t uct_memhs_size        = max_elem_count * sizeof(uct_mem_h);
     uct_rkey_t *uct_rkeys;
+    uct_mem_h *uct_memhs;
     ucs_status_t status;
-    size_t i;
+    size_t elem_count, idx;
 
-    uct_rkeys = ucs_alloc_on_stack(rkeys_size, "uct_sgl_rkeys");
+    ucs_assert(max_frag_length > 0);
+    ucs_assert(max_elem_count > 0);
+
+    /* Silence compiler warning, in case of an early return below */
+    next_iter->offset               = start_index;
+    next_iter->type.sgl.frag_offset = dt_iter->type.sgl.frag_offset;
+
+    if (ucs_unlikely((dt_iter->type.sgl.frag_offset != 0) ||
+                     !ucp_proto_put_sgl_elem_fits(lengths[start_index],
+                                                  max_frag_length))) {
+        return ucp_proto_put_sgl_offload_send_frag(req, lpriv, max_frag_length,
+                                                   next_iter);
+    }
+
+    uct_rkeys = ucs_alloc_on_stack(uct_rkeys_size, "uct_sgl_rkeys");
     if (uct_rkeys == NULL) {
         return UCS_ERR_NO_MEMORY;
     }
 
-    uct_memhs = ucs_alloc_on_stack(memhs_size, "uct_sgl_memhs");
+    uct_memhs = ucs_alloc_on_stack(uct_memhs_size, "uct_sgl_memhs");
     if (uct_memhs == NULL) {
-        ucs_free_on_stack(uct_rkeys, rkeys_size);
+        ucs_free_on_stack(uct_rkeys, uct_rkeys_size);
         return UCS_ERR_NO_MEMORY;
     }
 
-    for (i = 0; i < elem_count; i++) {
-        uct_memhs[i] = (sgl_memhs != NULL) ?
-                       sgl_memhs[start_index + i]->uct[md_index] :
-                       UCT_MEM_HANDLE_NULL;
-        uct_rkeys[i] = ucp_rkey_get_tl_rkey(
-                           dt_iter->type.sgl.rkeys[start_index + i], rkey_index);
+    for (elem_count = 0; elem_count < max_elem_count; elem_count++) {
+        idx = start_index + elem_count;
+        if (!ucp_proto_put_sgl_elem_fits(lengths[idx], max_frag_length)) {
+            break;
+        }
+
+        uct_memhs[elem_count] = (sgl_memhs != NULL) ?
+                                sgl_memhs[idx]->uct[md_index] :
+                                UCT_MEM_HANDLE_NULL;
+        uct_rkeys[elem_count] = ucp_rkey_get_tl_rkey(sgl_rkeys[idx],
+                                                     rkey_index);
     }
 
-    status = uct_ep_put_sgl_zcopy(
-                 uct_ep,
-                 &dt_iter->type.sgl.buffers[start_index],
-                 &dt_iter->type.sgl.lengths[start_index],
-                 uct_memhs,
-                 &dt_iter->type.sgl.remote_addrs[start_index],
-                 uct_rkeys,
-                 NULL, NULL,
-                 elem_count, &req->send.state.uct_comp);
+    next_iter->offset               = start_index + elem_count;
+    next_iter->type.sgl.frag_offset = 0;
 
-    ucs_free_on_stack(uct_memhs, memhs_size);
-    ucs_free_on_stack(uct_rkeys, rkeys_size);
+    status = ucp_proto_put_sgl_offload_post(req, lpriv, &buffers[start_index],
+                                            &lengths[start_index], uct_memhs,
+                                            &remote_addrs[start_index],
+                                            uct_rkeys, elem_count);
 
-    if (!UCS_STATUS_IS_ERR(status)) {
-        ucp_proto_put_offload_update_remote_flush(
-                ep, lpriv->flush_sys_dev_mask,
-                ucp_rkey_get_tl_rkey(dt_iter->type.sgl.rkeys[start_index],
-                                     rkey_index),
-                uct_ep,
-                dt_iter->type.sgl.remote_addrs[start_index]);
-    }
+    ucs_free_on_stack(uct_memhs, uct_memhs_size);
+    ucs_free_on_stack(uct_rkeys, uct_rkeys_size);
 
     return status;
 }
@@ -477,24 +551,40 @@ ucp_proto_put_sgl_offload_sw_send_func(ucp_request_t *req,
     uct_ep_h uct_ep              = ucp_ep_get_lane(ep, lane);
     ucp_md_index_t md_index      = ucp_ep_md_index(ep, lane);
     ucp_rsc_index_t rkey_index   = lpriv->super.rkey_index;
-    size_t index                 = dt_iter->offset;
+    size_t max_frag_length       = lpriv->max_frag;
     ucp_mem_h *sgl_memhs         = dt_iter->type.sgl.memhs;
-    uint64_t remote_addr         = dt_iter->type.sgl.remote_addrs[index];
+    ucp_rkey_h const *sgl_rkeys  = req->send.rma.sgl.rkeys;
+    void *buffer                 = NULL;
+    size_t length                = 0;
+    size_t elem_index            = 0;
+    uint64_t remote_addr         = 0;
+    size_t UCS_V_UNUSED desc_count;
     uct_rkey_t tl_rkey;
     uct_iov_t iov;
     ucs_status_t status;
 
-    /* TODO: fragment elements larger than cap.put.max_zcopy */
-    ucp_datatype_iter_next_sgl(dt_iter, 1, next_iter);
+    ucs_assert(max_frag_length > 0);
 
-    tl_rkey     = ucp_rkey_get_tl_rkey(dt_iter->type.sgl.rkeys[index],
-                                       rkey_index);
-    iov.buffer  = dt_iter->type.sgl.buffers[index];
-    iov.length  = dt_iter->type.sgl.lengths[index];
-    iov.memh    = (sgl_memhs != NULL) ? sgl_memhs[index]->uct[md_index] :
-                                        UCT_MEM_HANDLE_NULL;
-    iov.stride  = 0;
-    iov.count   = 1;
+    desc_count = ucp_datatype_iter_next_sgl_frags(
+            dt_iter, req->send.rma.sgl.remote_addrs, 1, max_frag_length,
+            next_iter, &buffer, &length, &remote_addr, &elem_index);
+    if (desc_count == 0) {
+        return UCS_OK;
+    }
+
+    ucs_assertv(desc_count == 1,
+                "dt_iter=%p offset=%zu length=%zu frag_offset=%zu "
+                "max_frag_length=%zu",
+                dt_iter, dt_iter->offset, dt_iter->length,
+                dt_iter->type.sgl.frag_offset, max_frag_length);
+
+    tl_rkey    = ucp_rkey_get_tl_rkey(sgl_rkeys[elem_index], rkey_index);
+    iov.buffer = buffer;
+    iov.length = length;
+    iov.memh   = (sgl_memhs != NULL) ? sgl_memhs[elem_index]->uct[md_index] :
+                                       UCT_MEM_HANDLE_NULL;
+    iov.stride = 0;
+    iov.count  = 1;
 
     status = uct_ep_put_zcopy(uct_ep, &iov, 1, remote_addr, tl_rkey,
                               &req->send.state.uct_comp);

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -193,10 +193,10 @@ ucs_status_ptr_t ucp_put_nbx(ucp_ep_h ep, const void *buffer, size_t count,
                              uint64_t remote_addr, ucp_rkey_h rkey,
                              const ucp_request_param_t *param)
 {
-    ucp_worker_h worker     = ep->worker;
-    size_t contig_length    = 0;
-    ucp_datatype_t datatype = ucp_dt_make_contig(1);
-    const ucp_dt_remote_sgl_t *remote;
+    ucp_worker_h worker               = ep->worker;
+    size_t contig_length              = 0;
+    ucp_datatype_t datatype           = ucp_dt_make_contig(1);
+    const ucp_dt_remote_sgl_t *remote = NULL;
     ucs_status_ptr_t ret;
     ucs_status_t status;
     ucp_request_t *req;
@@ -241,6 +241,10 @@ ucs_status_ptr_t ucp_put_nbx(ucp_ep_h ep, const void *buffer, size_t count,
                                 goto out_unlock;});
     req->send.rma.rkey        = rkey;
     req->send.rma.remote_addr = remote_addr;
+    if (remote != NULL) {
+        req->send.rma.sgl.remote_addrs = remote->remote_addrs;
+        req->send.rma.sgl.rkeys        = remote->rkeys;
+    }
 
     ret = ucp_proto_request_send_op_rma(
             ep, rkey, req, ucp_ep_rma_get_fence_flag(ep), UCP_OP_ID_PUT,

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -57,7 +57,7 @@ UCS_TEST_F(test_obj_size, size) {
     EXPECTED_SIZE(ucp_rkey_t, 24);
 #endif
     /* TODO reduce request size to 240 or less after removing old protocols state */
-    EXPECTED_SIZE(ucp_request_t, 280);
+    EXPECTED_SIZE(ucp_request_t, 272);
     EXPECTED_SIZE(ucp_recv_desc_t, 48);
     EXPECTED_SIZE(ucp_mem_t, 160);
     EXPECTED_SIZE(uct_ep_t, 8);

--- a/test/gtest/ucp/test_ucp_dt.cc
+++ b/test/gtest/ucp/test_ucp_dt.cc
@@ -296,32 +296,36 @@ protected:
         m_ucph.reset();
     }
 
-    void init_sgl_iter(size_t count) {
+    void init_sgl_iter(size_t count,
+                       const std::vector<size_t> &lengths = {})
+    {
+        ASSERT_TRUE(lengths.empty() || (lengths.size() == count));
+
         m_buffers.resize(count);
         m_lengths.resize(count);
         m_remote_addrs.resize(count);
         m_rkeys.resize(count);
 
-        m_dummy_rkey            = {};
-        m_dummy_rkey.cfg_index  = 0;
+        m_dummy_rkey           = {};
+        m_dummy_rkey.cfg_index = 0;
 #if ENABLE_PARAMS_CHECK
-        m_dummy_rkey.ep         = nullptr;
+        m_dummy_rkey.ep        = nullptr;
 #endif
 
         for (size_t i = 0; i < count; i++) {
             m_buffers[i]      = &m_buffers[i];
-            m_lengths[i]      = (i + 1) * 64;
+            m_lengths[i]      = lengths.empty() ? (i + 1) * 64 : lengths[i];
             m_remote_addrs[i] = 0x1000 + i * 0x100;
             m_rkeys[i]        = &m_dummy_rkey;
         }
 
-        m_local = {};
+        m_local            = {};
         m_local.field_mask = UCP_DT_LOCAL_SGL_FIELD_BUFFERS |
                              UCP_DT_LOCAL_SGL_FIELD_LENGTHS;
         m_local.buffers    = m_buffers.data();
         m_local.lengths    = m_lengths.data();
 
-        m_remote = {};
+        m_remote              = {};
         m_remote.field_mask   = UCP_DT_REMOTE_SGL_FIELD_REMOTE_ADDRS |
                                 UCP_DT_REMOTE_SGL_FIELD_LENGTHS |
                                 UCP_DT_REMOTE_SGL_FIELD_RKEYS;
@@ -335,25 +339,117 @@ protected:
         param.datatype     = ucp_dt_make_sgl();
         param.remote       = &m_remote;
 
-        ucs_status_t status = ucp_datatype_iter_sgl_init(m_ucph.get(),
-                                                         &m_dt_iter, &m_local,
-                                                         &m_remote, count,
-                                                         &param);
-        ASSERT_UCS_OK(status);
+        ASSERT_UCS_OK(ucp_datatype_iter_sgl_init(m_ucph.get(), &m_dt_iter,
+                                                 &m_local, &m_remote, count,
+                                                 &param));
+
+        m_next_iter   = {};
+        m_buffer      = NULL;
+        m_length      = 0;
+        m_remote_addr = 0;
+        m_elem_index  = 0;
+    }
+
+    size_t next_frags(size_t max_frag_count, size_t max_frag_length,
+                      void **buffers, size_t *lengths, uint64_t *remote_addrs,
+                      size_t *elem_indices)
+    {
+        m_next_iter = {};
+        return ucp_datatype_iter_next_sgl_frags(&m_dt_iter,
+                                                m_remote_addrs.data(),
+                                                max_frag_count,
+                                                max_frag_length, &m_next_iter,
+                                                buffers, lengths, remote_addrs,
+                                                elem_indices);
+    }
+
+    size_t next_frag(size_t max_frag_length)
+    {
+        return next_frags(1, max_frag_length, &m_buffer, &m_length,
+                          &m_remote_addr, &m_elem_index);
+    }
+
+    size_t next_batch(size_t max_frag_count, size_t max_frag_length)
+    {
+        m_desc_buffers.resize(max_frag_count);
+        m_desc_lengths.resize(max_frag_count);
+        m_desc_remote_addrs.resize(max_frag_count);
+        m_desc_elem_indices.resize(max_frag_count);
+
+        return next_frags(max_frag_count, max_frag_length,
+                          m_desc_buffers.data(), m_desc_lengths.data(),
+                          m_desc_remote_addrs.data(),
+                          m_desc_elem_indices.data());
+    }
+
+    void check_next_iter(size_t next_offset, size_t next_frag_offset)
+    {
+        EXPECT_EQ(next_offset, m_next_iter.offset);
+        EXPECT_EQ(next_frag_offset, m_next_iter.type.sgl.frag_offset);
+    }
+
+    void check_position(size_t offset, size_t frag_offset)
+    {
+        EXPECT_EQ(offset, m_dt_iter.offset);
+        EXPECT_EQ(frag_offset, m_dt_iter.type.sgl.frag_offset);
+    }
+
+    void start_partial_elem(size_t max_frag_length)
+    {
+        ASSERT_EQ(1u, next_frag(max_frag_length));
+        advance();
+        check_position(0, max_frag_length);
+    }
+
+    void check_frag(size_t elem_index, size_t frag_offset, size_t length,
+                    size_t next_offset, size_t next_frag_offset)
+    {
+        EXPECT_EQ(elem_index, m_elem_index);
+        EXPECT_EQ(length, m_length);
+        EXPECT_EQ(UCS_PTR_BYTE_OFFSET(m_buffers[elem_index], frag_offset),
+                  m_buffer);
+        EXPECT_EQ(m_remote_addrs[elem_index] + frag_offset, m_remote_addr);
+        check_next_iter(next_offset, next_frag_offset);
+    }
+
+    void check_desc(size_t desc_index, size_t elem_index, size_t frag_offset,
+                    size_t length)
+    {
+        EXPECT_EQ(elem_index, m_desc_elem_indices[desc_index]);
+        EXPECT_EQ(length, m_desc_lengths[desc_index]);
+        EXPECT_EQ(UCS_PTR_BYTE_OFFSET(m_buffers[elem_index], frag_offset),
+                  m_desc_buffers[desc_index]);
+        EXPECT_EQ(m_remote_addrs[elem_index] + frag_offset,
+                  m_desc_remote_addrs[desc_index]);
+    }
+
+    void advance()
+    {
+        ucp_datatype_iter_copy_position(&m_dt_iter, &m_next_iter,
+                                        UCS_BIT(UCP_DATATYPE_SGL));
     }
 
 private:
     ucs::handle<ucp_context_h> m_ucph;
-    std::vector<void*>         m_buffers;
-    std::vector<size_t>        m_lengths;
-    std::vector<uint64_t>      m_remote_addrs;
     std::vector<ucp_rkey_h>    m_rkeys;
     ucp_rkey_t                 m_dummy_rkey;
     ucp_dt_local_sgl_t         m_local;
     ucp_dt_remote_sgl_t        m_remote;
 
 protected:
+    std::vector<void*>         m_buffers;
+    std::vector<size_t>        m_lengths;
+    std::vector<uint64_t>      m_remote_addrs;
     ucp_datatype_iter_t        m_dt_iter;
+    ucp_datatype_iter_t        m_next_iter;
+    void                       *m_buffer;
+    size_t                     m_length;
+    uint64_t                   m_remote_addr;
+    size_t                     m_elem_index;
+    std::vector<void*>         m_desc_buffers;
+    std::vector<size_t>        m_desc_lengths;
+    std::vector<uint64_t>      m_desc_remote_addrs;
+    std::vector<size_t>        m_desc_elem_indices;
 };
 
 UCS_TEST_F(test_ucp_dt_sgl, iter_next_chunked) {
@@ -364,14 +460,11 @@ UCS_TEST_F(test_ucp_dt_sgl, iter_next_chunked) {
 
     size_t total_advanced = 0;
     while (!ucp_datatype_iter_is_end(&m_dt_iter)) {
-        ucp_datatype_iter_t next_iter = {};
-        size_t advanced = ucp_datatype_iter_next_sgl(&m_dt_iter,
-                                                     MAX_PER_STEP,
-                                                     &next_iter);
+        size_t advanced = next_batch(MAX_PER_STEP, SIZE_MAX);
         EXPECT_LE(advanced, MAX_PER_STEP);
         EXPECT_GT(advanced, 0u);
         total_advanced += advanced;
-        ucp_datatype_iter_copy_position(&m_dt_iter, &next_iter, UINT_MAX);
+        advance();
     }
 
     EXPECT_EQ(NUM_ELEMS, total_advanced);
@@ -383,11 +476,8 @@ UCS_TEST_F(test_ucp_dt_sgl, iter_next_single_step) {
     for (size_t count : counts) {
         init_sgl_iter(count);
 
-        ucp_datatype_iter_t next_iter = {};
-        size_t advanced = ucp_datatype_iter_next_sgl(&m_dt_iter, count,
-                                                     &next_iter);
-        EXPECT_EQ(count, advanced);
-        ucp_datatype_iter_copy_position(&m_dt_iter, &next_iter, UINT_MAX);
+        EXPECT_EQ(count, next_batch(count, SIZE_MAX));
+        advance();
         EXPECT_TRUE(ucp_datatype_iter_is_end(&m_dt_iter));
     }
 }
@@ -399,15 +489,191 @@ UCS_TEST_F(test_ucp_dt_sgl, iter_next_one_by_one) {
 
     for (size_t i = 0; i < NUM_ELEMS; i++) {
         EXPECT_FALSE(ucp_datatype_iter_is_end(&m_dt_iter));
-        ucp_datatype_iter_t next_iter = {};
-        size_t advanced = ucp_datatype_iter_next_sgl(&m_dt_iter, 1,
-                                                     &next_iter);
-        EXPECT_EQ(1u, advanced);
-        EXPECT_EQ(i + 1, next_iter.offset);
-        ucp_datatype_iter_copy_position(&m_dt_iter, &next_iter, UINT_MAX);
+        EXPECT_EQ(1u, next_frag(SIZE_MAX));
+        check_frag(i, 0, m_lengths[i], i + 1, 0);
+        advance();
+        check_position(i + 1, 0);
     }
 
     EXPECT_TRUE(ucp_datatype_iter_is_end(&m_dt_iter));
+}
+
+UCS_TEST_F(test_ucp_dt_sgl, iter_next_frag) {
+    static constexpr size_t NUM_ELEMS = 5;
+    static constexpr size_t MAX_FRAG  = 64;
+    static constexpr size_t MAX_COUNT = 3;
+
+    init_sgl_iter(NUM_ELEMS);
+
+    std::vector<size_t> elem_progress(NUM_ELEMS);
+
+    while (!ucp_datatype_iter_is_end(&m_dt_iter)) {
+        size_t desc_count = next_batch(MAX_COUNT, MAX_FRAG);
+
+        EXPECT_GT(desc_count, 0u);
+        EXPECT_LE(desc_count, MAX_COUNT);
+
+        for (size_t n = 0; n < desc_count; n++) {
+            size_t idx = m_desc_elem_indices[n];
+            ASSERT_LT(idx, NUM_ELEMS);
+
+            EXPECT_LE(m_desc_lengths[n], MAX_FRAG);
+            EXPECT_GT(m_desc_lengths[n], 0u);
+            check_desc(n, idx, elem_progress[idx], m_desc_lengths[n]);
+
+            elem_progress[idx] += m_desc_lengths[n];
+            EXPECT_LE(elem_progress[idx], m_lengths[idx]);
+        }
+
+        advance();
+    }
+
+    EXPECT_TRUE(ucp_datatype_iter_is_end(&m_dt_iter));
+
+    for (size_t i = 0; i < NUM_ELEMS; i++) {
+        EXPECT_EQ(m_lengths[i], elem_progress[i]);
+    }
+}
+
+UCS_TEST_F(test_ucp_dt_sgl, iter_next_frag_offset) {
+    static constexpr size_t MAX_FRAG = 32;
+
+    init_sgl_iter(1, {96});
+
+    EXPECT_EQ(1u, next_frag(MAX_FRAG));
+    check_frag(0, 0, MAX_FRAG, 0, MAX_FRAG);
+
+    advance();
+    check_position(0, MAX_FRAG);
+
+    EXPECT_EQ(1u, next_frag(MAX_FRAG));
+    check_frag(0, MAX_FRAG, MAX_FRAG, 0, 2 * MAX_FRAG);
+
+    advance();
+    check_position(0, 2 * MAX_FRAG);
+
+    EXPECT_EQ(1u, next_frag(MAX_FRAG));
+    check_frag(0, 2 * MAX_FRAG, MAX_FRAG, 1, 0);
+
+    advance();
+    check_position(1, 0);
+    EXPECT_TRUE(ucp_datatype_iter_is_end(&m_dt_iter));
+}
+
+UCS_TEST_F(test_ucp_dt_sgl, iter_next_skip_zero_length) {
+    init_sgl_iter(3, {64, 0, 32});
+
+    EXPECT_EQ(1u, next_frag(SIZE_MAX));
+    check_frag(0, 0, 64, 1, 0);
+    advance();
+
+    EXPECT_EQ(1u, next_frag(SIZE_MAX));
+    check_frag(2, 0, 32, 3, 0);
+    advance();
+    EXPECT_TRUE(ucp_datatype_iter_is_end(&m_dt_iter));
+}
+
+UCS_TEST_F(test_ucp_dt_sgl, iter_next_frag_zero_length) {
+    static constexpr size_t MAX_FRAG = 32;
+
+    init_sgl_iter(5, {0, 96, 0, 32, 0});
+
+    /* Leading zero-length element is skipped */
+    EXPECT_EQ(1u, next_frag(MAX_FRAG));
+    check_frag(1, 0, MAX_FRAG, 1, MAX_FRAG);
+    advance();
+
+    EXPECT_EQ(1u, next_frag(MAX_FRAG));
+    check_frag(1, MAX_FRAG, MAX_FRAG, 1, 2 * MAX_FRAG);
+    advance();
+
+    /* The last fragment leaves the iterator on the zero-length element */
+    EXPECT_EQ(1u, next_frag(MAX_FRAG));
+    check_frag(1, 2 * MAX_FRAG, MAX_FRAG, 2, 0);
+    advance();
+    EXPECT_FALSE(ucp_datatype_iter_is_end(&m_dt_iter));
+
+    /* Zero-length element between fragmented and whole elements is skipped */
+    EXPECT_EQ(1u, next_frag(MAX_FRAG));
+    check_frag(3, 0, MAX_FRAG, 4, 0);
+    advance();
+    EXPECT_FALSE(ucp_datatype_iter_is_end(&m_dt_iter));
+
+    /* Trailing zero-length element produces no descriptor */
+    EXPECT_EQ(0u, next_frag(MAX_FRAG));
+    check_next_iter(5, 0);
+    advance();
+    EXPECT_TRUE(ucp_datatype_iter_is_end(&m_dt_iter));
+}
+
+UCS_TEST_F(test_ucp_dt_sgl, iter_next_frag_mixed_lengths) {
+    static constexpr size_t MAX_FRAG  = 32;
+    static constexpr size_t MAX_COUNT = 2;
+
+    init_sgl_iter(3, {16, 80, 16});
+
+    /* A whole element is batched with the first fragment of the next one */
+    ASSERT_EQ(2u, next_batch(MAX_COUNT, MAX_FRAG));
+    check_desc(0, 0, 0, 16);
+    check_desc(1, 1, 0, MAX_FRAG);
+    check_next_iter(1, MAX_FRAG);
+    advance();
+
+    /* Two more fragments of the same element, the last one is the remainder */
+    ASSERT_EQ(2u, next_batch(MAX_COUNT, MAX_FRAG));
+    check_desc(0, 1, MAX_FRAG, MAX_FRAG);
+    check_desc(1, 1, 2 * MAX_FRAG, 80 - (2 * MAX_FRAG));
+    check_next_iter(2, 0);
+    advance();
+
+    ASSERT_EQ(1u, next_batch(MAX_COUNT, MAX_FRAG));
+    check_desc(0, 2, 0, 16);
+    check_next_iter(3, 0);
+    advance();
+    EXPECT_TRUE(ucp_datatype_iter_is_end(&m_dt_iter));
+}
+
+UCS_TEST_F(test_ucp_dt_sgl, iter_seek) {
+    static constexpr size_t MAX_FRAG = 32;
+
+    init_sgl_iter(2, {96, 64});
+    start_partial_elem(MAX_FRAG);
+
+    ucp_datatype_iter_seek(&m_dt_iter, 1, UCS_BIT(UCP_DATATYPE_SGL));
+    check_position(1, 0);
+    EXPECT_FALSE(ucp_datatype_iter_is_end(&m_dt_iter));
+
+    EXPECT_EQ(1u, next_frag(MAX_FRAG));
+    check_frag(1, 0, MAX_FRAG, 1, MAX_FRAG);
+
+    ucp_datatype_iter_seek(&m_dt_iter, 2, UCS_BIT(UCP_DATATYPE_SGL));
+    check_position(2, 0);
+    EXPECT_TRUE(ucp_datatype_iter_is_end(&m_dt_iter));
+}
+
+UCS_TEST_F(test_ucp_dt_sgl, iter_rewind) {
+    static constexpr size_t MAX_FRAG = 32;
+
+    init_sgl_iter(2, {96, 64});
+    start_partial_elem(MAX_FRAG);
+
+    ucp_datatype_iter_rewind(&m_dt_iter, UCS_BIT(UCP_DATATYPE_SGL));
+    check_position(0, 0);
+    EXPECT_FALSE(ucp_datatype_iter_is_end(&m_dt_iter));
+
+    std::vector<size_t> elem_progress(2);
+    while (!ucp_datatype_iter_is_end(&m_dt_iter)) {
+        ASSERT_EQ(1u, next_frag(MAX_FRAG));
+        ASSERT_LT(m_elem_index, m_buffers.size());
+        EXPECT_EQ(UCS_PTR_BYTE_OFFSET(m_buffers[m_elem_index],
+                                      elem_progress[m_elem_index]),
+                  m_buffer);
+        elem_progress[m_elem_index] += m_length;
+        advance();
+    }
+
+    EXPECT_EQ(96u, elem_progress[0]);
+    EXPECT_EQ(64u, elem_progress[1]);
 }
 
 UCS_TEST_F(test_ucp_dt_sgl, init_zero_count) {

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -1428,6 +1428,14 @@ UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_multi_rail,
     }
 }
 
+UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_fragmented_elements,
+                     RUNNING_ON_VALGRIND) {
+    cleanup();
+    modify_config("RMA_ZCOPY_MAX_SEG_SIZE", "256");
+    test_ucp_rma::init();
+    test_put_sgl({255, 256, 257, 1024, 64});
+}
+
 UCS_TEST_P(test_ucp_rma_sgl, put_force_imm_cmpl) {
     static constexpr size_t NUM_ELEMS = 4;
 


### PR DESCRIPTION
Backport #11647.