### PR TITLE
CI: Add Fedora 44, Ubuntu 26.10, Azure Linux 4.0, UOS and openEuler 22.03 SP4 / 24.03 SP3

### DIFF
--- a/.ci/pipeline/build_matrix.yaml
+++ b/.ci/pipeline/build_matrix.yaml
@@ -19,6 +19,7 @@ runs_on_dockers:
   - { name: "ubuntu2204-mofed5.7", url: "harbor.mellanox.com/ucx/x86_64/ubuntu22.04/builder:mofed-5.7-0.2.3.0", arch: x86_64 }
   - { name: "ubuntu2404-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0", arch: x86_64 }
   - { name: "ubuntu2604-mofed26.04", url: "harbor.mellanox.com/hpcx/x86_64/ubuntu26.04/builder:mofed-26.04-0.7.6.0", arch: x86_64 }
+  - { name: "ubuntu2610-inbox", url: "harbor.mellanox.com/hpcx/x86_64/ubuntu26.10/builder:inbox", arch: x86_64 }
   - { name: "rocky89-mofed24.10", url: "harbor.mellanox.com/hpcx/x86_64/rocky8.9/builder:mofed-24.10-3.2.5.0", arch: x86_64 }
   - { name: "rocky96-mofed24.10", url: "harbor.mellanox.com/hpcx/x86_64/rocky9.6/builder:mofed-24.10-3.2.5.0", arch: x86_64 }
   - { name: "debian125-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/debian12.5/builder:doca-2.9.0", arch: x86_64 }
@@ -26,6 +27,9 @@ runs_on_dockers:
   - { name: "debian130-doca3.2", url: "harbor.mellanox.com/hpcx/x86_64/debian13.0/builder:doca-3.2.0", arch: x86_64 }
   - { name: "centos10stream-inbox", url: "harbor.mellanox.com/hpcx/x86_64/centos10stream/builder:inbox", arch: x86_64 }
   - { name: "fedora41-inbox", url: "harbor.mellanox.com/hpcx/x86_64/fedora41/builder:inbox", arch: x86_64 }
+  - { name: "fedora44-inbox", url: "harbor.mellanox.com/hpcx/x86_64/fedora44/builder:inbox", arch: x86_64 }
+  # Azure Linux 4.0 is in public preview; the image tracks the azurelinux-beta channel.
+  - { name: "azurelinux40-inbox", url: "harbor.mellanox.com/hpcx/x86_64/azurelinux4.0/builder:inbox", arch: x86_64 }
   - { name: "rhel82-mofed5.0", url: "harbor.mellanox.com/ucx/x86_64/rhel8.2/builder:mofed-5.0-1.0.0.0", arch: x86_64 }
   - { name: "rhel90-mofed5.6", url: "harbor.mellanox.com/ucx/x86_64/rhel9.0/builder:mofed-5.6-0.5.0.0", arch: x86_64 }
   - { name: "rhel100-mofed25.07", url: "harbor.mellanox.com/hpcx/x86_64/rhel10.0/builder:mofed-25.07-0.9.7.0", arch: x86_64 }
@@ -33,13 +37,25 @@ runs_on_dockers:
   - { name: "sles16sp0-mofed26.01", url: "harbor.mellanox.com/hpcx/x86_64/sles16sp0/builder:mofed-26.01-0.8.0.0", arch: x86_64 }
   - { name: "kylin10sp3-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/kylin10sp3/builder:doca-2.9.0", arch: x86_64 }
   - { name: "euleros2sp12-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/euleros2.0sp12/builder:doca-2.9.0", arch: x86_64 }
