### PR TITLE
GTEST/UCP/RMA: Un-skip CUDA SGL tests

### DIFF
--- a/src/ucp/proto/proto_reconfig.c
+++ b/src/ucp/proto/proto_reconfig.c
@@ -104,6 +104,39 @@ static ucs_status_t ucp_proto_reconfig_progress(uct_pending_req_t *self)
         ucs_error("cannot find remote protocol for: %s",
                   ucs_string_buffer_cstr(&strb));
 
+        /* TEMPORARY DEBUG (do not merge): the message above reports the ep
+         * config index saved when the request was submitted, which is not
+         * necessarily the current one. Dump both, the wireup state, and the
+         * protocol matrix of the *current* config, to tell apart a request
+         * stranded by a config change from a config that genuinely has no
+         * matching protocol. */
+        {
+            UCS_STRING_BUFFER_ONSTACK(dbg, 256);
+
+            ucs_error("reconfig debug: ep %p cfg_index current=%d saved=%d "
+                      "ep_flags=0x%x remote_connected=%d p2p_lanes=0x%llx "
+                      "cm_lane=%d rkey_cfg_index=%d",
+                      ep, ep->cfg_index,
+                      req->send.proto_config->ep_cfg_index, ep->flags,
+                      !!(ep->flags & UCP_EP_FLAG_REMOTE_CONNECTED),
+                      (unsigned long long)ucp_ep_config(ep)->p2p_lanes,
+                      ucp_ep_has_cm_lane(ep),
+                      req->send.proto_config->rkey_cfg_index);
+
+            ucp_ep_config_name(ep->worker, ep->cfg_index, &dbg);
+            ucs_error("reconfig debug: current ep config: %s",
+                      ucs_string_buffer_cstr(&dbg));
+
+            ucs_string_buffer_reset(&dbg);
+            ucp_proto_select_info(ep->worker, ep->cfg_index,
+                                  req->send.proto_config->rkey_cfg_index,
+                                  &ucp_ep_config(ep)->proto_select, 1, &dbg);
+            fprintf(stderr, "# reconfig debug: protocol matrix of cfg#%d\n",
+                    ep->cfg_index);
+            ucs_string_buffer_dump(&dbg, "# ", stderr);
+            fflush(stderr);
+        }
+
         /* No protocol can serve this op on the current lane set - fail
          * the EP so the user error callback fires. */
         if (!ucp_ep_err_mode_eq(ep, UCP_ERR_HANDLING_MODE_NONE) &&

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -1423,6 +1423,26 @@ UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_multi_rail,
     }
 }
 
+/*
+ * The sporadic "cannot find remote protocol" failure is hit by the first
+ * operation on a freshly wired-up endpoint, so re-create the endpoints on
+ * every iteration instead of reusing a connected one.
+ */
+UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_wireup_stress,
+                     RUNNING_ON_VALGRIND) {
+    static const unsigned num_iters = 100;
+    for (unsigned i = 0; i < num_iters; ++i) {
+        cleanup();
+        modify_config("MAX_RMA_RAILS", "2");
+        test_ucp_rma::init();
+        test_put_sgl(4, UCS_KBYTE);
+        if (HasFailure() || (num_errors() > 0)) {
+            UCS_TEST_MESSAGE << "failed on iteration " << i;
+            break;
+        }
+    }
+}
+
 UCS_TEST_SKIP_COND_P(test_ucp_rma_sgl, put_fragmented_elements,
                      RUNNING_ON_VALGRIND) {
     cleanup();

--- a/test/gtest/ucp/test_ucp_rma.cc
+++ b/test/gtest/ucp/test_ucp_rma.cc
@@ -1013,11 +1013,6 @@ public:
     }
 
     virtual void init() override {
-        /* FIXME: sporadic failure on CUDA memory type. re-enable once fixed */
-        if (mem_type() == UCS_MEMORY_TYPE_CUDA) {
-            UCS_TEST_SKIP_R("sporadic failure on CUDA memory type");
-        }
-
         modify_config("MAX_RMA_RAILS", "2");
         test_ucp_rma::init();
     }


### PR DESCRIPTION
Opened to reproduce a sporadic CI failure.

Reverts the skip added in #11620, which disabled `test_ucp_rma_sgl` on CUDA memory type. The underlying bug only reproduces in CI (GPU lane), so this draft re-enables the test to get a failing run to investigate.

The failure looks like:

```
[swx-rdmz-ucx-gpu-01:61675:0]  proto_reconfig.c:104  UCX  ERROR cannot find remote protocol for: ucp_context_5834 intra-node cfg#2 | put from sgl cuda/GPU1 to cuda/dev[1]
```

i.e. a request parked on the reconfig protocol finds no SGL PUT protocol for cuda -> cuda in the endpoint configuration it is re-resolved against.

This PR will be turned into the actual fix (keeping the test enabled) once the root cause is understood.