### PR TITLE
UCT/ZE/COPY: Allocate DMA-BUF-exportable memory for RDMA

### DIFF
--- a/src/uct/ib/base/ib_md.c
+++ b/src/uct/ib/base/ib_md.c
@@ -2,6 +2,7 @@
  * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
  * Copyright (C) The University of Tennessee and The University
  *               of Tennessee Research Foundation. 2016. ALL RIGHTS RESERVED.
+ * Copyright (C) Intel Corporation, 2026. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
  */
@@ -1446,14 +1447,13 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
         /* check if ROCM KFD driver is loaded */
         uct_ib_check_gpudirect_driver(md, "/dev/kfd", UCS_MEMORY_TYPE_ROCM);
 
-        /* Check if Intel Xe driver is loaded */
-        uct_ib_check_gpudirect_driver(md, "/sys/module/xe/srcversion",
-                                      UCS_MEMORY_TYPE_ZE_DEVICE);
-
         /* Check for HabanaLabs Gaudi DMABuf support */
         uct_ib_check_gpudirect_driver(md, "/dev/accel/accel0",
                                       UCS_MEMORY_TYPE_GAUDI);
         uct_ib_check_gpudirect_driver(md, "/dev/hl0", UCS_MEMORY_TYPE_GAUDI);
+
+        /* Do not infer Level Zero device-memory registration support from the
+         * presence of the Xe module. DMA-BUF support is detected below. */
 
         /* Check for dma-buf support */
         uct_ib_md_check_dmabuf(md);
@@ -1463,15 +1463,19 @@ ucs_status_t uct_ib_md_open_common(uct_ib_md_t *md,
         !(md->cap_flags & UCT_MD_FLAG_REG_DMABUF) &&
         (md_config->enable_gpudirect_rdma == UCS_YES)) {
         ucs_error("%s: Couldn't enable GPUDirect RDMA. Please make sure "
-                  "nv_peer_mem, amdgpu plugin, or Intel Xe driver is "
-                  "installed correctly, or dmabuf is supported.",
+                  "nv_peer_mem or amdgpu plugin is installed correctly, or "
+                  "dmabuf is supported.",
                   uct_ib_device_name(&md->dev));
         status = UCS_ERR_UNSUPPORTED;
         goto err_cleanup_device;
     }
 
+    /* Limit the number of SGEs dumped by the packet tracer, so that it does not
+     * dereference non-host memory from the CPU. DMA-BUF registration makes such
+     * memory reachable without it being listed in 'reg_mem_types'. */
     md->dev.max_zcopy_log_sge = INT_MAX;
-    if (md->reg_mem_types & ~UCS_BIT(UCS_MEMORY_TYPE_HOST)) {
+    if ((md->reg_mem_types & ~UCS_BIT(UCS_MEMORY_TYPE_HOST)) ||
+        (md->cap_flags & UCT_MD_FLAG_REG_DMABUF)) {
         md->dev.max_zcopy_log_sge = 1;
     }
 

--- a/src/uct/ze/copy/ze_copy_md.c
+++ b/src/uct/ze/copy/ze_copy_md.c
@@ -22,6 +22,11 @@
 #include <ucs/memory/memtype_cache.h>
 
 
+/* Memory types which can be exported as a DMA-BUF file descriptor */
+#define UCT_ZE_COPY_MD_DMABUF_MEM_TYPES \
+    (UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) | UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE))
+
+
 static ucs_config_field_t uct_ze_copy_md_config_table[] = {
     {"", "", NULL, ucs_offsetof(uct_ze_copy_md_config_t, super),
      UCS_CONFIG_TYPE_TABLE(uct_md_config_table)},
@@ -31,11 +36,43 @@ static ucs_config_field_t uct_ze_copy_md_config_table[] = {
      ucs_offsetof(uct_ze_copy_md_config_t, device_ordinal),
      UCS_CONFIG_TYPE_INT},
 
+    {"DMABUF", "try",
+     "Enable using cross-device dmabuf file descriptor.\n"
+     "Level Zero device memory may have to be allocated with external\n"
+     "DMA-BUF export enabled. Without it, registration can succeed but an\n"
+     "RDMA device may read incorrect data, and no error is reported. Set to\n"
+     "'n' if the application allocates Level Zero memory without\n"
+     "requesting external export.",
+     ucs_offsetof(uct_ze_copy_md_config_t, enable_dmabuf),
+     UCS_CONFIG_TYPE_TERNARY},
+
     {NULL}
 };
 