+  - { name: "openeuler2203sp4-doca3.5", url: "harbor.mellanox.com/hpcx/x86_64/openeuler22.03sp4/builder:doca-3.5.0", arch: x86_64 }
+  - { name: "openeuler2403sp3-doca3.5", url: "harbor.mellanox.com/hpcx/x86_64/openeuler24.03sp3/builder:doca-3.5.0", arch: x86_64 }
   - { name: "ctyunos2507-mofed26.01", url: "harbor.mellanox.com/hpcx/x86_64/ctyunos25.07/builder:mofed-26.01-0.8.0.0", arch: x86_64 }
   - { name: "tencentos44-mofed26.04", url: "harbor.mellanox.com/hpcx/x86_64/tencentos4.4/builder:mofed-26.04-0.7.6.0", arch: x86_64 }
+  # 20.1060a is the newest UOS rootfs on urm; DOCA publishes it for x86_64 only.
+  - { name: "uos201060a-doca3.4", url: "harbor.mellanox.com/hpcx/x86_64/uos20.1060a/builder:doca-3.4.0", arch: x86_64 }
   - { name: "ubuntu2004-rocm5.4", url: "harbor.mellanox.com/ucx/x86_64/ubuntu2004:rocm_5_4_0", arch: x86_64 }
   - { name: "ubuntu2204-rocm6.0", url: "harbor.mellanox.com/ucx/x86_64/ubuntu2204:rocm-6.0.0", arch: x86_64 }
   # aarch64
   - { name: "ubuntu2404-doca2.9", url: "harbor.mellanox.com/hpcx/aarch64/ubuntu24.04/builder:doca-2.9.0", arch: aarch64 }
   - { name: "ubuntu2604-mofed26.04", url: "harbor.mellanox.com/hpcx/aarch64/ubuntu26.04/builder:mofed-26.04-0.7.6.0", arch: aarch64 }
+  - { name: "ubuntu2610-inbox", url: "harbor.mellanox.com/hpcx/aarch64/ubuntu26.10/builder:inbox", arch: aarch64 }
+  - { name: "fedora44-inbox", url: "harbor.mellanox.com/hpcx/aarch64/fedora44/builder:inbox", arch: aarch64 }
+  - { name: "azurelinux40-inbox", url: "harbor.mellanox.com/hpcx/aarch64/azurelinux4.0/builder:inbox", arch: aarch64 }
+  # DOCA publishes no aarch64 openEuler, so these take the MOFED route.
+  - { name: "openeuler2203sp4-mofed26.07", url: "harbor.mellanox.com/hpcx/aarch64/openeuler22.03sp4/builder:mofed-26.07-0.7.7.0", arch: aarch64 }
+  - { name: "openeuler2403sp3-mofed26.07", url: "harbor.mellanox.com/hpcx/aarch64/openeuler24.03sp3/builder:mofed-26.07-0.7.7.0", arch: aarch64 }
+  # No DOCA or MOFED for UOS 20.1060a on aarch64, so inbox (rdma-core 37).
+  - { name: "uos201060a-inbox", url: "harbor.mellanox.com/hpcx/aarch64/uos20.1060a/builder:inbox", arch: aarch64 }
   - { name: "rocky89-mofed24.10", url: "harbor.mellanox.com/hpcx/aarch64/rocky8.9/builder:mofed-24.10-3.2.5.0", arch: aarch64 }
   - { name: "rocky96-mofed24.10", url: "harbor.mellanox.com/hpcx/aarch64/rocky9.6/builder:mofed-24.10-3.2.5.0", arch: aarch64 }
   - { name: "rhel100-mofed25.07", url: "harbor.mellanox.com/hpcx/aarch64/rhel10.0/builder:mofed-25.07-0.9.7.0", arch: aarch64 }

--- a/.ci/pipeline/build_matrix.yaml
+++ b/.ci/pipeline/build_matrix.yaml
@@ -15,7 +15,6 @@ kubernetes:
 
 runs_on_dockers:
   # x86_64
