### PR TITLE
UCT/IB/EFA: Skip device open for other PCI vendors

### DIFF
--- a/src/ucs/sys/topo/base/topo.c
+++ b/src/ucs/sys/topo/base/topo.c
@@ -344,6 +344,20 @@ ucs_topo_read_pci_id_value(const char *dev_name, const char *sysfs_path,
     return (uint16_t)value;
 }
 
+ucs_sys_pci_id_t
+ucs_topo_get_sysfs_pci_id(const char *dev_name, const char *sysfs_path)
+{
+    ucs_sys_pci_id_t pci_id;
+
+    if (sysfs_path == NULL) {
+        return UCS_SYS_PCI_ID_UNDEFINED;
+    }
+
+    pci_id.vendor = ucs_topo_read_pci_id_value(dev_name, sysfs_path, "vendor");
+    pci_id.device = ucs_topo_read_pci_id_value(dev_name, sysfs_path, "device");
+    return pci_id;
+}
+
 static void ucs_topo_read_device_sysfs_info(const ucs_sys_bus_id_t *bus_id,
                                             const char *dev_name,
                                             ucs_numa_node_t *numa_node_p,
@@ -366,9 +380,7 @@ static void ucs_topo_read_device_sysfs_info(const ucs_sys_bus_id_t *bus_id,
     }
 
     *numa_node_p = ucs_numa_node_of_device(path);
-
-    pci_id_p->vendor = ucs_topo_read_pci_id_value(dev_name, path, "vendor");
-    pci_id_p->device = ucs_topo_read_pci_id_value(dev_name, path, "device");
+    *pci_id_p    = ucs_topo_get_sysfs_pci_id(dev_name, path);
 
     ucs_trace("read sysfs info for %s: numa_node %d, vendor %04x, device %04x",
               dev_name, *numa_node_p, pci_id_p->vendor, pci_id_p->device);

--- a/src/ucs/sys/topo/base/topo.h
+++ b/src/ucs/sys/topo/base/topo.h
@@ -345,6 +345,18 @@ ucs_sys_device_t ucs_topo_get_sysfs_dev(const char *dev_name,
                                         unsigned name_priority);
 
 /**
+ * Read the PCI identifier of a device from sysfs, without adding it as a system
+ * device.
+ *
+ * @param [in]  dev_name    Device name, used for logging.
+ * @param [in]  sysfs_path  sysfs path for the required device, or NULL.
+ *
+ * @return PCI identifier, or UCS_SYS_PCI_ID_UNDEFINED if it could not be read.
+ */
+ucs_sys_pci_id_t ucs_topo_get_sysfs_pci_id(const char *dev_name,
+                                           const char *sysfs_path);
+
+/**
  * Return system device name in BDF format: "<domain>:<bus>:<device>.<function>".
  *
  * @param [in]  sys_dev  System device id, as returned from

--- a/src/uct/ib/efa/base/ib_efa.h
+++ b/src/uct/ib/efa/base/ib_efa.h
@@ -13,9 +13,22 @@
 #include <infiniband/efadv.h>
 
 
+#define UCT_IB_AWS_EFA_PCI_VENDOR_ID 0x1d0f
+
+
 typedef struct uct_ib_efadv_md {
     uct_ib_md_t super;
 } uct_ib_efadv_md_t;
+
+
+/* Devices with an unavailable PCI vendor id are not filtered out, and have to
+ * be probed by efadv_query_device() */
+static inline int
+uct_ib_efadv_pci_vendor_match(const ucs_sys_pci_id_t *pci_id)
+{
+    return (pci_id->vendor == UCS_SYS_PCI_ID_VALUE_UNDEFINED) ||
+           (pci_id->vendor == UCT_IB_AWS_EFA_PCI_VENDOR_ID);
+}
 
 
 static inline int

--- a/src/uct/ib/efa/base/ib_efa_md.c
+++ b/src/uct/ib/efa/base/ib_efa_md.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -11,9 +11,38 @@
 #include <uct/ib/efa/base/ib_efa.h>
 #include <ucs/type/status.h>
 #include <ucs/debug/log.h>
+#include <ucs/debug/memtrack_int.h>
+#include <ucs/sys/string.h>
 
 
 static uct_ib_md_ops_t uct_ib_efa_md_ops;
+
+static ucs_status_t uct_ib_efa_md_check_pci_vendor(struct ibv_device *ibv_device)
+{
+    const char *dev_name = ibv_get_device_name(ibv_device);
+    ucs_sys_pci_id_t pci_id;
+    const char *sysfs_path;
+    ucs_status_t status;
+    char *path_buffer;
+
+    status = ucs_string_alloc_path_buffer(&path_buffer, "path_buffer");
+    if (status != UCS_OK) {
+        return status;
+    }
+
+    sysfs_path = ucs_topo_resolve_sysfs_path(ibv_device->ibdev_path,
+                                             path_buffer);
+    pci_id     = ucs_topo_get_sysfs_pci_id(dev_name, sysfs_path);
+    ucs_free(path_buffer);
+
+    if (uct_ib_efadv_pci_vendor_match(&pci_id)) {
+        return UCS_OK;
+    }
+
+    ucs_debug("%s: pci id " UCS_SYS_PCI_ID_FMT " is not EFA", dev_name,
+              UCS_SYS_PCI_ID_ARG(&pci_id));
+    return UCS_ERR_UNSUPPORTED;
+}
 
 static ucs_status_t uct_ib_efa_md_open(struct ibv_device *ibv_device,
                                        const uct_ib_md_config_t *md_config,
@@ -25,6 +54,12 @@ static ucs_status_t uct_ib_efa_md_open(struct ibv_device *ibv_device,
     struct efadv_device_attr attr;
     ucs_status_t status;
     int ret;
+
+    /* Avoid expensive calls when device is not Amazon */
+    status = uct_ib_efa_md_check_pci_vendor(ibv_device);
+    if (status != UCS_OK) {
+        return status;
+    }
 
     ctx = ibv_open_device(ibv_device);
     if (ctx == NULL) {

--- a/src/uct/ib/efa/srd/srd_iface.c
+++ b/src/uct/ib/efa/srd/srd_iface.c
@@ -1009,6 +1009,10 @@ uct_srd_query_tl_devices(uct_md_h md, uct_tl_device_resource_t **tl_devices_p,
     struct efadv_device_attr efa_attr;
     int ret;
 
+    if (!uct_ib_efadv_pci_vendor_match(&ib_md->dev.pci_id)) {
+        return UCS_ERR_NO_DEVICE;
+    }
+
     ctx = ibv_open_device(ib_md->dev.ibv_context->device);
     if (ctx == NULL) {
         return UCS_ERR_NO_DEVICE;


### PR DESCRIPTION
## What?
Reject non-Amazon devices by their sysfs PCI vendor id before opening a verbs context, in EFA memory domain open and in the SRD transport device query.

## Why?
On a host with non-EFA HCAs, EFA discovery paid an `ibv_open_device()`/`efadv_query_device()` per device just to learn the device is not an EFA one, adding that cost to `ucp_init()`. Both the kernel and rdma-core match EFA by PCI vendor.

## How?
Adds `ucs_topo_get_sysfs_pci_id()` to read a PCI id from a sysfs path without registering a system device. Devices whose vendor id is unreadable keep being decided by `efadv_query_device()`, so the probe stays the authority and the check is only a fast reject.
### Test
- UD and SRD can still be used.