### PR TITLE
UCT/CUDA/CUDA_IPC: Fix call to CUDA API

### DIFF
--- a/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
+++ b/src/uct/cuda/cuda_ipc/cuda_ipc_md.c
@@ -384,7 +384,7 @@ uct_cuda_ipc_mem_add_reg(void *addr, uct_cuda_ipc_memh_t *memh,
 legacy_path:
     key->ph.handle_type = UCT_CUDA_IPC_KEY_HANDLE_TYPE_LEGACY;
     status              = UCT_CUDADRV_FUNC_LOG_ERR(
-            cuIpcGetMemHandle(&key->ph.handle.legacy, (CUdeviceptr)addr));
+            cuIpcGetMemHandle(&key->ph.handle.legacy, (CUdeviceptr)key->d_bptr));
     if (status != UCS_OK) {
         goto out_pop_ctx;
     }


### PR DESCRIPTION
## What?
Fix param sent to cuIpcGetMemHandle. Send the base pointer instead of address inside allocation, as defined in cuda api docs.

## Why?
#11724 

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
