### PR TITLE
UCP/WIREUP: Improve p2p lane matching diagnostics

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2020. ALL RIGHTS RESERVED.
+* Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2026. ALL RIGHTS RESERVED.
 * Copyright (C) Los Alamos National Security, LLC. 2019 ALL RIGHTS RESERVED.
 *
 * See file LICENSE for terms.
@@ -1656,12 +1656,11 @@ ucp_ep_set_failed(ucp_ep_h ucp_ep, ucp_lane_index_t lane, ucs_status_t status)
             log_level = ucp_ep_config_err_handling_enabled(ucp_ep) ?
                     UCS_LOG_LEVEL_ERROR : UCS_LOG_LEVEL_DIAG;
 
-            ucp_ep_get_lane_info_str(ucp_ep, lane, &lane_info_strb);
             ucs_log(log_level,
-                    "ep %p: error '%s' on %s will not be handled"
+                    UCP_EP_LANE_FMT ": error '%s' will not be handled"
                     " since no error callback is installed",
-                    ucp_ep, ucs_status_string(status),
-                    ucs_string_buffer_cstr(&lane_info_strb));
+                    UCP_EP_LANE_ARG(ucp_ep, lane, &lane_info_strb),
+                    ucs_status_string(status));
             return UCS_ERR_UNSUPPORTED;
         } else {
             ucp_ep_invoke_err_cb(ucp_ep, status);
@@ -4325,24 +4324,25 @@ void ucp_ep_get_tl_bitmap(const ucp_ep_config_key_t *key,
     }
 }
 
-void ucp_ep_get_lane_info_str(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
-                              ucs_string_buffer_t *lane_info_strb)
+const char *ucp_ep_get_lane_info_str(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
+                                     ucs_string_buffer_t *lane_info_strb)
 {
-    ucp_rsc_index_t rsc_index;
-    uct_tl_resource_desc_t *tl_rsc;
+    ucs_string_buffer_reset(lane_info_strb);
 
     if (lane == UCP_NULL_LANE) {
-        ucs_string_buffer_appendf(lane_info_strb, "NULL lane");
+        ucs_string_buffer_appendf(lane_info_strb, "no lane");
     } else if (lane == ucp_ep_get_cm_lane(ucp_ep)) {
-        ucs_string_buffer_appendf(lane_info_strb, "CM lane");
+        ucs_string_buffer_appendf(lane_info_strb, "lane[%d] cm", lane);
     } else {
-        rsc_index = ucp_ep_get_rsc_index(ucp_ep, lane);
-        tl_rsc    = &ucp_ep->worker->context->tl_rscs[rsc_index].tl_rsc;
-
         ucs_string_buffer_appendf(lane_info_strb,
-                                  UCT_TL_RESOURCE_DESC_FMT,
-                                  UCT_TL_RESOURCE_DESC_ARG(tl_rsc));
+                                  "lane[%d] " UCT_TL_RESOURCE_DESC_FMT ".%d",
+                                  lane,
+                                  UCT_TL_RESOURCE_DESC_ARG(
+                                          ucp_ep_get_tl_rsc(ucp_ep, lane)),
+                                  ucp_ep_get_path_index(ucp_ep, lane));
     }
+
+    return ucs_string_buffer_cstr(lane_info_strb);
 }
 
 void ucp_ep_invoke_err_cb(ucp_ep_h ep, ucs_status_t status)

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -26,6 +26,12 @@
 #define UCP_MAX_IOV                16UL
 
 
+/* Print an ep lane, using a caller-provided string buffer as scratch space */
+#define UCP_EP_LANE_FMT "ep %p: %s"
+#define UCP_EP_LANE_ARG(_ep, _lane, _strb) \
+    (_ep), ucp_ep_get_lane_info_str(_ep, _lane, _strb)
+
+
 /* Endpoint flags type */
 #if ENABLE_DEBUG_DATA || UCS_ENABLE_ASSERT
 typedef uint32_t                   ucp_ep_flags_t;
