### PR TITLE
TEST/UCP: Allow non-contiguous mlx5 devices

### DIFF
--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -520,7 +520,6 @@ protected:
     /* Count how many mlx5 devices exist */
     static unsigned get_mlx5_device_count(const entity &e)
     {
-        unsigned max_idx = 0;
         unsigned count   = 0;
 
         for (const std::string &dev_name :
@@ -529,15 +528,8 @@ protected:
             if (sscanf(dev_name.c_str(), "mlx5_%u:%u", &idx, &port) == 2) {
                 EXPECT_EQ(port, 1)
                         << "Expected port 1 for mlx5 device, found: " << port;
-                max_idx = std::max(max_idx, idx);
                 count++;
             }
-        }
-
-        if (count > 0) {
-            /* Assuming we have all devices from 0 to max_idx */
-            EXPECT_EQ(max_idx + 1, count) << "Expected " << (max_idx + 1)
-                                          << " mlx5 devices, found: " << count;
         }
 
         return count;

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -520,6 +520,7 @@ protected:
     /* Count how many mlx5 devices exist */
     static unsigned get_mlx5_device_count(const entity &e)
     {
+        unsigned max_idx = 0;
         unsigned count   = 0;
 
         for (const std::string &dev_name :
@@ -528,8 +529,18 @@ protected:
             if (sscanf(dev_name.c_str(), "mlx5_%u:%u", &idx, &port) == 2) {
                 EXPECT_EQ(port, 1)
                         << "Expected port 1 for mlx5 device, found: " << port;
+                max_idx = std::max(max_idx, idx);
                 count++;
             }
+        }
+
+        /*
+        * Range tests assume devices mlx5_0 .. mlx5_<max_idx>. This assumption
+        * can break in virtualized environments with devices that may use any idx.
+        */
+        if ((count > 0) && ((max_idx + 1) != count)) {
+            UCS_TEST_SKIP_R("mlx5 devices are not numbered from 0 to " +
+                        std::to_string(max_idx));
         }
 
         return count;

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -534,8 +534,7 @@ protected:
             }
         }
 
-        /*
-         * Range tests assume devices mlx5_0 .. mlx5_<max_idx>. This assumption
+         /* Range tests assume devices mlx5_0 .. mlx5_<max_idx>. This assumption
          * can break in virtualized environments with devices that may use any
          * idx. */
         if ((count > 0) && ((max_idx + 1) != count)) {

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -535,12 +535,13 @@ protected:
         }
 
         /*
-        * Range tests assume devices mlx5_0 .. mlx5_<max_idx>. This assumption
-        * can break in virtualized environments with devices that may use any idx.
-        */
+         * Range tests assume devices mlx5_0 .. mlx5_<max_idx>. This assumption
+         * can break in virtualized environments with devices that may use any
+         * idx.
+         */
         if ((count > 0) && ((max_idx + 1) != count)) {
             UCS_TEST_SKIP_R("mlx5 devices are not numbered from 0 to " +
-                        std::to_string(max_idx));
+                            std::to_string(max_idx));
         }
 
         return count;

--- a/test/gtest/ucp/test_ucp_context.cc
+++ b/test/gtest/ucp/test_ucp_context.cc
@@ -537,8 +537,7 @@ protected:
         /*
          * Range tests assume devices mlx5_0 .. mlx5_<max_idx>. This assumption
          * can break in virtualized environments with devices that may use any
-         * idx.
-         */
+         * idx. */
         if ((count > 0) && ((max_idx + 1) != count)) {
             UCS_TEST_SKIP_R("mlx5 devices are not numbered from 0 to " +
                             std::to_string(max_idx));


### PR DESCRIPTION
Removes assumption that mlx5 devices always start at mlx5_0 and go up to mlx5_n with a valid device in each slot. This allows for testing setups with sparse configurations

## What?
Removes assumption that mlx5 devices always start at mlx5_0 and go up to mlx5_n with a valid device in each slot. This allows for testing setups with sparse configurations.

## Why?
Blossom CI setup configures a single virtualized device per pod typically not mlx5_0. For example, mlx5_18.