### PR TITLE
UCP/PROTO: Keep direct-access protocols eligible for CPU-accessible memory

### DIFF
--- a/src/ucp/proto/proto_init.c
+++ b/src/ucp/proto/proto_init.c
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2021. ALL RIGHTS RESERVED.
+ * Copyright (C) Intel Corporation, 2026. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -274,6 +275,23 @@ ucp_proto_init_add_memreg_time(const ucp_proto_common_init_params_t *params,
     return status;
 }
 
+/*
+ * Whether copying between the given memory types is done by a CPU memcpy rather
+ * than by a memtype endpoint. Protocols which access the buffer directly don't
+ * set a memtype operation, see ucp_proto_common_check_mem_access().
+ */
+static int
+ucp_proto_buffer_copy_is_memcpy(ucs_memory_type_t local_mem_type,
+                                ucs_memory_type_t remote_mem_type,
+                                uct_ep_operation_t memtype_op)
+{
+    return (UCP_MEM_IS_HOST(local_mem_type) &&
+            UCP_MEM_IS_HOST(remote_mem_type)) ||
+           ((memtype_op == UCT_EP_OP_LAST) &&
+            UCP_MEM_IS_ACCESSIBLE_FROM_CPU(local_mem_type) &&
+            UCP_MEM_IS_ACCESSIBLE_FROM_CPU(remote_mem_type));
+}
+
 static ucp_proto_perf_factor_id_t
 ucp_proto_buffer_copy_factor_id(ucs_memory_type_t local_mem_type,
                                 ucs_memory_type_t remote_mem_type,
@@ -286,6 +304,17 @@ ucp_proto_buffer_copy_factor_id(ucs_memory_type_t local_mem_type,
      * while eager procols that imply blocking copy set SHORT */
     if ((memtype_op == UCT_EP_OP_GET_SHORT) ||
         (memtype_op == UCT_EP_OP_PUT_SHORT) || h2h) {
+        return ucp_proto_buffer_copy_cpu_factor_id(is_local);
+    }
+
+    /* Direct buffer access is allowed only when both buffers are CPU
+     * accessible, in which case the copy is done by the CPU */
+    if (memtype_op == UCT_EP_OP_LAST) {
+        ucs_assertv(UCP_MEM_IS_ACCESSIBLE_FROM_CPU(local_mem_type) &&
+                    UCP_MEM_IS_ACCESSIBLE_FROM_CPU(remote_mem_type),
+                    "local_mem_type=%s remote_mem_type=%s",
+                    ucs_memory_type_names[local_mem_type],
+                    ucs_memory_type_names[remote_mem_type]);
         return ucp_proto_buffer_copy_cpu_factor_id(is_local);
     }
 
@@ -322,7 +351,8 @@ ucp_proto_init_add_buffer_copy_time(ucp_worker_h worker, const char *title,
     buffer_copy_factor_id = ucp_proto_buffer_copy_factor_id(local_mem_type,
                                                             remote_mem_type,
                                                             memtype_op, local);
-    if (UCP_MEM_IS_HOST(local_mem_type) && UCP_MEM_IS_HOST(remote_mem_type)) {
+    if (ucp_proto_buffer_copy_is_memcpy(local_mem_type, remote_mem_type,
+                                        memtype_op)) {
         perf_factors[buffer_copy_factor_id] =
                 ucs_linear_func_make(0, 1.0 / context->config.ext.bcopy_bw);
         perf_node = ucp_proto_perf_node_new_data(title, "memcpy");

--- a/test/gtest/ucp/test_ucp_proto.cc
+++ b/test/gtest/ucp/test_ucp_proto.cc
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2020-2026. ALL RIGHTS RESERVED.
+ * Copyright (C) Intel Corporation, 2026. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -1074,6 +1075,49 @@ UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_cuda_async_non_reg, rcx,
                               "rc_x,cuda_copy")
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_cuda_async_non_reg, rcv,
                               "rc_v,cuda_copy")
+
+class test_ucp_proto_ze : public test_ucp_proto {
+public:
+    static void get_test_variants(std::vector<ucp_test_variant> &variants)
+    {
+        add_variant(variants, UCP_FEATURE_TAG);
+    }
+
+protected:
+    void init() override
+    {
+        if (!mem_buffer::is_mem_type_supported(UCS_MEMORY_TYPE_ZE_HOST)) {
+            UCS_TEST_SKIP_R("ZE memory is not supported");
+        }
+
+        test_ucp_proto::init();
+    }
+};
+
+/* ZE-host and ZE-managed memory is accessible from the CPU, so protocols which
+ * access the payload directly (memtype_op == UCT_EP_OP_LAST) have to stay
+ * eligible for it. This covers protocol selection only, it does not exercise
+ * data movement. */
+UCS_TEST_P(test_ucp_proto_ze, cpu_accessible_direct_proto_eligible,
+           "RNDV_THRESH=inf")
+{
+    static const ucs_memory_type_t mem_types[] = {UCS_MEMORY_TYPE_ZE_HOST,
+                                                  UCS_MEMORY_TYPE_ZE_MANAGED};
+
+    for (auto mem_type : mem_types) {
+        if (!mem_buffer::is_mem_type_supported(mem_type)) {
+            continue;
+        }
+
+        const ucp_proto_threshold_elem_t *thresh =
+                select_tag_send_protocol(mem_type, 1);
+        ASSERT_NE(nullptr, thresh);
+        EXPECT_STREQ("egr/short", thresh->proto_config.proto->name)
+                << "mem_type=" << ucs_memory_type_names[mem_type];
+    }
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_proto_ze, rcx_ze, "rc_x,ze_copy")
 
 class test_perf_node : public test_ucp_proto {
 };


### PR DESCRIPTION
## What?

Protocols which access the payload directly do not set a memtype operation, and
`ucp_proto_common_check_mem_access()` explicitly permits `UCT_EP_OP_LAST` when
the memory is accessible from the CPU. The performance estimation path did not
follow that contract, in two ways:

- `ucp_proto_buffer_copy_factor_id()` asserted that the operation is
  `GET_ZCOPY` or `PUT_ZCOPY`, so any CPU-accessible memory type other than plain
  host aborted:

   ```sh
   proto_init.c:292  Assertion `(memtype_op == UCT_EP_OP_GET_ZCOPY) || (memtype_op == UCT_EP_OP_PUT_ZCOPY)' failed: memtype_op=16
   ```

- `ucp_proto_init_add_buffer_copy_time()` modeled a plain memcpy only when both
buffers are `UCS_MEMORY_TYPE_HOST`. Other CPU-accessible types fell through to
the memtype endpoint lookup and returned `UCS_ERR_UNSUPPORTED`, which silently
dropped the protocol.

Both affect the memory types in `UCS_MEMORY_TYPES_CPU_ACCESSIBLE` which are not
plain host memory: ze-host, ze-managed and rocm-managed.

Add `ucp_proto_buffer_copy_is_memcpy()` to decide when the copy is performed by
the CPU, and use it for the memcpy estimation. Keep the explicit
`UCT_EP_OP_LAST` branch in `ucp_proto_buffer_copy_factor_id()` to assert that
both buffers are CPU-accessible and report their memory types if that contract
is violated, rather than producing the misleading zero-copy-operation assertion.

## Why?

With `rc_x` and `ze_copy`, initiating a 4 MB tag send from ze-host memory
aborted while initializing protocol candidates. Even with the assertion
silenced, the protocol was silently dropped, so direct-access protocols were
never eligible for CPU-accessible non-host memory.

## How?

The predicate is deliberately narrow: it treats the copy as a memcpy only for
host/host, or for `UCT_EP_OP_LAST` with both sides CPU-accessible. Widening it
to all CPU-accessible pairs would also re-model rocm-managed and ze-managed
`*_SHORT` operations as `bcopy_bw` instead of querying the copy interface, which
is a behavior change beyond this fix.

`test_ucp_proto_ze.cpu_accessible_direct_proto_eligible` verifies that
`egr/short` is selected for each supported CPU-accessible ZE memory type under
`RNDV_THRESH=inf`. Reverting only `proto_init.c` makes it reproduce the original
assertion failure. This is protocol-selection coverage only; it does not
exercise data movement.

Tested on Intel Arc Pro B60, `rc_mlx5` over RoCE:

- Protocol initialization completes. For messages in the 0..2038-byte range,
ze-host and ze-managed select "eager short" instead of "eager copy-in
copy-out". ze-device is not CPU accessible and is unchanged.
- `ucx_perftest tag_lat -V` passes for ze-host and ze-managed, which aborted before.

This touches generic protocol code, so it affects every backend — rocm-managed
is in the same class as the ZE types. Validation was only possible on Intel
hardware, so CUDA/ROCm CI coverage is worth confirming, particularly
managed-memory protocol selection.