### PR TITLE
UCT/IB: Allow ODP with DDP for FW >= 49.1014

### DIFF
--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -26,6 +26,7 @@
 #include <libgen.h>
 #include <pthread.h>
 #include <sched.h>
+#include <stdio.h>
 
 #ifdef HAVE_NETLINK_RDMA
 #include <rdma/rdma_netlink.h>
@@ -1209,6 +1210,21 @@ int uct_ib_device_is_port_roce(uct_ib_device_t *dev, uint8_t port_num)
 const char *uct_ib_device_name(const uct_ib_device_t *dev)
 {
     return ibv_get_device_name(dev->ibv_context->device);
+}
+
+int uct_ib_fw_ver_release_at_least(const char *fw_ver, unsigned min_release,
+                                   unsigned min_build)
+{
+    unsigned release, build;
+
+    ucs_assert(fw_ver != NULL);
+
+    if (sscanf(fw_ver, "%*u.%u.%u", &release, &build) != 2) {
+        return 0;
+    }
+
+    return (release > min_release) ||
+           ((release == min_release) && (build >= min_build));
 }
 
 size_t uct_ib_mtu_value(enum ibv_mtu mtu)

--- a/src/uct/ib/base/ib_device.c
+++ b/src/uct/ib/base/ib_device.c
@@ -26,7 +26,6 @@
 #include <libgen.h>
 #include <pthread.h>
 #include <sched.h>
-#include <stdio.h>
 
 #ifdef HAVE_NETLINK_RDMA
 #include <rdma/rdma_netlink.h>
@@ -699,9 +698,10 @@ ucs_status_t uct_ib_device_init(uct_ib_device_t *dev,
     ucs_recursive_spinlock_init(&dev->ah_lock, 0);
     dev->ah_cache_ttl = UCS_TIME_INFINITY;
 
-    ucs_debug("initialized device '%s' (%s) with %d ports", uct_ib_device_name(dev),
-              ibv_node_type_str(ibv_device->node_type),
-              dev->num_ports);
+    ucs_debug("initialized device '%s' (%s) with %d ports, fw %s",
+              uct_ib_device_name(dev),
+              ibv_node_type_str(ibv_device->node_type), dev->num_ports,
+              IBV_DEV_ATTR(dev, fw_ver));
     return UCS_OK;
 
 err_release_stats:
@@ -1210,21 +1210,6 @@ int uct_ib_device_is_port_roce(uct_ib_device_t *dev, uint8_t port_num)
 const char *uct_ib_device_name(const uct_ib_device_t *dev)
 {
     return ibv_get_device_name(dev->ibv_context->device);
-}
-
-int uct_ib_fw_ver_release_at_least(const char *fw_ver, unsigned min_release,
-                                   unsigned min_build)
-{
-    unsigned release, build;
-
-    ucs_assert(fw_ver != NULL);
-
-    if (sscanf(fw_ver, "%*u.%u.%u", &release, &build) != 2) {
-        return 0;
-    }
-
-    return (release > min_release) ||
-           ((release == min_release) && (build >= min_build));
 }
 
 size_t uct_ib_mtu_value(enum ibv_mtu mtu)

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -330,6 +330,17 @@ const char *uct_ib_device_name(const uct_ib_device_t *dev);
 
 
 /**
+ * Compare firmware AA.BB.CCCC against a minimum BB.CCCC, ignoring the
+ * device-family prefix AA.
+ *
+ * @return 1 if @a fw_ver parses and is at least
+ *         @a min_release.@a min_build, otherwise 0.
+ */
+int uct_ib_fw_ver_release_at_least(const char *fw_ver, unsigned min_release,
+                                   unsigned min_build);
+
+
+/**
  * @return whether the port is InfiniBand
  */
 int uct_ib_device_is_port_ib(uct_ib_device_t *dev, uint8_t port_num);

--- a/src/uct/ib/base/ib_device.h
+++ b/src/uct/ib/base/ib_device.h
@@ -330,17 +330,6 @@ const char *uct_ib_device_name(const uct_ib_device_t *dev);
 
 
 /**
- * Compare firmware AA.BB.CCCC against a minimum BB.CCCC, ignoring the
- * device-family prefix AA.
- *
- * @return 1 if @a fw_ver parses and is at least
- *         @a min_release.@a min_build, otherwise 0.
- */
-int uct_ib_fw_ver_release_at_least(const char *fw_ver, unsigned min_release,
-                                   unsigned min_build);
-
-
-/**
  * @return whether the port is InfiniBand
  */
 int uct_ib_device_is_port_ib(uct_ib_device_t *dev, uint8_t port_num);

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -31,10 +31,6 @@
      UCS_BIT(UCT_IB_DEVX_OBJ_DCT) | UCS_BIT(UCT_IB_DEVX_OBJ_DCSRQ) | \
      UCS_BIT(UCT_IB_DEVX_OBJ_DCI) | UCS_BIT(UCT_IB_DEVX_OBJ_CQ))
 