+static int uct_ze_copy_md_is_dmabuf_supported(ze_device_handle_t ze_device)
+{
+    ze_device_external_memory_properties_t props = {
+        .stype = ZE_STRUCTURE_TYPE_DEVICE_EXTERNAL_MEMORY_PROPERTIES
+    };
+    int supported;
+
+    if (UCT_ZE_FUNC_LOG_DEBUG(
+                zeDeviceGetExternalMemoryProperties(ze_device, &props)) !=
+        UCS_OK) {
+        return 0;
+    }
+
+    supported = !!(props.memoryAllocationExportTypes &
+                   ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF);
+    ucs_debug("ze device %p: DMA-BUF export is%s supported", ze_device,
+              supported ? "" : " not");
+    return supported;
+}
+
 static ucs_status_t uct_ze_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
 {
+    uct_ze_copy_md_t *ze_md = ucs_derived_of(md, uct_ze_copy_md_t);
+
     uct_md_base_md_query(md_attr);
     md_attr->flags            = UCT_MD_FLAG_REG | UCT_MD_FLAG_ALLOC;
     md_attr->reg_mem_types    = UCS_BIT(UCS_MEMORY_TYPE_HOST) |
@@ -55,8 +92,8 @@ static ucs_status_t uct_ze_copy_md_query(uct_md_h md, uct_md_attr_v2_t *md_attr)
     md_attr->detect_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
                                 UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE) |
                                 UCS_BIT(UCS_MEMORY_TYPE_ZE_MANAGED);
-    md_attr->dmabuf_mem_types = UCS_BIT(UCS_MEMORY_TYPE_ZE_HOST) |
-                                UCS_BIT(UCS_MEMORY_TYPE_ZE_DEVICE);
+    md_attr->dmabuf_mem_types = ze_md->enable_dmabuf ?
+                                UCT_ZE_COPY_MD_DMABUF_MEM_TYPES : 0;
     md_attr->max_alloc        = SIZE_MAX;
     return UCS_OK;
 }
