### PR TITLE
AZP/TESTS: Build once per GPU test row and share the tree with the workers

### DIFF
--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -371,6 +371,7 @@ stages:
         demands: ucx_gpu -equals yes
         test_perf: 1
         container: ubuntu2404_doca31_gpunetio
+        prebuild: yes
     - template: tests.yml
       parameters:
         name: new
@@ -528,6 +529,7 @@ stages:
         test_perf: 0
         container: centos8_cuda11_asan
         asan_check: yes
+        prebuild: yes
     - template: tests.yml
       parameters:
         name: new

--- a/buildlib/pr/tests.yml
+++ b/buildlib/pr/tests.yml
@@ -7,9 +7,52 @@ parameters:
   run_tests: yes
   asan_check: no
   valgrind_check: no
+  # Build once in a separate job and hand the tree to the workers. Only for
+  # container jobs: the build tree holds absolute paths and the container
+  # workspace path is the same on every agent.
+  prebuild: no
 
 jobs:
+  - ${{ if eq(parameters.prebuild, 'yes') }}:
+    - job: build_${{ parameters.name }}
+      pool:
+        name: MLNX
+        demands: ${{ parameters.demands }}
+      displayName: ${{ parameters.name }} prebuild
+      timeoutInMinutes: 120
+      container: ${{ parameters.container }}
+      workspace:
+        clean: all
+      steps:
+        - checkout: self
+          clean: true
+          fetchDepth: 100
+          retryCountOnTaskFailure: 5
+
+        - bash: |
+            source ./buildlib/az-helpers.sh
+            check_gpu ${{ parameters.name }}
+            az_init_modules
+            ./contrib/test_jenkins.sh
+            exit $?
+          displayName: Build for tests
+          env:
+            BUILD_NUMBER: "$(Build.BuildId)-$(Build.BuildNumber)"
+            JOB_URL: "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"
+            EXECUTOR_NUMBER: $(AZP_AGENT_ID)
+            RUN_TESTS: ${{ parameters.run_tests }}
+            ASAN_CHECK: ${{ parameters.asan_check }}
+            BUILD_ONLY_TARBALL: $(Build.ArtifactStagingDirectory)/ucx-build.tar
+            RUNNING_IN_AZURE: yes
+
+        - task: PublishPipelineArtifact@1
+          inputs:
+            targetPath: $(Build.ArtifactStagingDirectory)/ucx-build.tar
+            artifact: ucx-build-$(System.StageName)-${{ parameters.name }}
+
   - job: tests_${{ parameters.name }}
+    ${{ if eq(parameters.prebuild, 'yes') }}:
+      dependsOn: build_${{ parameters.name }}
     pool:
       name: MLNX
       demands: ${{ parameters.demands }}
@@ -30,6 +73,12 @@ jobs:
         fetchDepth: 100
         retryCountOnTaskFailure: 5
 
+      - ${{ if eq(parameters.prebuild, 'yes') }}:
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifact: ucx-build-$(System.StageName)-${{ parameters.name }}
+            path: $(Pipeline.Workspace)/prebuilt
+
       - bash: |
           source ./buildlib/az-helpers.sh
           check_gpu ${{ parameters.name }}
@@ -49,3 +98,5 @@ jobs:
           ASAN_CHECK: ${{ parameters.asan_check }}
           VALGRIND_CHECK: ${{ parameters.valgrind_check }}
           RUNNING_IN_AZURE: yes
+          ${{ if eq(parameters.prebuild, 'yes') }}:
+            PREBUILT_TARBALL: $(Pipeline.Workspace)/prebuilt/ucx-build.tar

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -17,6 +17,8 @@
 #  - TEST_PERF         : whether to validate performance
 #  - ASAN_CHECK        : set to enable Address Sanitizer instrumentation build
 #  - VALGRIND_CHECK    : set to enable running tests with Valgrind