@@ -859,13 +865,6 @@ size_t ucp_ep_tag_offload_min_rndv_thresh(ucp_context_h context,
 
 void ucp_ep_config_rndv_zcopy_commit(ucp_lane_index_t lanes_count,
                                      ucp_ep_rndv_zcopy_config_t *rndv_zcopy);
-
-
-/* Print an ep lane, using a caller-provided string buffer as scratch space */
-#define UCP_EP_LANE_FMT "ep %p: %s"
-#define UCP_EP_LANE_ARG(_ep, _lane, _strb) \
-    (_ep), ucp_ep_get_lane_info_str(_ep, _lane, _strb)
-
 
 const char *ucp_ep_get_lane_info_str(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
                                      ucs_string_buffer_t *lane_info_strb);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -860,8 +860,15 @@ size_t ucp_ep_tag_offload_min_rndv_thresh(ucp_context_h context,
 void ucp_ep_config_rndv_zcopy_commit(ucp_lane_index_t lanes_count,
                                      ucp_ep_rndv_zcopy_config_t *rndv_zcopy);
 
-void ucp_ep_get_lane_info_str(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
-                              ucs_string_buffer_t *lane_info_strb);
+
+/* Print an ep lane, using a caller-provided string buffer as scratch space */
+#define UCP_EP_LANE_FMT "ep %p: %s"
+#define UCP_EP_LANE_ARG(_ep, _lane, _strb) \
+    (_ep), ucp_ep_get_lane_info_str(_ep, _lane, _strb)
+
+
+const char *ucp_ep_get_lane_info_str(ucp_ep_h ucp_ep, ucp_lane_index_t lane,
+                                     ucs_string_buffer_t *lane_info_strb);
 
 void ucp_ep_config_rndv_zcopy_commit(ucp_lane_index_t lanes_count,
                                      ucp_ep_rndv_zcopy_config_t *rndv_zcopy);

--- a/src/ucp/wireup/address.c
+++ b/src/ucp/wireup/address.c
@@ -1853,12 +1853,15 @@ ucs_status_t ucp_address_unpack(ucp_worker_t *worker, const void *buffer,
             }
 
             ucp_address_trace(unpack_flags,
-                              "unpack addr[%d] : sysdev %d paths %d eps %u"
-                              " tl_flags 0x%" PRIx64 " bw %.2f/nMBs"
+                              "unpack addr[%d] : %s md[%d] sysdev %d paths %d"
+                              " eps %u tl_flags 0x%" PRIx64 " bw %.2f/nMBs"
                               " ovh %.0fns lat_ovh %.0fns dev_priority %d"
                               " a32 0x%" PRIx64 "/0x%" PRIx64 " a64 0x%" PRIx64
                               "/0x%" PRIx64,
-                              (int)(address - address_list), address->sys_dev,
+                              (int)(address - address_list),
+                              ucp_find_tl_name_by_csum(worker->context,
+                                                       address->tl_name_csum),
+                              address->md_index, address->sys_dev,
                               address->dev_num_paths, address->num_ep_addrs,
                               address->iface_attr.flags,
                               address->iface_attr.bandwidth / UCS_MBYTE,

--- a/src/ucp/wireup/select.c
+++ b/src/ucp/wireup/select.c
@@ -2888,8 +2888,17 @@ ucp_wireup_construct_lanes(const ucp_wireup_select_params_t *select_params,
         key->lanes[lane].path_index   = ucp_wireup_default_path_index(
                                        select_ctx->lane_descs[lane].path_index);
 
-        ucs_trace("ep %p: construct lane %d to addr_index %d", ep, lane,
-                  select_ctx->lane_descs[lane].addr_index);
+        rsc_index = select_ctx->lane_descs[lane].rsc_index;
+        if (rsc_index == UCP_NULL_RESOURCE) {
+            ucs_trace("ep %p: construct lane %d cm", ep, lane);
+        } else {
+            ucs_trace("ep %p: construct lane %d " UCT_TL_RESOURCE_DESC_FMT
+                      ".%d to addr_index %d", ep, lane,
+                      UCT_TL_RESOURCE_DESC_ARG(
+                              &context->tl_rscs[rsc_index].tl_rsc),
+                      key->lanes[lane].path_index,
+                      select_ctx->lane_descs[lane].addr_index);
+        }
 
         if (select_ctx->lane_descs[lane].lane_types & UCS_BIT(UCP_LANE_TYPE_CM)) {
             ucs_assert(key->cm_lane == UCP_NULL_LANE);

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -376,6 +376,8 @@ ucp_wireup_match_p2p_lanes(ucp_ep_h ep,
                            const unsigned *addr_indices,
                            ucp_lane_index_t *lanes2remote)
 {
+    UCS_STRING_BUFFER_ONSTACK(lane_strb, 64);
+    ucp_context_h context = ep->worker->context;
     const ucp_address_entry_t *address;
     unsigned address_index;
     ucp_lane_index_t lane, remote_lane, num_lanes;
@@ -406,21 +408,33 @@ ucp_wireup_match_p2p_lanes(ucp_ep_h ep,
         /* Select next remote ep address within the address_index as specified
          * by addr_indices argument
          */
-        address_index      = addr_indices[lane];
-        address            = &remote_address->address_list[address_index];
-        ep_addr_index      = ep_addr_indexes[address_index]++;
-        ucs_assertv(ep_addr_index < address->num_ep_addrs,
-                    "lane=%d/%d tl_name_csum=0x%02x address_index=%u "
-                    "ep_addr_index=%u num_ep_addrs=%u",
-                    lane, num_lanes, address->tl_name_csum, address_index,
-                    ep_addr_index, address->num_ep_addrs);
+        address_index = addr_indices[lane];
+        address       = &remote_address->address_list[address_index];
+        ep_addr_index = ep_addr_indexes[address_index]++;
+        if (ep_addr_index >= address->num_ep_addrs) {
+            /* The peer packs one ep address per own lane on that resource, so
+             * this ep selected more lanes towards it than the peer provides */
+            ucp_ep_get_lane_info_str(ep, lane, &lane_strb);
+            ucs_fatal("ep %p: lane[%d] %s.%d -> addr[%u] %s: no ep address %u,"
+                      " only %u provided", ep, lane,
+                      ucs_string_buffer_cstr(&lane_strb),
+                      ucp_ep_get_path_index(ep, lane), address_index,
+                      ucp_find_tl_name_by_csum(context, address->tl_name_csum),
+                      ep_addr_index, address->num_ep_addrs);
+        }
+
         remote_lane        = address->ep_addrs[ep_addr_index].lane;
         lanes2remote[lane] = remote_lane;
 
         if (used_remote_lanes & UCS_BIT(remote_lane)) {
-            ucs_fatal("ep %p: remote lane %d is used more than once", ep,
+            ucp_ep_get_lane_info_str(ep, lane, &lane_strb);
+            ucs_fatal("ep %p: lane[%d] %s.%d -> addr[%u]: remote lane %d is"
+                      " used more than once", ep, lane,
+                      ucs_string_buffer_cstr(&lane_strb),
+                      ucp_ep_get_path_index(ep, lane), address_index,
                       remote_lane);
         }
+
         used_remote_lanes |= UCS_BIT(remote_lane);
 
         ucs_trace("ep %p: lane[%d]->remote_lane[%d] (address[%d].ep_address[%d])",
@@ -456,6 +470,7 @@ ucp_wireup_connect_local(ucp_ep_h ep,
                          const ucp_unpacked_address_t *remote_address,
                          const ucp_lane_index_t *lanes2remote)
 {
+    UCS_STRING_BUFFER_ONSTACK(lane_strb, 64);
     ucp_lane_index_t lane, remote_lane;
     const ucp_address_entry_t *address_entry;
     const ucp_address_entry_ep_addr_t *ep_entry;
@@ -474,8 +489,11 @@ ucp_wireup_connect_local(ucp_ep_h ep,
         status = ucp_wireup_find_remote_p2p_addr(ep, remote_lane, remote_address,
                                                  &address_entry, &ep_entry);
         if (status != UCS_OK) {
-            ucs_error("ep %p: no remote ep address for lane[%d]->remote_lane[%d]",
-                      ep, lane, remote_lane);
+            ucp_ep_get_lane_info_str(ep, lane, &lane_strb);
+            ucs_error("ep %p: lane[%d] %s.%d: no remote ep address for remote"
+                      " lane %d", ep, lane,
+                      ucs_string_buffer_cstr(&lane_strb),
+                      ucp_ep_get_path_index(ep, lane), remote_lane);
             goto out;
         }
 

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -414,11 +414,9 @@ ucp_wireup_match_p2p_lanes(ucp_ep_h ep,
         if (ep_addr_index >= address->num_ep_addrs) {
             /* The peer packs one ep address per own lane on that resource, so
              * this ep selected more lanes towards it than the peer provides */
-            ucp_ep_get_lane_info_str(ep, lane, &lane_strb);
-            ucs_fatal("ep %p: lane[%d] %s.%d -> addr[%u] %s: no ep address %u,"
-                      " only %u provided", ep, lane,
-                      ucs_string_buffer_cstr(&lane_strb),
-                      ucp_ep_get_path_index(ep, lane), address_index,
+            ucs_fatal(UCP_EP_LANE_FMT " -> addr[%u] %s: no ep address %u,"
+                      " only %u provided",
+                      UCP_EP_LANE_ARG(ep, lane, &lane_strb), address_index,
                       ucp_find_tl_name_by_csum(context, address->tl_name_csum),
                       ep_addr_index, address->num_ep_addrs);
         }
@@ -427,11 +425,9 @@ ucp_wireup_match_p2p_lanes(ucp_ep_h ep,
         lanes2remote[lane] = remote_lane;
 
         if (used_remote_lanes & UCS_BIT(remote_lane)) {
-            ucp_ep_get_lane_info_str(ep, lane, &lane_strb);
-            ucs_fatal("ep %p: lane[%d] %s.%d -> addr[%u]: remote lane %d is"
-                      " used more than once", ep, lane,
-                      ucs_string_buffer_cstr(&lane_strb),
-                      ucp_ep_get_path_index(ep, lane), address_index,
+            ucs_fatal(UCP_EP_LANE_FMT " -> addr[%u]: remote lane %d is"
+                      " used more than once",
+                      UCP_EP_LANE_ARG(ep, lane, &lane_strb), address_index,
                       remote_lane);
         }
 
@@ -489,11 +485,9 @@ ucp_wireup_connect_local(ucp_ep_h ep,
         status = ucp_wireup_find_remote_p2p_addr(ep, remote_lane, remote_address,
                                                  &address_entry, &ep_entry);
         if (status != UCS_OK) {
-            ucp_ep_get_lane_info_str(ep, lane, &lane_strb);
-            ucs_error("ep %p: lane[%d] %s.%d: no remote ep address for remote"
-                      " lane %d", ep, lane,
-                      ucs_string_buffer_cstr(&lane_strb),
-                      ucp_ep_get_path_index(ep, lane), remote_lane);
+            ucs_error(UCP_EP_LANE_FMT ": no remote ep address for remote"
+                      " lane %d",
+                      UCP_EP_LANE_ARG(ep, lane, &lane_strb), remote_lane);
             goto out;
         }
 

--- a/test/gtest/ucp/test_ucp_sockaddr.cc
+++ b/test/gtest/ucp/test_ucp_sockaddr.cc
@@ -823,8 +823,8 @@ public:
         if (level == UCS_LOG_LEVEL_ERROR) {
             std::string err_str = format_message(message, ap);
 
-            if (err_str.find("on CM lane will not be handled since no error"
-                             " callback is installed") != std::string::npos) {
+            if (err_str.find("will not be handled since no error callback is"
+                             " installed") != std::string::npos) {
                 UCS_TEST_MESSAGE << "< " << err_str << " >";
                 ++m_err_count;
                 return UCS_LOG_FUNC_RC_STOP;


### PR DESCRIPTION
## What?
Improve wireup p2p lane matching diagnostics, and report an ep address overflow as a fatal error instead of a debug-only assertion.

Related: https://nvbugspro.nvidia.com/bug/6665318
## Why?
When an endpoint selects more lanes toward a remote device than the peer packed ep addresses for, `ucp_wireup_match_p2p_lanes()` reads past `ep_addrs[]`: debug builds assert, release builds pick up a zeroed entry and die later with a message naming neither the local device nor the remote address entry. Diagnosing it required the peer's pack traces to learn which devices `addr[N]` and each lane referred to.
## How?
Ep address overflow, now fatal in release builds too:
```diff
- Assertion `ep_addr_index < address->num_ep_addrs' failed: lane=7/14 tl_name_csum=0xd47a address_index=3 ep_addr_index=2 num_ep_addrs=2
+ Fatal: ep 0xfffd7c000140: lane[7] rc_mlx5/mlx5_0:1.1 -> addr[3] rc_mlx5: no ep address 2, only 2 provided
```
Duplicate remote lane:
```diff
- Fatal: ep 0xfffd7c000140: remote lane 0 is used more than once
+ Fatal: ep 0xfffd7c000140: lane[7] rc_mlx5/mlx5_0:1.1 -> addr[3]: remote lane 0 is used more than once
```
Missing remote ep address in `ucp_wireup_connect_local()`:
```diff
- ep 0xfffd7c000140: no remote ep address for lane[2]->remote_lane[5]
+ ep 0xfffd7c000140: lane[2] rc_mlx5/mlx5_1:1.0: no remote ep address for remote lane 5
```
Lane construction trace, the only lane-to-device record when an unchanged config skips `ucp_wireup_print_config()`:
```diff
- ep 0xfffd7c000140: construct lane 7 to addr_index 3
+ ep 0xfffd7c000140: construct lane 7 rc_mlx5/mlx5_0:1.1 to addr_index 3
- ep 0xfffd7c000140: construct lane 0 to addr_index 4294967295
+ ep 0xfffd7c000140: construct lane 0 cm
```
Address unpack trace, so the receiver's log is self-describing:
```diff
- unpack addr[3] : sysdev 6 paths 2 eps 2 tl_flags 0x39a bw 45747.33/nMBs ...
+ unpack addr[3] : rc_mlx5 md[7] sysdev 6 paths 2 eps 2 tl_flags 0x39a bw 45747.33/nMBs ...
```