### PR TITLE
BUILD: Fix compilation with GCC 16

### DIFF
--- a/src/tools/perf/perftest.c
+++ b/src/tools/perf/perftest.c
@@ -248,7 +248,11 @@ static void sock_rte_barrier(void *rte_group, void (*progress)(void *arg),
 {
 #if _OPENMP
 #  pragma omp barrier
-#  pragma omp master
+#  if _OPENMP >= 202011
+#    pragma omp masked
+#  else
+#    pragma omp master
+#  endif
 #endif
   {
     sock_rte_group_t *group = rte_group;
@@ -582,7 +586,11 @@ static void mpi_rte_barrier(void *rte_group, void (*progress)(void *arg),
 
 #pragma omp barrier
 
-#pragma omp master
+#if defined(_OPENMP) && (_OPENMP >= 202011)
+#  pragma omp masked
+#else
+#  pragma omp master
+#endif
   {
     /*
      * Naive non-blocking barrier implementation over send/recv, to call user

--- a/test/gtest/ucs/test_pgtable.cc
+++ b/test/gtest/ucs/test_pgtable.cc
@@ -189,7 +189,6 @@ UCS_TEST_F(test_pgtable, multi_search) {
         ucs_pgt_addr_t max = 0;
 
         /* generate random regions */
-        unsigned num_regions = 0;
         for (int i = 0; i < 200 / ucs::test_time_multiplier(); ++i) {
             ucs_pgt_addr_t start = (ucs::rand() & 0x7fffffff) << 24;
             size_t         size  = ucs_min((size_t)ucs::rand(),
@@ -203,7 +202,6 @@ UCS_TEST_F(test_pgtable, multi_search) {
             min = ucs_min(start, min);
             max = ucs_max(start, max);
             regions.push_back(make_region(start, end));
-            ++num_regions;
         }
 
         /* Insert regions */

--- a/test/gtest/uct/ib/test_ud_pending.cc
+++ b/test/gtest/uct/ib/test_ud_pending.cc
@@ -197,7 +197,6 @@ UCS_TEST_SKIP_COND_P(test_ud_pending, window,
 UCS_TEST_SKIP_COND_P(test_ud_pending, tx_wqe,
                      !check_caps(UCT_IFACE_FLAG_PUT_SHORT))
 {
-    int i;
     uct_pending_req_t r;
     ucs_status_t status;
 
@@ -208,10 +207,8 @@ UCS_TEST_SKIP_COND_P(test_ud_pending, tx_wqe,
     connect();
     /* set big window */
     set_tx_win(m_e1, 8192);
-    i = 0;
     do {
        status = tx(m_e1);
-       i++;
     } while (status == UCS_OK);
 
     r.func = pending_cb_dispatch;

--- a/test/gtest/uct/test_mem.cc
+++ b/test/gtest/uct/test_mem.cc
@@ -229,7 +229,6 @@ UCS_TEST_P(test_mem, mmap_fixed) {
     const size_t            n_tryes     = 101;
     uct_alloc_method_t      meth;
     size_t                  length      = 1;
-    size_t                  n_success;
     ucs::mmap_fixed_address p_addr(page_size * 2 * (n_tryes + 1));
     void*                   curr_addr;
 
@@ -245,7 +244,6 @@ UCS_TEST_P(test_mem, mmap_fixed) {
     params.name            = "test";
     params.mem_type        = UCS_MEMORY_TYPE_HOST;
 
-    n_success = 0;
     curr_addr = *p_addr;
 
     for (i = 0; i < n_tryes; ++i) {
@@ -254,7 +252,6 @@ UCS_TEST_P(test_mem, mmap_fixed) {
 
         status = uct_mem_alloc(length, &meth, 1, &params, &uct_mem);
         if (status == UCS_OK) {
-            ++n_success;
             EXPECT_EQ(meth, uct_mem.method);
             EXPECT_EQ(curr_addr, uct_mem.address);
             EXPECT_GE(uct_mem.length, (size_t)1);


### PR DESCRIPTION
## What?

Make UCX build with GCC 16 (Fedora 44): two source fixes, no behaviour change.

## Why?

Fedora 44's GCC 16 turns two things into errors under `-Werror`:

- OpenMP 5.1 renamed `master` to `masked`; `-Werror=deprecated-openmp` rejects the old spelling in `ucx_perftest`.
- `-Werror=unused-but-set-variable` now fires on three gtest counters that are only ever incremented.

Seen on both arches in openucx/ucx#11906, which adds the Fedora 44 CI rows and depends on this.

## How?

- `src/tools/perf/perftest.c`: both `#pragma omp master` sites switch on `defined(_OPENMP) && (_OPENMP >= 202011)`.
- `test/gtest/ucs/test_pgtable.cc`, `uct/ib/test_ud_pending.cc`, `uct/test_mem.cc`: drop the dead counters; each test asserts on other values.
- Build: full `make -k` of `configure-devel` and `configure-release` trees in the Fedora 44 builder image, `gcc (GCC) 16.2.1 20260819`, clean.
- Tests: this PR's Azure run (134621) ran the edited tests green on IB hardware - `test_pgtable.multi_search`, `test_mem.mmap_fixed/0-3`, `test_ud_pending.tx_wqe` on `ud_mlx5` and `ud_verbs` - and drove `ucx_perftest` through `run_ucx_perftest*`, `run_ucx_perftest_fault_tolerance` and `run_ucx_perftest_with_daemon`. Those compilers take the `master` path. The `masked` path was run under GCC 16 in the Fedora 44 image: `ucx_perftest` client/server, single-threaded and `-T 2`, clean; the `fedora44` rows in #11906 build it in CI.