-  - { name: "ubuntu2004-mofed5.0", url: "harbor.mellanox.com/ucx/x86_64/ubuntu20.04/builder:mofed-5.0-1.0.0.0", arch: x86_64 }
   - { name: "ubuntu2204-mofed5.7", url: "harbor.mellanox.com/ucx/x86_64/ubuntu22.04/builder:mofed-5.7-0.2.3.0", arch: x86_64 }
   - { name: "ubuntu2404-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0", arch: x86_64 }
   - { name: "ubuntu2604-mofed26.04", url: "harbor.mellanox.com/hpcx/x86_64/ubuntu26.04/builder:mofed-26.04-0.7.6.0", arch: x86_64 }
@@ -26,7 +25,6 @@ runs_on_dockers:
   - { name: "debian113-mofed5.8", url: "harbor.mellanox.com/hpcx/x86_64/debian11.3/builder:mofed-5.8-3.0.7.0", arch: x86_64 }
   - { name: "debian130-doca3.2", url: "harbor.mellanox.com/hpcx/x86_64/debian13.0/builder:doca-3.2.0", arch: x86_64 }
   - { name: "centos10stream-inbox", url: "harbor.mellanox.com/hpcx/x86_64/centos10stream/builder:inbox", arch: x86_64 }
-  - { name: "fedora41-inbox", url: "harbor.mellanox.com/hpcx/x86_64/fedora41/builder:inbox", arch: x86_64 }
   - { name: "fedora44-inbox", url: "harbor.mellanox.com/hpcx/x86_64/fedora44/builder:inbox", arch: x86_64 }
   # Azure Linux 4.0 is in public preview; the image tracks the azurelinux-beta channel.
   - { name: "azurelinux40-inbox", url: "harbor.mellanox.com/hpcx/x86_64/azurelinux4.0/builder:inbox", arch: x86_64 }
@@ -35,15 +33,12 @@ runs_on_dockers:
   - { name: "rhel100-mofed25.07", url: "harbor.mellanox.com/hpcx/x86_64/rhel10.0/builder:mofed-25.07-0.9.7.0", arch: x86_64 }
   - { name: "sles15sp7-mofed26.01", url: "harbor.mellanox.com/hpcx/x86_64/sles15sp7/builder:mofed-26.01-0.8.8.0", arch: x86_64 }
   - { name: "sles16sp0-mofed26.01", url: "harbor.mellanox.com/hpcx/x86_64/sles16sp0/builder:mofed-26.01-0.8.0.0", arch: x86_64 }
-  - { name: "kylin10sp3-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/kylin10sp3/builder:doca-2.9.0", arch: x86_64 }
-  - { name: "euleros2sp12-doca2.9", url: "harbor.mellanox.com/hpcx/x86_64/euleros2.0sp12/builder:doca-2.9.0", arch: x86_64 }
   - { name: "openeuler2203sp4-doca3.5", url: "harbor.mellanox.com/hpcx/x86_64/openeuler22.03sp4/builder:doca-3.5.0", arch: x86_64 }
   - { name: "openeuler2403sp3-doca3.5", url: "harbor.mellanox.com/hpcx/x86_64/openeuler24.03sp3/builder:doca-3.5.0", arch: x86_64 }
   - { name: "ctyunos2507-mofed26.01", url: "harbor.mellanox.com/hpcx/x86_64/ctyunos25.07/builder:mofed-26.01-0.8.0.0", arch: x86_64 }
   - { name: "tencentos44-mofed26.04", url: "harbor.mellanox.com/hpcx/x86_64/tencentos4.4/builder:mofed-26.04-0.7.6.0", arch: x86_64 }
   # 20.1060a is the newest UOS rootfs on urm; DOCA publishes it for x86_64 only.
   - { name: "uos201060a-doca3.4", url: "harbor.mellanox.com/hpcx/x86_64/uos20.1060a/builder:doca-3.4.0", arch: x86_64 }
-  - { name: "ubuntu2004-rocm5.4", url: "harbor.mellanox.com/ucx/x86_64/ubuntu2004:rocm_5_4_0", arch: x86_64 }
   - { name: "ubuntu2204-rocm6.0", url: "harbor.mellanox.com/ucx/x86_64/ubuntu2204:rocm-6.0.0", arch: x86_64 }
   # aarch64
   - { name: "ubuntu2404-doca2.9", url: "harbor.mellanox.com/hpcx/aarch64/ubuntu24.04/builder:doca-2.9.0", arch: aarch64 }