+#  - BUILD_ONLY_TARBALL: build for tests, pack the tree into this tarball, exit
+#  - PREBUILT_TARBALL  : use the build tree from this tarball instead of building
 #
 # Optional environment variables (could be set by job configuration):
 #  - nworkers : number of parallel executors
@@ -1436,10 +1438,13 @@ run_configure_tests() {
 }
 
 #
-# Run all tests
+# Build for devel tests and gtest, or for ASAN
 #
-run_tests() {
-	export UCX_PROTO_REQUEST_RESET=y
+build_for_tests() {
+	if [[ "$ASAN_CHECK" == "yes" ]]; then
+		build devel --enable-gtest --enable-asan --without-valgrind
+		return
+	fi
 
 	# all are running mpi tests
 	run_mpi_tests
@@ -1447,8 +1452,16 @@ run_tests() {
 	# configuration related tests
 	run_configure_tests
 
-	# build for devel tests and gtest
 	build devel --enable-gtest --without-valgrind
+}
+
+#
+# Run all tests
+#
+run_tests() {
+	export UCX_PROTO_REQUEST_RESET=y
+
+	[ -n "$PREBUILT_TARBALL" ] || build_for_tests
 
 	# devel mode tests
 	do_distributed_task 0 4 test_unused_env_var
@@ -1486,7 +1499,7 @@ run_tests() {
 }
 
 run_asan_check() {
-	build devel --enable-gtest --enable-asan --without-valgrind
+	[ -n "$PREBUILT_TARBALL" ] || build_for_tests
 
 	if ! ldd ${WORKSPACE}/build-test/test/gtest/gtest | grep -q "libasan.so"
 	then
@@ -1518,12 +1531,22 @@ run_valgrind_check() {
 prepare
 try_load_cuda_env
 
+if [ -n "$PREBUILT_TARBALL" ]
+then
+	# -m stamps the extracted files with the current time, so make treats the
+	# prebuilt objects as newer than the fresh checkout
+	tar -xmf "$PREBUILT_TARBALL" -C ${WORKSPACE}
+fi
+
 if [ "$RUN_TESTS" == "yes" ]
 then
     check_machine
     set_ucx_common_test_env
 
-    if [[ "$ASAN_CHECK" == "yes" ]]; then
+    if [ -n "$BUILD_ONLY_TARBALL" ]; then
+        build_for_tests
+        tar -cf "$BUILD_ONLY_TARBALL" -C ${WORKSPACE} build-test install
+    elif [[ "$ASAN_CHECK" == "yes" ]]; then
         run_asan_check
     elif [[ "$VALGRIND_CHECK" == "yes" ]]; then
         run_valgrind_check


### PR DESCRIPTION
## What?
Add an optional `prebuild` mode to `buildlib/pr/tests.yml`: one job builds UCX for the row, publishes `build-test` + `install` as a pipeline artifact, and the four worker jobs download it and skip their own build. Enabled for the two GPU rows (`Tests/gpu`, `AddressSanitizer/gpu`).

## Why?
Each worker of a test row runs `build devel --enable-gtest` before its share of the tests, so a row builds the same tree four times per PR build. On the GPU pool, which is 100% booked and has the longest queue in the pipeline, the build is 15-40% of every job (measured on build 133940: 18-49 min of 112-150 min per Tests worker, 22 of 52 min per ASAN worker). Building once cuts roughly 150 GPU slot-minutes per PR build.

## How?
- `test_jenkins.sh`: `BUILD_ONLY_TARBALL` builds (mpi tests, configure tests, `build devel`, or the ASAN build) and packs the tree; `PREBUILT_TARBALL` extracts it with `tar -m` so the objects are newer than the fresh checkout and `make` does not rebuild them. The rest of the flow is unchanged.
- `tests.yml`: `prebuild: yes` adds a `build_<name>` job with the same demands and container, and makes the workers depend on it and download the artifact.
- Only container rows can use this: the build tree holds absolute paths and the container workspace path is the same on every agent. The host rows (`new`, `roce`, `BlueField`) keep building per worker.