@@ -66,7 +103,18 @@ uct_ze_copy_mem_alloc(uct_md_h tl_md, size_t *length_p, void **address_p,
                       ucs_memory_type_t mem_type, ucs_sys_device_t sys_dev,
                       unsigned flags, const char *alloc_name, uct_mem_h *memh_p)
 {
-    uct_ze_copy_md_t *md                = ucs_derived_of(tl_md, uct_ze_copy_md_t);
+    uct_ze_copy_md_t *md = ucs_derived_of(tl_md, uct_ze_copy_md_t);
+    /* Request DMA-BUF exportability for the memory types advertised in
+     * 'dmabuf_mem_types', and only for those, so that allocating a type without
+     * a DMA-BUF path cannot fail because of the descriptor. Level Zero may
+     * return a DMA-BUF for an allocation which was not created for external
+     * export, but such a handle does not necessarily describe the requested
+     * range, and an RDMA device may read incorrect data through it. */
+    ze_external_memory_export_desc_t export_desc = {
+        .stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_EXPORT_DESC,
+        .flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF
+    };
+    void *export_desc_p                 = NULL;
     ze_host_mem_alloc_desc_t host_desc  = {
         .stype = ZE_STRUCTURE_TYPE_HOST_MEM_ALLOC_DESC
     };
@@ -76,13 +124,20 @@ uct_ze_copy_mem_alloc(uct_md_h tl_md, size_t *length_p, void **address_p,
     size_t alignment                    = ucs_get_page_size();
     ucs_status_t status;
 
+    if (md->enable_dmabuf &&
+        (UCS_BIT(mem_type) & UCT_ZE_COPY_MD_DMABUF_MEM_TYPES)) {
+        export_desc_p = &export_desc;
+    }
+
     switch (mem_type) {
     case UCS_MEMORY_TYPE_ZE_HOST:
+        host_desc.pNext = export_desc_p;
         status = UCT_ZE_FUNC_LOG_ERR(zeMemAllocHost(md->ze_context, &host_desc,
                                                     *length_p, alignment,
                                                     address_p));
         break;
     case UCS_MEMORY_TYPE_ZE_DEVICE:
+        dev_desc.pNext = export_desc_p;
         status = UCT_ZE_FUNC_LOG_ERR(zeMemAllocDevice(md->ze_context, &dev_desc,
                                                       *length_p, alignment,
                                                       md->ze_device,
@@ -198,12 +253,14 @@ static ucs_status_t uct_ze_copy_md_mem_query(uct_md_h md, const void *addr,
                                              const size_t length,
                                              uct_md_mem_attr_v2_t *mem_attr_p)
 {
-    int dmabuf_fd    = UCT_DMABUF_FD_INVALID;
-    int *dmabuf_fd_p = NULL;
+    uct_ze_copy_md_t *ze_md = ucs_derived_of(md, uct_ze_copy_md_t);
+    int dmabuf_fd           = UCT_DMABUF_FD_INVALID;
+    int *dmabuf_fd_p        = NULL;
     ucs_memory_info_t mem_info;
     ucs_status_t status;
 
-    if (mem_attr_p->field_mask & UCT_MD_MEM_ATTR_V2_FIELD_DMABUF_FD) {
+    if ((mem_attr_p->field_mask & UCT_MD_MEM_ATTR_V2_FIELD_DMABUF_FD) &&
+        ze_md->enable_dmabuf) {
         mem_attr_p->dmabuf_fd = UCT_DMABUF_FD_INVALID;
         dmabuf_fd_p           = &dmabuf_fd;
     }
@@ -302,6 +359,7 @@ uct_ze_copy_md_open(uct_component_h component, const char *md_name,
     ze_context_desc_t context_desc = {};
     ze_result_t ret;
     const uct_ze_subdevice_t *subdevice;
+    int dmabuf_supported;
 
     ze_driver = uct_ze_base_get_driver();
     if (ze_driver == NULL) {
@@ -337,6 +395,16 @@ uct_ze_copy_md_open(uct_component_h component, const char *md_name,
         return UCS_ERR_NO_DEVICE;
     }
 
+    dmabuf_supported = uct_ze_copy_md_is_dmabuf_supported(md->ze_device);
+    if ((config->enable_dmabuf == UCS_YES) && !dmabuf_supported) {
+        ucs_error("%s: DMA-BUF is not supported by the Level Zero device",
+                  md_name);
+        zeContextDestroy(md->ze_context);
+        ucs_free(md);
+        return UCS_ERR_UNSUPPORTED;
+    }
+
+    md->enable_dmabuf   = (config->enable_dmabuf != UCS_NO) && dmabuf_supported;
     md->super.ops       = &md_ops;
     md->super.component = &uct_ze_copy_component;
 

--- a/src/uct/ze/copy/ze_copy_md.h
+++ b/src/uct/ze/copy/ze_copy_md.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Intel Corporation, 2023-2024. ALL RIGHTS RESERVED.
+ * Copyright (C) Intel Corporation, 2023-2026. ALL RIGHTS RESERVED.
  * See file LICENSE for terms.
  */
 
@@ -21,6 +21,7 @@ typedef struct uct_ze_copy_md {
     uct_md_t            super; /**< Domain info */
     ze_context_handle_t ze_context;
     ze_device_handle_t  ze_device;
+    int                 enable_dmabuf; /**< Expose memory as DMA-BUF */
 } uct_ze_copy_md_t;
 
 
@@ -28,8 +29,9 @@ typedef struct uct_ze_copy_md {
  * ze copy domain configuration.
  */
 typedef struct uct_ze_copy_md_config {
-    uct_md_config_t super;
-    int             device_ordinal;
+    uct_md_config_t          super;
+    int                      device_ordinal;
+    ucs_ternary_auto_value_t enable_dmabuf;
 } uct_ze_copy_md_config_t;
 
 

--- a/test/gtest/ucp/test_ucp_mem_type.cc
+++ b/test/gtest/ucp/test_ucp_mem_type.cc
@@ -1,5 +1,6 @@
 /**
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2017. ALL RIGHTS RESERVED.
+* Copyright (C) Intel Corporation, 2026. ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
 */
@@ -11,6 +12,7 @@ extern "C" {
 #include <uct/api/uct.h>
 #include <ucp/core/ucp_context.h>
 #include <ucp/core/ucp_mm.h>
+#include <ucp/core/ucp_ep.inl>
 }
 
 
@@ -97,6 +99,206 @@ UCS_TEST_P(test_ucp_mem_type_alloc_before_init, xfer) {
 }
 
 UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_mem_type_alloc_before_init, all, "all")
+
+
+/*
+ * Moves a payload out of memory allocated by UCP, using the transport which
+ * performs the rendezvous zero-copy operation. This covers the registration
+ * path a network transport uses to reach non-host memory directly, including
+ * registration through a DMA-BUF handle: memory which is registered but not
+ * readable by the transport is detected by the payload check rather than
+ * silently reported as a successful transfer.
+ */
+class test_ucp_mem_type_rndv_zcopy : public test_ucp_mem_type {
+public:
+    static const uint64_t SEED = 0x1234567890abcdeflu;
+
+protected:
+    typedef ucs::handle<ucp_mem_h, ucp_context_h> mem_handle_t;
+
+    static void unmap_memh(ucp_mem_h memh, ucp_context_h context)
+    {
+        ucs_status_t status = ucp_mem_unmap(context, memh);
+        if (status != UCS_OK) {
+            ucs_warn("failed to unmap memory: %s", ucs_status_string(status));
+        }
+    }
+
+    void init() override
+    {
+        test_ucp_mem_type::init();
+        sender().connect(&receiver(), get_ep_params());
+        receiver().connect(&sender(), get_ep_params());
+    }
+
+    /* Allocate through UCP so that a memory domain performs the allocation */
+    void *alloc_mem(entity &e, size_t length, ucs_memory_type_t mem_type,
+                    mem_handle_t &memh_handle)
+    {
+        ucp_mem_map_params_t params;
+        ucp_mem_attr_t attr;
+        ucp_mem_h memh;
+        ucs_status_t status;
+
+        params.field_mask  = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                             UCP_MEM_MAP_PARAM_FIELD_LENGTH |
+                             UCP_MEM_MAP_PARAM_FIELD_FLAGS |
+                             UCP_MEM_MAP_PARAM_FIELD_MEMORY_TYPE;
+        params.address     = NULL;
+        params.length      = length;
+        params.flags       = UCP_MEM_MAP_ALLOCATE;
+        params.memory_type = mem_type;
+
+        status = ucp_mem_map(e.ucph(), &params, &memh);
+        if (status != UCS_OK) {
+            UCS_TEST_SKIP_R(std::string("cannot allocate ") +
+                            ucs_memory_type_names[mem_type] + " memory: " +
+                            ucs_status_string(status));
+        }
+
+        memh_handle.reset(memh, unmap_memh, e.ucph());
+
+        attr.field_mask = UCP_MEM_ATTR_FIELD_ADDRESS;
+        status          = ucp_mem_query(memh, &attr);
+        if (status != UCS_OK) {
+            UCS_TEST_ABORT("ucp_mem_query() failed: " +
+                           std::string(ucs_status_string(status)));
+        }
+
+        return attr.address;
+    }
+
+    /*
+     * Memory domains used by the endpoint's rendezvous zero-copy lanes.
+     *
+     * 'remote' returns the destination domains, which is what a GET issued by
+     * this endpoint addresses on its peer, so the indices are in the peer's
+     * domain space. Otherwise the endpoint's own domains are returned, which is
+     * what a PUT issued by this endpoint registers locally.
+     */
+    ucp_md_map_t rndv_zcopy_md_map(entity &e, bool remote)
+    {
+        const ucp_ep_config_t *ep_config = ucp_ep_config(e.ep());
+        ucp_context_h context            = e.ucph();
+        ucp_md_map_t md_map              = 0;
+        ucp_lane_index_t i, lane;
+        ucp_rsc_index_t rsc_index;
+
+        for (i = 0; i < UCP_MAX_LANES; ++i) {
+            lane = ep_config->key.rma_bw_lanes[i];
+            if (lane == UCP_NULL_LANE) {
+                break;
+            }
+
+            if (remote) {
+                md_map |= UCS_BIT(ep_config->key.lanes[lane].dst_md_index);
+            } else {
+                rsc_index = ep_config->key.lanes[lane].rsc_index;
+                md_map   |= UCS_BIT(context->tl_rscs[rsc_index].md_index);
+            }
+        }
+
+        return md_map;
+    }
+
+    std::string md_map_str(entity &e, ucp_md_map_t md_map)
+    {
+        ucp_context_h context = e.ucph();
+        std::string names;
+        ucp_md_index_t md_index;
+
+        ucs_for_each_bit(md_index, md_map) {
+            if (!names.empty()) {
+                names += ",";
+            }
+            names += (md_index < context->num_mds) ?
+                             context->tl_mds[md_index].rsc.md_name :
+                             "<unknown>";
+        }
+
+        return names.empty() ? "<none>" : names;
+    }
+
+    void test_xfer_from_mem_type(size_t length, bool is_get);
+};
+
+void test_ucp_mem_type_rndv_zcopy::test_xfer_from_mem_type(size_t length,
+                                                          bool is_get)
+{
+    const ucs_memory_type_t send_mem_type = mem_type();
+    ucp_request_param_t param;
+    mem_handle_t send_memh, recv_memh;
+    void *send_buf, *recv_buf;
+    void *sreq, *rreq;
+
+    if (!mem_buffer::is_mem_type_supported(send_mem_type)) {
+        UCS_TEST_SKIP_R(std::string(ucs_memory_type_names[send_mem_type]) +
+                        " memory is not supported");
+    }
+
+    /*
+     * Resolve the lanes and the registration capability before allocating, so
+     * that skipping does not leak the memory mappings.
+     */
+    entity &op_entity        = is_get ? receiver() : sender();
+    ucp_md_map_t lane_md_map = rndv_zcopy_md_map(op_entity, is_get);
+    if (lane_md_map == 0) {
+        UCS_TEST_SKIP_R("no rendezvous zero-copy lane is available");
+    }
+
+    if (!(sender().ucph()->reg_md_map[send_mem_type] & lane_md_map)) {
+        UCS_TEST_SKIP_R(
+                std::string("the rendezvous zero-copy lane cannot register ") +
+                ucs_memory_type_names[send_mem_type] + " memory");
+    }
+
+    send_buf = alloc_mem(sender(), length, send_mem_type, send_memh);
+    recv_buf = alloc_mem(receiver(), length, UCS_MEMORY_TYPE_HOST, recv_memh);
+
+    UCS_TEST_MESSAGE << (is_get ? "get" : "put") << " lane mds: "
+                     << md_map_str(sender(), lane_md_map)
+                     << " | source memh mds: "
+                     << md_map_str(sender(), send_memh->md_map);
+
+    EXPECT_NE(0u, send_memh->md_map & lane_md_map)
+            << ucs_memory_type_names[send_mem_type]
+            << " memory is not registered on the memory domain used by the "
+               "rendezvous zero-copy lane, the payload would be staged instead "
+               "of accessed by the transport";
+
+    mem_buffer::pattern_fill(send_buf, length, SEED, send_mem_type);
+    mem_buffer::pattern_fill(recv_buf, length, 0, UCS_MEMORY_TYPE_HOST);
+
+    param.op_attr_mask = UCP_OP_ATTR_FIELD_MEMH;
+    param.memh         = recv_memh;
+    rreq = ucp_tag_recv_nbx(receiver().worker(), recv_buf, length, 1, 1,
+                            &param);
+
+    param.memh = send_memh;
+    sreq       = ucp_tag_send_nbx(sender().ep(), send_buf, length, 1, &param);
+
+    EXPECT_UCS_OK(request_wait(sreq));
+    EXPECT_UCS_OK(request_wait(rreq));
+
+    mem_buffer::pattern_check(recv_buf, length, SEED, UCS_MEMORY_TYPE_HOST);
+}
+
+UCS_TEST_P(test_ucp_mem_type_rndv_zcopy, get_zcopy, "RNDV_THRESH=0",
+           "RNDV_SCHEME=get_zcopy")
+{
+    test_xfer_from_mem_type(4 * UCS_MBYTE, true);
+}
+
+UCS_TEST_P(test_ucp_mem_type_rndv_zcopy, put_zcopy, "RNDV_THRESH=0",
+           "RNDV_SCHEME=put_zcopy")
+{
+    test_xfer_from_mem_type(4 * UCS_MBYTE, false);
+}
+
+UCP_INSTANTIATE_TEST_CASE_TLS_GPU_AWARE(test_ucp_mem_type_rndv_zcopy, rcx,
+                                        "rc_x")
+UCP_INSTANTIATE_TEST_CASE_TLS(test_ucp_mem_type_rndv_zcopy, rcx_ze,
+                              "rc_x,ze_copy")
 
 class test_ucp_cuda : public ucp_test {
 public:


### PR DESCRIPTION
Depends on #11902, which must merge first. Without it, the ze-host and
ze-managed variants of the test added here abort in protocol initialization.

## What?

Level Zero device memory may have to be allocated with external DMA-BUF export
enabled. The ze_copy memory domain advertised ze-host and ze-device in
`dmabuf_mem_types` and returned a file descriptor from
`zeMemGetAllocProperties()`, but allocated without an export descriptor.

- Request DMA-BUF exportability in `uct_ze_copy_mem_alloc()`, and only for the
  memory types advertised in `dmabuf_mem_types`, so allocating a type without a
  DMA-BUF path cannot fail because of the descriptor.
- Add `UCX_ZE_COPY_DMABUF`, following the `cuda_copy` and `rocm_copy` pattern:
  query export support once at `md_open()` with `zeDeviceGetExternalMemoryProperties()`,
  fail `md_open()` when `y` is requested but unsupported, and advertise `dmabuf_mem_types`
  and return a DMA-BUF file descriptor only when effectively enabled.
- Remove the Intel Xe module heuristic from the IB memory domain, which claimed
  plain `ibv_reg_mr()` could register ze-device memory.
- Apply the packet-tracer SGE bound whenever the IB memory domain supports
  DMA-BUF registration.

## Why?

A DMA-BUF obtained without an export descriptor does not necessarily describe
the requested range. Registration succeeds, the transfer completes, the
completion is `UCS_OK`, and the payload is wrong. Nothing reports an error at
any layer:

```sh
ucx_perftest -t tag_lat -m ze-device -V -s 4194304   # UCX_TLS=rc,ze_copy
ucp_tests.h:166  UCX  ERROR data validation failed at offset 0: got 0x0 expected 0x1
```

On the tested systems, writes into ze-device memory were unaffected; failures
occurred only in flows where the RDMA device read from ze-device memory. Such
transfers returned UCS_OK, but the destination contained incorrect data.

## How?

UCP already routes DMA-BUF registration by combining a provider's `dmabuf_mem_types`
with an RDMA memory domain's `UCT_MD_FLAG_REG_DMABUF`. Therefore, removing the
Xe heuristic does not disable the DMA-BUF GPUDirect RDMA path when both capabilities
are available. With  `UCX_ZE_COPY_DMABUF=n` that heuristic made UCP attempt an
ordinary registration which failed with EFAULT instead of staging through `ze_copy`. Removing
ZE device memory from the IB MD's `reg_mem_types` also disabled the packet-tracer
bound, hence extending it to any DMA-BUF-capable IB memory domain; otherwise
tracing may dereference device memory from the CPU.

Memory allocated by an application without requesting external export cannot be
repaired by UCX, so `UCX_ZE_COPY_DMABUF=n` is available to disable DMA-BUF
registration for it.

`test_ucp_mem_type_rndv_zcopy` sends from memory allocated by
`ucp_mem_map(UCP_MEM_MAP_ALLOCATE)` to a host buffer using a forced rendezvous
zero-copy lane and verifies a non-zero pattern. It asserts that the source
memory handle is registered on a memory domain used by a rendezvous zero-copy
lane, preventing a staged-only transfer from passing silently, and skips when
that lane cannot register the memory type. It is parameterized over all memory
types and instantiated for `rc_x` plus `rc_x,ze_copy`, so CUDA and ROCm are
covered where present and ZE variants skip cleanly where `ze_copy` is
unavailable. Reverting only the export descriptor makes both the `get_zcopy`
and `put_zcopy` ze-device variants fail the pattern check with zeros.

Tested on Intel Arc Pro B60 (Battlemage), `rc_mlx5` over RoCE:

- 27 gtests pass: `test_ucp_mem_type_rndv_zcopy` (16), `test_ucp_proto_ze` (1),
  `ze_cpy/test_md_dmabuf` (1), `ze_copy/test_ze_copy_rma` (9).
- `ucx_perftest tag_lat -V` passes for ze-device, ze-host, ze-managed, host and
  the mixed host/ze-device pairs, including `UCX_ZE_COPY_DMABUF=n` and `=y`.
  GPUDirect RDMA is confirmed active with DMA-BUF versus staged with `DMABUF=n`.

Known limitation: UCT-level `ucx_perftest` has no DMA-BUF registration path:
`uct_perf_md_mem_reg()` does not supply a DMA-BUF fd. Before this change,
`-x rc_mlx5 -m ze-device` relied on the Xe module heuristic and attempted
`ibv_reg_mr()` on a device pointer; on the tested systems, this failed with
`EFAULT`. After removing ze-device from the IB MD's `reg_mem_types`,
`uct_perf_test_check_md_support()` rejects this invocation up front instead:
```sh
    Unsupported memory type ze-device by rc_mlx5/...
```
This does not imply that ordinary registration is unsupported on every
platform; only that the presence of the Xe module is insufficient evidence of
that capability. Adding DMA-BUF registration to UCT-level perftest is left for
a separate change.

UCP-level perftest is unaffected. The ZE allocator provides no `mem_alloc`
hook, so UCP allocates the buffer itself through
`ucp_mem_map(UCP_MEM_MAP_ALLOCATE)` with the requested memory type and
registers it through UCP's DMA-BUF path.