--- a/buildlib/pr/build_job.yml
+++ b/buildlib/pr/build_job.yml
@@ -15,31 +15,14 @@ jobs:
       # x86_64 matrix
       ${{ if contains(parameters.name, 'x86_64') }}:
         matrix:
-          rhel76:
-            CONTAINER: rhel76
-            build_mode: short
-          ubuntu2004:
-            CONTAINER: ubuntu2004
-            build_mode: short
-            extra_modules: ""
-          ubuntu1804:
-            CONTAINER: ubuntu1804
-            build_mode: sanity
-            extra_modules: ""
           ubuntu2204:
             CONTAINER: ubuntu2204
             build_mode: short
           ubuntu2404:
             CONTAINER: ubuntu2404
             build_mode: long
-          ubuntu2210:
-            CONTAINER: ubuntu2210
-            build_mode: sanity
           debian113:
             CONTAINER: debian113
-            build_mode: short
-          debian109:
-            CONTAINER: debian109
             build_mode: sanity
           debian125:
             CONTAINER: debian125
@@ -72,26 +55,14 @@ jobs:
           rocky96:
             CONTAINER: rocky96
             build_mode: sanity
-          fedora41:
-            CONTAINER: fedora41
-            build_mode: sanity
           centos7:
             CONTAINER: centos7_ib
             build_mode: sanity
           centos10stream:
             CONTAINER: centos10stream
             build_mode: sanity
-          ubuntu2004_rocm:
-            CONTAINER: ubuntu2004_rocm_5_4_0
-            build_mode: short
           ubuntu2204_rocm:
             CONTAINER: ubuntu2204_rocm_6_0_0
-            build_mode: short
-          kylin10sp3:
-            CONTAINER: kylin10sp3
-            build_mode: short
-          euleros2sp12:
-            CONTAINER: euleros2sp12
             build_mode: short
           ctyunos2507:
             CONTAINER: ctyunos2507

--- a/buildlib/pr/build_job.yml
+++ b/buildlib/pr/build_job.yml
@@ -102,6 +102,24 @@ jobs:
           tencentos44:
             CONTAINER: tencentos44
             build_mode: short
+          fedora44:
+            CONTAINER: fedora44
+            build_mode: sanity
+          ubuntu2610:
+            CONTAINER: ubuntu2610
+            build_mode: sanity
+          azurelinux40:
+            CONTAINER: azurelinux40
+            build_mode: sanity
+          openeuler2203sp4:
+            CONTAINER: openeuler2203sp4
+            build_mode: short
+          openeuler2403sp3:
+            CONTAINER: openeuler2403sp3
+            build_mode: short
+          uos201060a:
+            CONTAINER: uos201060a
+            build_mode: short
           ubuntu2404_ze:
             CONTAINER: ubuntu2404_ze
             build_mode: ze
@@ -141,6 +159,24 @@ jobs:
             build_mode: short
           tencentos44_aarch64:
             CONTAINER: tencentos44_aarch64
+            build_mode: short
+          fedora44_aarch64:
+            CONTAINER: fedora44_aarch64
+            build_mode: short
+          ubuntu2610_aarch64:
+            CONTAINER: ubuntu2610_aarch64
+            build_mode: short
+          azurelinux40_aarch64:
+            CONTAINER: azurelinux40_aarch64
+            build_mode: short
+          openeuler2203sp4_aarch64:
+            CONTAINER: openeuler2203sp4_aarch64
+            build_mode: short
+          openeuler2403sp3_aarch64:
+            CONTAINER: openeuler2403sp3_aarch64
+            build_mode: short
+          uos201060a_aarch64:
+            CONTAINER: uos201060a_aarch64
             build_mode: short
     timeoutInMinutes: 340
 