-/* Host FW 49.1014 first verified ODP with DDP, as per 4238670. */
-#define UCT_IB_MLX5_ODP_DDP_MIN_FW_RELEASE 49
-#define UCT_IB_MLX5_ODP_DDP_MIN_FW_BUILD   1014
-
 
 static uint32_t uct_ib_mlx5_flush_rkey_make()
 {
@@ -118,12 +114,10 @@ uct_ib_mlx5_md_check_odp_common(const uct_ib_mlx5_md_t *md, const char **reason_
             (md->dp_ordering_cap_devx.dc == UCT_IB_MLX5_DP_ORDERING_OOO_ALL) ||
             md->ddp_support_dv.rc || md->ddp_support_dv.dc;
 
-    /* as per 4238670 */
+    /* Host FW 49.1014 first verified ODP with DDP, as per 4238670 */
     if (ddp_supported &&
-        !uct_ib_fw_ver_release_at_least(
-                IBV_DEV_ATTR(&md->super.dev, fw_ver),
-                UCT_IB_MLX5_ODP_DDP_MIN_FW_RELEASE,
-                UCT_IB_MLX5_ODP_DDP_MIN_FW_BUILD)) {
+        !uct_ib_mlx5_fw_ver_release_at_least(
+                IBV_DEV_ATTR(&md->super.dev, fw_ver), 49, 1014)) {
         *reason_ptr = "ODP does not work with DDP";
         return 0;
     }

--- a/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
+++ b/src/uct/ib/mlx5/dv/ib_mlx5dv_md.c
@@ -31,6 +31,10 @@
      UCS_BIT(UCT_IB_DEVX_OBJ_DCT) | UCS_BIT(UCT_IB_DEVX_OBJ_DCSRQ) | \
      UCS_BIT(UCT_IB_DEVX_OBJ_DCI) | UCS_BIT(UCT_IB_DEVX_OBJ_CQ))
 
+/* Host FW 49.1014 first verified ODP with DDP, as per 4238670. */
+#define UCT_IB_MLX5_ODP_DDP_MIN_FW_RELEASE 49
+#define UCT_IB_MLX5_ODP_DDP_MIN_FW_BUILD   1014
+
 
 static uint32_t uct_ib_mlx5_flush_rkey_make()
 {
@@ -107,12 +111,20 @@ uct_ib_mlx5_md_check_odp_common(const uct_ib_mlx5_md_t *md, const char **reason_
                                 const uct_ib_md_config_t *md_config)
 {
     int is_odp_supported = uct_ib_md_check_odp_common(&md->super, reason_ptr);
+    int ddp_supported;
 
-    /* Issue 4238670 */
-    if ((md->dp_ordering_cap_devx.rc == UCT_IB_MLX5_DP_ORDERING_OOO_ALL) ||
-        (md->dp_ordering_cap_devx.dc == UCT_IB_MLX5_DP_ORDERING_OOO_ALL) ||
-        md->ddp_support_dv.rc || md->ddp_support_dv.dc) {
-        *reason_ptr         = "ODP does not work with DDP";
+    ddp_supported =
+            (md->dp_ordering_cap_devx.rc == UCT_IB_MLX5_DP_ORDERING_OOO_ALL) ||
+            (md->dp_ordering_cap_devx.dc == UCT_IB_MLX5_DP_ORDERING_OOO_ALL) ||
+            md->ddp_support_dv.rc || md->ddp_support_dv.dc;
+
+    /* as per 4238670 */
+    if (ddp_supported &&
+        !uct_ib_fw_ver_release_at_least(
+                IBV_DEV_ATTR(&md->super.dev, fw_ver),
+                UCT_IB_MLX5_ODP_DDP_MIN_FW_RELEASE,
+                UCT_IB_MLX5_ODP_DDP_MIN_FW_BUILD)) {
+        *reason_ptr = "ODP does not work with DDP";
         return 0;
     }
 

--- a/src/uct/ib/mlx5/ib_mlx5.c
+++ b/src/uct/ib/mlx5/ib_mlx5.c
@@ -20,6 +20,7 @@
 #include <ucs/sys/sys.h>
 #include <ucs/vfs/base/vfs_cb.h>
 #include <ucs/vfs/base/vfs_obj.h>
+#include <stdio.h>
 #include <string.h>
 
 
@@ -1061,6 +1062,22 @@ void uct_ib_mlx5_destroy_qp(uct_ib_mlx5_md_t *md, uct_ib_mlx5_qp_t *qp)
 size_t uct_ib_mlx5_devx_sq_length(size_t tx_qp_length)
 {
     return ucs_roundup_pow2_or0(tx_qp_length * UCT_IB_MLX5_MAX_BB);
+}
+
+int uct_ib_mlx5_fw_ver_release_at_least(const char *fw_ver,
+                                        unsigned min_release,
+                                        unsigned min_build)
+{
+    unsigned release, build;
+
+    ucs_assert(fw_ver != NULL);
+
+    if (sscanf(fw_ver, "%*u.%u.%u", &release, &build) != 2) {
+        return 0;
+    }
+
+    return (release > min_release) ||
+           ((release == min_release) && (build >= min_build));
 }
 
 /* Keep the function as a separate to test SL selection */

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -1292,6 +1292,17 @@ ucs_status_t uct_ib_mlx5_devx_reg_exported_key(uct_ib_mlx5_md_t *md,
                                                uct_ib_mlx5_devx_mem_t *memh);
 #endif
 
+/**
+ * Compare firmware AA.BB.CCCC against a minimum BB.CCCC, ignoring the
+ * device-family prefix AA.
+ *
+ * @return 1 if @a fw_ver parses and is at least
+ *         @a min_release.@a min_build, otherwise 0.
+ */
+int uct_ib_mlx5_fw_ver_release_at_least(const char *fw_ver,
+                                        unsigned min_release,
+                                        unsigned min_build);
+
 ucs_status_t uct_ib_mlx5_select_sl(const uct_ib_iface_config_t *ib_config,
                                    ucs_ternary_auto_value_t ar_enable,
                                    uint16_t hw_sl_mask, int have_sl_mask_cap,

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -681,19 +681,21 @@ UCS_TEST_F(test_uct_ib_utils, sec_to_rnr_time) {
     EXPECT_EQ(0, rnr_val);
 }
 
+#ifdef HAVE_MLX5_DV
 UCS_TEST_F(test_uct_ib_utils, fw_ver_release_at_least) {
-    EXPECT_TRUE(uct_ib_fw_ver_release_at_least("40.48.1000", 48, 1000));
-    EXPECT_TRUE(uct_ib_fw_ver_release_at_least("82.48.1000", 48, 1000));
-    EXPECT_TRUE(uct_ib_fw_ver_release_at_least("32.48.1000", 48, 1000));
-    EXPECT_TRUE(uct_ib_fw_ver_release_at_least("40.49.1", 48, 1000));
-    EXPECT_TRUE(uct_ib_fw_ver_release_at_least("40.48.1001", 48, 1000));
-    EXPECT_FALSE(uct_ib_fw_ver_release_at_least("40.44.1036", 48, 1000));
-    EXPECT_FALSE(uct_ib_fw_ver_release_at_least("40.48.999", 48, 1000));
-    EXPECT_FALSE(uct_ib_fw_ver_release_at_least("40.47.1026", 48, 1000));
-    EXPECT_FALSE(uct_ib_fw_ver_release_at_least("0.0.0.0", 48, 1000));
-    EXPECT_FALSE(uct_ib_fw_ver_release_at_least("bogus", 48, 1000));
-    EXPECT_FALSE(uct_ib_fw_ver_release_at_least("", 48, 1000));
+    EXPECT_TRUE(uct_ib_mlx5_fw_ver_release_at_least("40.48.1000", 48, 1000));
+    EXPECT_TRUE(uct_ib_mlx5_fw_ver_release_at_least("82.48.1000", 48, 1000));
+    EXPECT_TRUE(uct_ib_mlx5_fw_ver_release_at_least("32.48.1000", 48, 1000));
+    EXPECT_TRUE(uct_ib_mlx5_fw_ver_release_at_least("40.49.1", 48, 1000));
+    EXPECT_TRUE(uct_ib_mlx5_fw_ver_release_at_least("40.48.1001", 48, 1000));
+    EXPECT_FALSE(uct_ib_mlx5_fw_ver_release_at_least("40.44.1036", 48, 1000));
+    EXPECT_FALSE(uct_ib_mlx5_fw_ver_release_at_least("40.48.999", 48, 1000));
+    EXPECT_FALSE(uct_ib_mlx5_fw_ver_release_at_least("40.47.1026", 48, 1000));
+    EXPECT_FALSE(uct_ib_mlx5_fw_ver_release_at_least("0.0.0.0", 48, 1000));
+    EXPECT_FALSE(uct_ib_mlx5_fw_ver_release_at_least("bogus", 48, 1000));
+    EXPECT_FALSE(uct_ib_mlx5_fw_ver_release_at_least("", 48, 1000));
 }
+#endif
 
 
 #if HAVE_DEVX

--- a/test/gtest/uct/ib/test_ib.cc
+++ b/test/gtest/uct/ib/test_ib.cc
@@ -681,6 +681,20 @@ UCS_TEST_F(test_uct_ib_utils, sec_to_rnr_time) {
     EXPECT_EQ(0, rnr_val);
 }
 
+UCS_TEST_F(test_uct_ib_utils, fw_ver_release_at_least) {
+    EXPECT_TRUE(uct_ib_fw_ver_release_at_least("40.48.1000", 48, 1000));
+    EXPECT_TRUE(uct_ib_fw_ver_release_at_least("82.48.1000", 48, 1000));
+    EXPECT_TRUE(uct_ib_fw_ver_release_at_least("32.48.1000", 48, 1000));
+    EXPECT_TRUE(uct_ib_fw_ver_release_at_least("40.49.1", 48, 1000));
+    EXPECT_TRUE(uct_ib_fw_ver_release_at_least("40.48.1001", 48, 1000));
+    EXPECT_FALSE(uct_ib_fw_ver_release_at_least("40.44.1036", 48, 1000));
+    EXPECT_FALSE(uct_ib_fw_ver_release_at_least("40.48.999", 48, 1000));
+    EXPECT_FALSE(uct_ib_fw_ver_release_at_least("40.47.1026", 48, 1000));
+    EXPECT_FALSE(uct_ib_fw_ver_release_at_least("0.0.0.0", 48, 1000));
+    EXPECT_FALSE(uct_ib_fw_ver_release_at_least("bogus", 48, 1000));
+    EXPECT_FALSE(uct_ib_fw_ver_release_at_least("", 48, 1000));
+}
+
 
 #if HAVE_DEVX
 class test_uct_ib_sl_utils : public test_uct_ib_utils {


### PR DESCRIPTION
## What?
Enable ODP/cuda-managed with FW >= 49.1014 as mentioned in report.

Has impact on wireup lanes: https://nvbugspro.nvidia.com/bug/6665318

## Why?
Enable broad cuda-managed support. Incidentally uniform memory support across interfaces help wireup lanes selection.

## How?
Confirmed cuda-managed zcopy using rc_mlx5.

Tested on 40.49.1014:
```
UCX_NET_DEVICES=mlx5_1 ./rfs/bin/ucx_perftest
UCX_PROTO_INFO=used UCX_NET_DEVICES=mlx5_0 ./rfs/bin/ucx_perftest \
    -m cuda-managed -t ucp_put_bw -n 10000 localhost
```

Tested on 40.51.0230 (soul):
```
UCX_REG_NONBLOCK_MEM_TYPES=host,cuda-managed UCX_IB_ODP_MEM_TYPES=host,cuda-managed \
    UCX_NET_DEVICES=mlx5_0 ./rfs/bin/ucx_perftest &
UCX_REG_NONBLOCK_MEM_TYPES=host,cuda-managed UCX_IB_ODP_MEM_TYPES=host,cuda-managed \
UCX_TLS=^cuda_ipc,cma \
UCX_NET_DEVICES=mlx5_0 UCX_PROTO_INFO=used rfs/bin/ucx_perftest \
    -t ucp_get/ucp_put_bw -m cuda-managed -n 1000  localhost -s 1024
```