--- a/buildlib/pr/coverity.yml
+++ b/buildlib/pr/coverity.yml
@@ -1,6 +1,6 @@
 parameters:
   demands: []
-  container: rhel76
+  container: coverity_rh7
   modes: ["release", "devel"]
 
 jobs:

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -98,6 +98,46 @@ resources:
     - container: tencentos44_aarch64
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/tencentos4.4/builder:mofed-26.04-0.7.6.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: fedora44
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/fedora44/builder:inbox
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: fedora44_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/fedora44/builder:inbox
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: ubuntu2610
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/ubuntu26.10/builder:inbox
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: ubuntu2610_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/ubuntu26.10/builder:inbox
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    # Azure Linux 4.0 is in public preview; the image tracks the azurelinux-beta channel.
+    - container: azurelinux40
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/azurelinux4.0/builder:inbox
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: azurelinux40_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/azurelinux4.0/builder:inbox
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    # DOCA publishes no aarch64 openEuler, so aarch64 takes the MOFED route.
+    - container: openeuler2203sp4
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/openeuler22.03sp4/builder:doca-3.5.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: openeuler2203sp4_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/openeuler22.03sp4/builder:mofed-26.07-0.7.7.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: openeuler2403sp3
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/openeuler24.03sp3/builder:doca-3.5.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: openeuler2403sp3_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/openeuler24.03sp3/builder:mofed-26.07-0.7.7.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    # 20.1060a is the newest UOS rootfs on urm; DOCA publishes it for x86_64 only, so
+    # aarch64 is inbox (rdma-core 37).
+    - container: uos201060a
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/uos20.1060a/builder:doca-3.4.0
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
+    - container: uos201060a_aarch64
+      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/uos20.1060a/builder:inbox
+      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: debian113
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/debian11.3/builder:mofed-5.8-3.0.7.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)

--- a/buildlib/pr/main.yml
+++ b/buildlib/pr/main.yml
@@ -21,14 +21,8 @@ resources:
     - container: fedora
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/fedora33:2
       options: $(DOCKER_OPT_ARGS)
-    - container: fedora41
-      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/fedora41/builder:inbox
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: coverity_rh7
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/coverity:mofed-5.1-2.3.8.0
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
-    - container: rhel76
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/rhel7.6/builder:mofed-5.0-1.0.0.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: rhel82
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/rhel8.2/builder:mofed-5.0-1.0.0.0
@@ -57,21 +51,12 @@ resources:
     - container: rocky96_aarch64
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/aarch64/rocky9.6/builder:mofed-24.10-3.2.5.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
-    - container: ubuntu2004
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu20.04/builder:mofed-5.0-1.0.0.0
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: ubuntu2204
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04/builder:mofed-5.7-0.2.3.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: ubuntu2204_ib
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04/builder:mofed-5.7-0.2.3.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_IB)
-    - container: ubuntu2210
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.10/builder:mofed-5.8-0.2.1.0
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
-    - container: ubuntu1804
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu18.04/builder:mofed-5.0-1.0.0.0
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: ubuntu2404
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/ubuntu24.04/builder:doca-2.9.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
@@ -140,9 +125,6 @@ resources:
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: debian113
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/debian11.3/builder:mofed-5.8-3.0.7.0
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
-    - container: debian109
-      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/debian10.9/builder:mofed-5.8-3.0.7.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: debian125
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/debian12.5/builder:doca-2.9.0
@@ -279,9 +261,6 @@ resources:
     - container: ubuntu20_cuda11
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/ubuntu20.04-mofed5-cuda11:1
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
-    - container: ubuntu2004_rocm_5_4_0
-      image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu2004:rocm_5_4_0
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: ubuntu22_cuda12
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu22.04-mofed5-cuda12:3
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
@@ -293,12 +272,6 @@ resources:
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES) $(DOCKER_OPT_GPU)
     - container: ubuntu2204_rocm_6_0_0
       image: rdmz-harbor.rdmz.labs.mlnx/ucx/x86_64/ubuntu2204:rocm-6.0.0
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
-    - container: kylin10sp3
-      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/kylin10sp3/builder:doca-2.9.0
-      options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
-    - container: euleros2sp12
-      image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/euleros2.0sp12/builder:doca-2.9.0
       options: $(DOCKER_OPT_ARGS) $(DOCKER_OPT_VOLUMES)
     - container: ctyunos2507
       image: rdmz-harbor.rdmz.labs.mlnx/hpcx/x86_64/ctyunos25.07/builder:mofed-26.01-0.8.0.0
@@ -497,13 +470,13 @@ stages:
               extra_modules: ucx-ib ucx-cma ucx-rdmacm ucx-ib-mlx5
               extra_tls: dc_mlx5 rc_mlx5 ud_mlx5 rc_verbs ud_verbs cma
               run_tls: ib rc rc_v rc_x dc dc_x ud ud_v ud_x shm sm
-            ubuntu2004:
-              CONTAINER: ubuntu2004
+            ubuntu2204:
+              CONTAINER: ubuntu2204
               extra_modules: ""
               extra_tls: ""
               run_tls: ""
-            ubuntu1804:
-              CONTAINER: ubuntu1804
+            ubuntu2404:
+              CONTAINER: ubuntu2404
               extra_modules: ""
               extra_tls: ""
               run_tls: ""

--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -248,7 +248,11 @@ static void sock_rte_barrier(void *rte_group, void (*progress)(void *arg),
 {
 #if _OPENMP
 #  pragma omp barrier
-#  pragma omp master
+#  if _OPENMP >= 202011
+#    pragma omp masked
+#  else
+#    pragma omp master
+#  endif
 #endif
   {
     sock_rte_group_t *group = rte_group;
@@ -582,7 +586,11 @@ static void mpi_rte_barrier(void *rte_group, void (*progress)(void *arg),
 
 #pragma omp barrier
 
-#pragma omp master
+#if defined(_OPENMP) && (_OPENMP >= 202011)
+#  pragma omp masked
+#else
+#  pragma omp master
+#endif
   {
     /*
      * Naive non-blocking barrier implementation over send/recv, to call user

--- a/test/gtest/ucs/test_pgtable.cc
+++ b/test/gtest/ucs/test_pgtable.cc
@@ -189,7 +189,6 @@ UCS_TEST_F(test_pgtable, multi_search) {
         ucs_pgt_addr_t max = 0;
 
         /* generate random regions */
-        unsigned num_regions = 0;
         for (int i = 0; i < 200 / ucs::test_time_multiplier(); ++i) {
             ucs_pgt_addr_t start = (ucs::rand() & 0x7fffffff) << 24;
             size_t         size  = ucs_min((size_t)ucs::rand(),
@@ -203,7 +202,6 @@ UCS_TEST_F(test_pgtable, multi_search) {
             min = ucs_min(start, min);
             max = ucs_max(start, max);
             regions.push_back(make_region(start, end));
-            ++num_regions;
         }
 
         /* Insert regions */

--- a/test/gtest/uct/ib/test_ud_pending.cc
+++ b/test/gtest/uct/ib/test_ud_pending.cc
@@ -197,7 +197,6 @@ UCS_TEST_SKIP_COND_P(test_ud_pending, window,
 UCS_TEST_SKIP_COND_P(test_ud_pending, tx_wqe,
                      !check_caps(UCT_IFACE_FLAG_PUT_SHORT))
 {
-    int i;
     uct_pending_req_t r;
     ucs_status_t status;
 
@@ -208,10 +207,8 @@ UCS_TEST_SKIP_COND_P(test_ud_pending, tx_wqe,
     connect();
     /* set big window */
     set_tx_win(m_e1, 8192);
-    i = 0;
     do {
        status = tx(m_e1);
-       i++;
     } while (status == UCS_OK);
 
     r.func = pending_cb_dispatch;

--- a/test/gtest/uct/test_mem.cc
+++ b/test/gtest/uct/test_mem.cc
@@ -229,7 +229,6 @@ UCS_TEST_P(test_mem, mmap_fixed) {
     const size_t            n_tryes     = 101;
     uct_alloc_method_t      meth;
     size_t                  length      = 1;
-    size_t                  n_success;
     ucs::mmap_fixed_address p_addr(page_size * 2 * (n_tryes + 1));
     void*                   curr_addr;
 
@@ -245,7 +244,6 @@ UCS_TEST_P(test_mem, mmap_fixed) {
     params.name            = "test";
     params.mem_type        = UCS_MEMORY_TYPE_HOST;
 
-    n_success = 0;
     curr_addr = *p_addr;
 
     for (i = 0; i < n_tryes; ++i) {
@@ -254,7 +252,6 @@ UCS_TEST_P(test_mem, mmap_fixed) {
 
         status = uct_mem_alloc(length, &meth, 1, &params, &uct_mem);
         if (status == UCS_OK) {
-            ++n_success;
             EXPECT_EQ(meth, uct_mem.method);
             EXPECT_EQ(curr_addr, uct_mem.address);
             EXPECT_GE(uct_mem.length, (size_t)1);


### PR DESCRIPTION
## What?

Add six OSes to the Azure PR pipeline, both arches: Fedora 44, Ubuntu 26.10, Azure Linux 4.0 (preview), openEuler 22.03 SP4 and 24.03 SP3, UOS 20.1060a.

## Retired (second commit)

Agreed with UCX dev management once the new rows were green:

| row | reason |
|---|---|
| `rhel76` | RHEL 7 EOL 2024-06 |
| `debian109` | Debian 10 LTS ended 2024-06 |
| `ubuntu1804` | EOL 2023-05 |
| `ubuntu2004`, `ubuntu2004_rocm` | Ubuntu 20.04 EOL 2025-05 |
| `ubuntu2210` | interim, EOL 2023-07 |
| `fedora41` | EOL 2025-12, replaced by `fedora44` |
| `euleros2sp12` | DOCA 3.5 dropped EulerOS; the openEuler rows cover it |
| `kylin10sp3` | OFED now targets Kylin V11 only |

`debian113` (LTS ended 2026-08-31) drops to `sanity`; `centos7` stays as `sanity`. Containers for the retired rows go too. Two of them were used outside the build matrix: `Build_Static` built on Ubuntu 20.04 and 18.04 and now builds on 22.04 and 24.04, and `rhel76` was the unused default of the `coverity.yml` container parameter, now `coverity_rh7`. Same images removed from the Jenkins matrix.

Net Build stage: 51 -> 42 rows.

## Why?

No CI coverage on any of them. Fedora 41 is long EOL; openEuler is where the OFED trains are going (MLNX_OFED 26.07 dropped `openeuler22.03sp3` for sp4, DOCA 3.5 dropped EulerOS).

## How?

- `buildlib/pr/main.yml`: 12 containers, images on `rdmz-harbor` (all present).
- `buildlib/pr/build_job.yml`: 6 rows in the x86_64 matrix, 6 in aarch64. `sanity` for inbox-only rows, `short` for OFED-backed rows and aarch64, matching the existing split.
- `.ci/pipeline/build_matrix.yaml`: same 12 rows so the Jenkins matrix does not drift.
- openEuler is DOCA on x86_64, MOFED on aarch64 (DOCA has no aarch64 openEuler). UOS is DOCA on x86_64, inbox on aarch64.
- Images from Mellanox-lab/hpcx-build#233; merge that first. The `fedora44` rows need #11908 (GCC 16 vs `omp master`).
- Third commit is a temporary copy of #11908 (both GCC 16 fixes) so the `fedora44` rows can build here; drop it before merge.

## Not fixed here

- Fedora 44 ships GCC 16, which rejects `#pragma omp master` and three set-but-unused gtest counters under `-Werror`. Fixed in #11908; carried here as a temporary test commit until it lands.
