### PR TITLE
UCP/RMA: Activate non-blocking endpoint fences

### DIFF
--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -232,7 +232,6 @@ static void ucp_ep_deallocate(ucp_ep_h ep)
 static ucp_ep_h ucp_ep_allocate(ucp_worker_h worker, const char *peer_name)
 {
     ucp_ep_h ep;
-    ucp_lane_index_t lane;
     ucs_status_t status;
 
     ep = ucs_strided_alloc_get(&worker->ep_alloc, "ucp_ep");
@@ -271,6 +270,7 @@ static ucp_ep_h ucp_ep_allocate(ucp_worker_h worker, const char *peer_name)
 #endif
     ep->ext->peer_mem                     = NULL;
     ep->ext->unflushed_lanes              = 0;
+    ep->ext->lane_generation              = 0;
     ep->ext->fence_seq                    = 0;
     ep->ext->uct_eps                      = NULL;
     ep->ext->flush_sys_dev_map            = 0;
@@ -281,9 +281,7 @@ static ucp_ep_h ucp_ep_allocate(ucp_worker_h worker, const char *peer_name)
 
     ucs_hlist_head_init(&ep->ext->proto_reqs);
 
-    for (lane = 0; lane < UCP_MAX_FAST_PATH_LANES; ++lane) {
-        ucp_ep_set_lane(ep, lane, NULL);
-    }
+    memset(ep->uct_eps, 0, sizeof(ep->uct_eps));
 #if ENABLE_DEBUG_DATA
     ucs_snprintf_zero(ep->peer_name, UCP_WORKER_ADDRESS_NAME_MAX, "%s",
                       peer_name);
@@ -4707,7 +4705,13 @@ ucs_status_t ucp_ep_realloc_lanes(ucp_ep_h ep, unsigned new_num_lanes)
                             0;
 
     for (lane = old_num_lanes; lane < new_num_lanes; ++lane) {
-        ucp_ep_set_lane(ep, lane, NULL);
+        /* New storage is not initialized yet, so bypass lane change
+         * tracking. */
+        if (lane < UCP_MAX_FAST_PATH_LANES) {
+            ep->uct_eps[lane] = NULL;
+        } else {
+            ep_ext->uct_eps[lane - UCP_MAX_FAST_PATH_LANES] = NULL;
+        }
     }
 
     return UCS_OK;

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -276,6 +276,7 @@ static ucp_ep_h ucp_ep_allocate(ucp_worker_h worker, const char *peer_name)
     ep->ext->fence_seq                    = 0;
     ep->ext->fence_inflight_req           = NULL;
     ep->ext->fence_status                 = UCS_OK;
+    ep->ext->fence_lanes_dirty            = 0;
     ep->ext->fence_pending_scheduled      = 0;
     ep->ext->uct_eps                      = NULL;
     ep->ext->flush_sys_dev_map            = 0;
@@ -628,6 +629,19 @@ static int ucp_ep_fence_dispatch_request(ucp_ep_h ep)
     req = ucs_queue_pull_elem_non_empty(&ep_ext->fence_pending_q,
                                         ucp_request_t,
                                         send.fence_pending_elem);
+
+    if ((req->flags & UCP_REQUEST_FLAG_PROTO_SEND) &&
+        ((ep->cfg_index != req->send.proto_config->ep_cfg_index) ||
+         ep->worker->context->config.ext.proto_request_reset)) {
+        /* A request on the fence queue bypasses wireup pending replay. Restart
+         * it on the current endpoint configuration before its old callback can
+         * use a failed or replaced lane. Its fence epoch remains unchanged. */
+        ucp_trace_req(req, "restart fenced proto %s after reconfiguration",
+                      req->send.proto_config->proto->name);
+        req->flags &= ~UCP_REQUEST_FLAG_FENCE_BLOCKED;
+        ucp_proto_request_restart(req);
+        return 1;
+    }
 
     is_proto   = req->flags & UCP_REQUEST_FLAG_PROTO_SEND;
     req->flags &= ~UCP_REQUEST_FLAG_FENCE_BLOCKED;
@@ -1685,7 +1699,9 @@ static void ucp_ep_discard_lanes_callback(void *request, ucs_status_t status,
     }
 
     ucs_trace("ep %p: discard lanes completed", arg->ucp_ep);
-    ucp_ep_reqs_purge(arg->ucp_ep, arg->status);
+    ucp_ep_reqs_purge(
+            arg->ucp_ep, arg->status,
+            arg->deactivate_cfg_index == UCP_WORKER_CFG_INDEX_NULL);
     ucp_ep_config_deactivate_worker_ifaces(arg->ucp_ep->worker,
                                            arg->deactivate_cfg_index);
     ucp_ep_release_discard_arg(arg);
@@ -1742,7 +1758,7 @@ static void ucp_ep_discard_lanes(ucp_ep_h ep, ucp_lane_map_t lanes,
         ucs_error("ep %p: failed to allocate memory for discarding lanes"
                   " argument", ep);
         ucp_ep_cleanup_lanes(ep); /* Just close all UCT endpoints */
-        ucp_ep_reqs_purge(ep, discard_status);
+        ucp_ep_reqs_purge(ep, discard_status, 1);
         return;
     }
 
@@ -4680,13 +4696,16 @@ void ucp_ep_req_purge(ucp_ep_h ucp_ep, ucp_request_t *req,
     }
 }
 
-void ucp_ep_reqs_purge(ucp_ep_h ucp_ep, ucs_status_t status)
+void ucp_ep_reqs_purge(ucp_ep_h ucp_ep, ucs_status_t status,
+                       int purge_fence_pending)
 {
     ucs_hlist_head_t *proto_reqs = &ucp_ep->ext->proto_reqs;
     ucp_ep_flush_state_t *flush_state;
     ucp_request_t *req;
 
-    ucp_ep_fence_pending_purge(ucp_ep, status);
+    if (purge_fence_pending) {
+        ucp_ep_fence_pending_purge(ucp_ep, status);
+    }
 
     while (!ucs_hlist_is_empty(proto_reqs)) {
         req = ucs_hlist_head_elem(proto_reqs, ucp_request_t, send.list);

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -273,7 +273,7 @@ static ucp_ep_h ucp_ep_allocate(ucp_worker_h worker, const char *peer_name)
     ep->ext->peer_mem                     = NULL;
     ep->ext->unflushed_lanes              = 0;
     ep->ext->lane_generation              = 0;
-    ep->ext->fence_seq                    = 0;
+    ep->ext->fence_seq                    = 1;
     ep->ext->fence_inflight_req           = NULL;
     ep->ext->fence_status                 = UCS_OK;
     ep->ext->fence_lanes_dirty            = 0;

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -44,6 +44,8 @@ __KHASH_IMPL(ucp_ep_peer_mem_hash, kh_inline, uint64_t,
              ucp_ep_peer_mem_data_t, 1,
              kh_int64_hash_func, kh_int64_hash_equal);
 
+#define UCP_EP_FENCE_PROGRESS_BATCH 16
+
 typedef struct {
     double reg_growth;
     double reg_overhead;
@@ -272,8 +274,12 @@ static ucp_ep_h ucp_ep_allocate(ucp_worker_h worker, const char *peer_name)
     ep->ext->unflushed_lanes              = 0;
     ep->ext->lane_generation              = 0;
     ep->ext->fence_seq                    = 0;
+    ep->ext->fence_inflight_req           = NULL;
+    ep->ext->fence_status                 = UCS_OK;
+    ep->ext->fence_pending_scheduled      = 0;
     ep->ext->uct_eps                      = NULL;
     ep->ext->flush_sys_dev_map            = 0;
+    ucs_queue_head_init(&ep->ext->fence_pending_q);
 
     UCS_STATIC_ASSERT(sizeof(ep->ext->ep_match) >=
                       sizeof(ep->ext->flush_state));
@@ -516,13 +522,188 @@ static int ucp_ep_wireup_eps_progress_filter(const ucs_callbackq_elem_t *elem,
     return (elem->cb == ucp_wireup_eps_progress) && (elem->arg == arg);
 }
 
+static UCS_F_ALWAYS_INLINE ucs_queue_elem_t*
+ucp_ep_fence_req_elem(uct_pending_req_t *uct_req)
+{
+    ucp_request_t *req = ucs_container_of(uct_req, ucp_request_t, send.uct);
+
+    return &req->send.fence_pending_elem;
+}
+
+static unsigned ucp_ep_fence_pending_progress(void *arg);
+
+static int
+ucp_ep_fence_pending_progress_filter(const ucs_callbackq_elem_t *elem,
+                                     void *arg)
+{
+    return (elem->cb == ucp_ep_fence_pending_progress) && (elem->arg == arg);
+}
+
+static UCS_F_ALWAYS_INLINE void ucp_ep_fence_pending_schedule(ucp_ep_h ep)
+{
+    if (ep->ext->fence_pending_scheduled) {
+        return;
+    }
+
+    ep->ext->fence_pending_scheduled = 1;
+    ucs_callbackq_add_oneshot(&ep->worker->uct->progress_q, ep,
+                              ucp_ep_fence_pending_progress, ep);
+    ucp_worker_signal_internal(ep->worker);
+}
+
+void ucp_ep_fence_pending_resume(ucp_ep_h ep)
+{
+    if (!ucs_queue_is_empty(&ep->ext->fence_pending_q)) {
+        ucp_ep_fence_pending_schedule(ep);
+    }
+}
+
+void ucp_ep_fence_pending_add(ucp_ep_h ep, uct_pending_req_t *uct_req)
+{
+    ucs_queue_head_t *queue = &ep->ext->fence_pending_q;
+    ucp_request_t *new_req  =
+            ucs_container_of(uct_req, ucp_request_t, send.uct);
+    ucs_queue_elem_t *elem = ucp_ep_fence_req_elem(uct_req);
+    ucs_queue_iter_t iter;
+    ucp_request_t *queued_req;
+
+    for (iter = ucs_queue_iter_begin(queue);
+         !ucs_queue_iter_end(queue, iter);
+         iter = ucs_queue_iter_next(iter)) {
+        queued_req = ucs_container_of(*iter, ucp_request_t,
+                                      send.fence_pending_elem);
+        if (queued_req->send.fence_seq > new_req->send.fence_seq) {
+            elem->next = *iter;
+            *iter      = elem;
+            ucp_ep_fence_pending_schedule(ep);
+            return;
+        }
+    }
+
+    ucs_queue_push(queue, elem);
+    ucp_ep_fence_pending_schedule(ep);
+}
+
+void ucp_ep_fence_pending_purge(ucp_ep_h ep, ucs_status_t status)
+{
+    ucp_request_t *req;
+
+    ucs_queue_for_each_extract(req, &ep->ext->fence_pending_q,
+                              send.fence_pending_elem, 1) {
+        req->flags &= ~UCP_REQUEST_FLAG_FENCE_BLOCKED;
+        if (req->flags & UCP_REQUEST_FLAG_PROTO_SEND) {
+            ucp_proto_request_abort(req, status);
+        } else {
+            ucp_request_send_state_ff(req, status);
+        }
+    }
+}
+
+static UCS_F_ALWAYS_INLINE int
+ucp_ep_fence_try_advance_epoch(ucp_ep_h ep, uint64_t fence_seq)
+{
+    ucs_status_t status;
+
+    status = ucp_ep_fence_strong_nb(ep, fence_seq);
+    if (ucs_unlikely(status != UCS_OK)) {
+        ucp_ep_fence_pending_purge(ep, status);
+        return 0;
+    }
+
+    if (ucs_unlikely(ep->ext->fence_inflight_req == NULL)) {
+        return ep->ext->fence_status == UCS_OK;
+    }
+
+    return 0;
+}
+
+static int ucp_ep_fence_dispatch_request(ucp_ep_h ep)
+{
+    ucp_ep_ext_t *ep_ext = ep->ext;
+    ucp_request_t *req;
+    ucs_status_t status;
+    int is_proto;
+    int batch;
+
+    req = ucs_queue_pull_elem_non_empty(&ep_ext->fence_pending_q,
+                                        ucp_request_t,
+                                        send.fence_pending_elem);
+
+    is_proto   = req->flags & UCP_REQUEST_FLAG_PROTO_SEND;
+    req->flags &= ~UCP_REQUEST_FLAG_FENCE_BLOCKED;
+
+    for (batch = 0; batch < UCP_EP_FENCE_PROGRESS_BATCH; ++batch) {
+        /* coverity[address_free] */
+        status = req->send.uct.func(&req->send.uct);
+        if (status != UCS_INPROGRESS) {
+            break;
+        }
+    }
+
+    if ((status == UCS_INPROGRESS) ||
+        (status == UCS_ERR_NO_RESOURCE) ||
+        (status == UCP_STATUS_FENCE_DEFER)) {
+        req->flags |= UCP_REQUEST_FLAG_FENCE_BLOCKED;
+        ucs_queue_push_head(&ep_ext->fence_pending_q,
+                            &req->send.fence_pending_elem);
+        if (ep_ext->fence_inflight_req == NULL) {
+            ucp_ep_fence_pending_schedule(ep);
+        }
+        return 0;
+    }
+
+    if (ucs_unlikely((status != UCS_OK) && UCS_STATUS_IS_ERR(status))) {
+        if (is_proto) {
+            ucp_proto_request_abort(req, status);
+        } else {
+            ucp_request_send_state_ff(req, status);
+        }
+    } else {
+        ucs_assert(status == UCS_OK);
+    }
+
+    return 1;
+}
+
+static unsigned ucp_ep_fence_pending_progress(void *arg)
+{
+    ucp_ep_h ep          = arg;
+    ucp_ep_ext_t *ep_ext = ep->ext;
+    ucp_request_t *req;
+
+    ep_ext->fence_pending_scheduled = 0;
+
+    while (!ucs_queue_is_empty(&ep_ext->fence_pending_q)) {
+        if (ucs_unlikely(ep_ext->fence_inflight_req != NULL)) {
+            break;
+        }
+
+        req = ucs_queue_head_elem_non_empty(&ep_ext->fence_pending_q,
+                                            ucp_request_t,
+                                            send.fence_pending_elem);
+        if (ucs_unlikely(req->send.fence_seq > ep_ext->fence_seq)) {
+            if (!ucp_ep_fence_try_advance_epoch(ep,
+                                                req->send.fence_seq)) {
+                break;
+            }
+        }
+
+        if (!ucp_ep_fence_dispatch_request(ep)) {
+            break;
+        }
+    }
+
+    return 0;
+}
+
 static int ucp_ep_remove_filter(const ucs_callbackq_elem_t *elem, void *arg)
 {
     if (ucp_wireup_msg_ack_cb_pred(elem, arg) ||
         ucp_listener_accept_cb_remove_filter(elem, arg) ||
         ucp_ep_local_disconnect_progress_remove_filter(elem, arg) ||
         ucp_ep_set_failed_remove_filter(elem, arg) ||
-        ucp_ep_wireup_eps_progress_filter(elem, arg)) {
+        ucp_ep_wireup_eps_progress_filter(elem, arg) ||
+        ucp_ep_fence_pending_progress_filter(elem, arg)) {
         return 1;
     }
 
@@ -540,6 +721,7 @@ void ucp_ep_destroy_base(ucp_ep_h ep)
     ucp_ep_refcount_assert(ep, discard, ==, 0);
     ucp_ep_refcount_assert(ep, probe, ==, 0);
     ucs_assert(ucs_hlist_is_empty(&ep->ext->proto_reqs));
+    ucs_assert(ucs_queue_is_empty(&ep->ext->fence_pending_q));
 
     if (!(ep->flags & UCP_EP_FLAG_INTERNAL)) {
         ucs_assert(worker->num_all_eps > 0);
@@ -4503,6 +4685,8 @@ void ucp_ep_reqs_purge(ucp_ep_h ucp_ep, ucs_status_t status)
     ucs_hlist_head_t *proto_reqs = &ucp_ep->ext->proto_reqs;
     ucp_ep_flush_state_t *flush_state;
     ucp_request_t *req;
+
+    ucp_ep_fence_pending_purge(ucp_ep, status);
 
     while (!ucs_hlist_is_empty(proto_reqs)) {
         req = ucs_hlist_head_elem(proto_reqs, ucp_request_t, send.list);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -575,6 +575,8 @@ typedef struct ucp_ep_ext {
     ucs_queue_head_t              fence_pending_q; /* Fence-blocked requests */
     ucp_request_t                 *fence_inflight_req; /* Active fence flush */
     ucs_status_t                  fence_status; /* Current/last flush status */
+    /* Lane topology changed since fence lane tracking was normalized. */
+    uint8_t                       fence_lanes_dirty;
     uint8_t                       fence_pending_scheduled; /* Progress armed */
 
     /**
@@ -958,8 +960,12 @@ void ucp_ep_req_purge(ucp_ep_h ucp_ep, ucp_request_t *req,
  * @param [in]     ucp_ep           Endpoint object on which requests should be
  *                                  purged.
  * @param [in]     status           Completion status.
+ * @param [in]     purge_fence_pending Whether to purge requests waiting for a
+ *                                  fence epoch. Reconfiguration keeps them so
+ *                                  they can restart on the new topology.
  */
-void ucp_ep_reqs_purge(ucp_ep_h ucp_ep, ucs_status_t status);
+void ucp_ep_reqs_purge(ucp_ep_h ucp_ep, ucs_status_t status,
+                       int purge_fence_pending);
 
 void ucp_ep_fence_pending_add(ucp_ep_h ep, uct_pending_req_t *req);
 void ucp_ep_fence_pending_purge(ucp_ep_h ep, ucs_status_t status);

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -572,6 +572,11 @@ typedef struct ucp_ep_ext {
     uint64_t                      fence_seq;       /* Sequence number for fence
                                                       detection */
 
+    ucs_queue_head_t              fence_pending_q; /* Fence-blocked requests */
+    ucp_request_t                 *fence_inflight_req; /* Active fence flush */
+    ucs_status_t                  fence_status; /* Current/last flush status */
+    uint8_t                       fence_pending_scheduled; /* Progress armed */
+
     /**
      * UCT endpoints for every slow-path lane that has no room in the base endpoint
      * structure. TODO allocate this array dynamically.
@@ -956,6 +961,9 @@ void ucp_ep_req_purge(ucp_ep_h ucp_ep, ucp_request_t *req,
  */
 void ucp_ep_reqs_purge(ucp_ep_h ucp_ep, ucs_status_t status);
 
+void ucp_ep_fence_pending_add(ucp_ep_h ep, uct_pending_req_t *req);
+void ucp_ep_fence_pending_purge(ucp_ep_h ep, ucs_status_t status);
+void ucp_ep_fence_pending_resume(ucp_ep_h ep);
 
 /**
  * @brief Query local and/or remote socket address of endpoint @a ucp_ep.

--- a/src/ucp/core/ucp_ep.h
+++ b/src/ucp/core/ucp_ep.h
@@ -567,6 +567,8 @@ typedef struct ucp_ep_ext {
 
     ucp_lane_map_t                unflushed_lanes; /* Bitmap of lanes which have
                                                       unflushed operations */
+    uint64_t                      lane_generation; /* Incremented whenever a lane
+                                                      is updated */
     uint64_t                      fence_seq;       /* Sequence number for fence
                                                       detection */
 
@@ -760,6 +762,21 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned req_flags,
                                        ucp_request_callback_t flushed_cb,
                                        const char *debug_name,
                                        unsigned uct_flags);
+
+/**
+ * @brief Flush a subset of endpoint lanes specified by @a lane_mask.
+ *
+ * Same as @ref ucp_ep_flush_internal, but only lanes whose bit is set in
+ * @a lane_mask are initially flushed. If the endpoint topology changes while
+ * the flush is active, current live lanes are added conservatively.
+ */
+ucs_status_ptr_t
+ucp_ep_flush_lanes_internal(ucp_ep_h ep, unsigned req_flags,
+                            const ucp_request_param_t *param,
+                            ucp_request_t *worker_req,
+                            ucp_request_callback_t flushed_cb,
+                            const char *debug_name, unsigned uct_flags,
+                            ucp_lane_map_t lane_mask);
 
 void ucp_ep_config_key_set_err_mode(ucp_ep_config_key_t *key,
                                     unsigned ep_init_flags);

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -54,6 +54,10 @@ static UCS_F_ALWAYS_INLINE void ucp_ep_set_lane(ucp_ep_h ep, size_t lane_index,
     }
 
     ++ep->ext->lane_generation;
+    if ((old_uct_ep != NULL) &&
+        (ep->ext->unflushed_lanes & UCS_BIT(lane_index))) {
+        ep->ext->fence_lanes_dirty = 1;
+    }
 
     if (lane_index < UCP_MAX_FAST_PATH_LANES) {
         ep->uct_eps[lane_index] = uct_ep;

--- a/src/ucp/core/ucp_ep.inl
+++ b/src/ucp/core/ucp_ep.inl
@@ -44,7 +44,16 @@ ucp_ep_get_lane(ucp_ep_h ep, ucp_lane_index_t lane_index)
 static UCS_F_ALWAYS_INLINE void ucp_ep_set_lane(ucp_ep_h ep, size_t lane_index,
                                                 uct_ep_h uct_ep)
 {
+    uct_ep_h old_uct_ep;
+
     ucs_assert(lane_index != UCP_NULL_LANE);
+
+    old_uct_ep = ucp_ep_get_lane(ep, lane_index);
+    if (old_uct_ep == uct_ep) {
+        return;
+    }
+
+    ++ep->ext->lane_generation;
 
     if (lane_index < UCP_MAX_FAST_PATH_LANES) {
         ep->uct_eps[lane_index] = uct_ep;

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -373,8 +373,19 @@ struct ucp_request {
                     uint8_t            uct_flags_orig;
                     uint8_t            sw_started;
                     uint8_t            sw_done;
-                    /* Memory specific flushes */
-                    ucp_mem_flush_t    mem;
+                    union {
+                        struct {
+                            /* Snapshot used to detect same-index lane
+                             * replacement */
+                            uint64_t       lane_generation;
+                            /* Lanes targeted by this flush. Replacement lanes
+                             * are added if endpoint failover changes the live
+                             * topology. */
+                            ucp_lane_map_t lane_mask;
+                        } lanes;
+                        /* Used only after transport lane flushes complete */
+                        ucp_mem_flush_t mem;
+                    };
                 } flush;
 
                 struct {

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -538,6 +538,8 @@ struct ucp_request {
 
         struct {
             ucp_worker_h            worker;       /* Worker to flush */
+            /* Fence work from later epochs does not delay this flush. */
+            uint64_t                fence_seq_th;
             ucp_send_nbx_callback_t cb;           /* Completion callback */
             uct_worker_cb_id_t      prog_id;      /* Progress callback ID */
             ucp_ep_ext_t            *next_ep_ext; /* Extension of the next endpoint to flush */

--- a/src/ucp/core/ucp_request.h
+++ b/src/ucp/core/ucp_request.h
@@ -29,6 +29,16 @@
 #define ucp_trace_req(_sreq, _message, ...) \
     ucs_trace_req("req %p: " _message, (_sreq), ## __VA_ARGS__)
 
+#define UCP_STATUS_FENCE_DEFER ((ucs_status_t)(UCS_ERR_LAST + 1))
+#ifdef __cplusplus
+static_assert((UCP_STATUS_FENCE_DEFER < UCS_OK) &&
+              (UCP_STATUS_FENCE_DEFER >= UCS_ERR_LAST),
+              "fence defer status must be an error pointer");
+#else
+_Static_assert((UCP_STATUS_FENCE_DEFER < UCS_OK) &&
+               (UCP_STATUS_FENCE_DEFER >= UCS_ERR_LAST),
+               "fence defer status must be an error pointer");
+#endif
 
 /**
  * Request flags
@@ -69,7 +79,8 @@ enum {
     UCP_REQUEST_FLAG_RNDV_SEND_INTERNAL    = UCS_BIT(26),
     UCP_REQUEST_FLAG_RNDV_GET_REQ          = UCS_BIT(27),
     UCP_REQUEST_FLAG_RNDV_FLUSH            = UCS_BIT(28),
-    UCP_REQUEST_FLAG_RNDV_START_FLUSH      = UCS_BIT(29)
+    UCP_REQUEST_FLAG_RNDV_START_FLUSH      = UCS_BIT(29),
+    UCP_REQUEST_FLAG_FENCE_BLOCKED         = UCS_BIT(30)
 };
 
 
@@ -242,14 +253,31 @@ struct ucp_request {
                 } msg_proto;
 
                 struct {
-                    uint64_t   remote_addr; /* Remote address */
-                    ucp_rkey_h rkey; /* Remote memory key */
+                    /* Fence state shared by RMA and atomic send requests. */
+                    uint64_t         fence_seq;
+                    ucs_queue_elem_t fence_pending_elem;
 
-                    struct {
-                        const uint64_t   *remote_addrs;
-                        ucp_rkey_h const *rkeys;
-                    } sgl;
-                } rma;
+                    union {
+                        struct {
+                            uint64_t   remote_addr; /* Remote address */
+                            ucp_rkey_h rkey;        /* Remote memory key */
+
+                            struct {
+                                const uint64_t   *remote_addrs;
+                                ucp_rkey_h const *rkeys;
+                            } sgl;
+                        } rma;
+
+                        struct {
+                            uint64_t        remote_addr; /* Remote address */
+                            ucp_rkey_h      rkey;        /* Remote memory key */
+                            uint64_t        value;       /* Atomic argument */
+                            uint64_t        result;      /* Atomic result */
+                            void           *reply_buffer;
+                            uct_atomic_op_t uct_op;      /* Requested UCT AMO */
+                        } amo;
+                    };
+                };
 
                 struct {
                     /* Remote request ID received from a peer */
@@ -359,6 +387,8 @@ struct ucp_request {
                 } rkey_ptr;
 
                 struct {
+                    /* Fence epoch advanced by this flush */
+                    uint64_t           fence_seq;
                     /* All lanes that are being flushed */
                     ucp_lane_map_t     all_lanes;
                     /* Which lanes flush has been started on */
@@ -400,15 +430,6 @@ struct ucp_request {
                     /* Index of UCT EP to be flushed and destroyed */
                     ucp_rsc_index_t    rsc_index;
                 } discard_uct_ep;
-
-                struct {
-                    uint64_t              remote_addr; /* Remote address */
-                    ucp_rkey_h            rkey;        /* Remote memory key */
-                    uint64_t              value;       /* Atomic argument */
-                    uint64_t              result;      /* Atomic result */
-                    void                  *reply_buffer;
-                    uct_atomic_op_t       uct_op;      /* Requested UCT AMO */
-                } amo;
 
                 struct {
                     ucs_queue_elem_t  queue;     /* Elem in outgoing ssend reqs queue */

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -348,6 +348,10 @@ static int UCS_F_ALWAYS_INLINE ucp_request_try_send(ucp_request_t *req)
     } else if (status == UCS_INPROGRESS) {
         /* Not completed, but made progress */
         return 0;
+    } else if (status == UCP_STATUS_FENCE_DEFER) {
+        /* No UCT lane was selected yet. Wait on the endpoint fence queue. */
+        ucp_ep_fence_pending_add(req->send.ep, &req->send.uct);
+        return 1;
     } else if (status == UCS_ERR_NO_RESOURCE) {
         /* No send resources, try to add to pending queue */
         return ucp_request_pending_add(req);

--- a/src/ucp/core/ucp_worker.c
+++ b/src/ucp/core/ucp_worker.c
@@ -2618,7 +2618,7 @@ ucs_status_t ucp_worker_create(ucp_context_h context,
     worker->context              = context;
     worker->uuid                 = ucs_generate_uuid((uintptr_t)worker);
     worker->flush_ops_count      = 0;
-    worker->fence_seq            = 0;
+    worker->fence_seq            = 1;
     worker->inprogress           = 0;
     worker->num_active_ifaces    = 0;
     worker->num_ifaces           = 0;

--- a/src/ucp/proto/proto_common.inl
+++ b/src/ucp/proto/proto_common.inl
@@ -255,8 +255,11 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_request_lookup_proto(
 static UCS_F_ALWAYS_INLINE void
 ucp_proto_request_send_init(ucp_request_t *req, ucp_ep_h ep, uint32_t flags)
 {
-    req->flags   = UCP_REQUEST_FLAG_PROTO_SEND | flags;
-    req->send.ep = ep;
+    req->flags             = UCP_REQUEST_FLAG_PROTO_SEND | flags;
+    req->send.ep           = ep;
+    req->send.pending_lane = UCP_NULL_LANE;
+    req->send.fence_seq    = (flags & UCP_REQUEST_FLAG_FENCE_REQUIRED) ?
+                             ep->worker->fence_seq : 0;
 }
 
 

--- a/src/ucp/proto/proto_multi.inl
+++ b/src/ucp/proto/proto_multi.inl
@@ -217,7 +217,17 @@ ucp_proto_multi_bcopy_progress(ucp_request_t *req,
         ucp_proto_multi_request_init(req);
         if (init_func != NULL) {
             status = init_func(req);
-            if (status != UCS_OK) {
+            if (status == UCP_STATUS_FENCE_DEFER) {
+                if (req->send.pending_lane != UCP_NULL_LANE) {
+                    ucp_ep_fence_pending_add(req->send.ep, &req->send.uct);
+                    req->send.pending_lane = UCP_NULL_LANE;
+                    return UCS_OK;
+                }
+
+                return status;
+            } else if (status == UCS_ERR_NO_RESOURCE) {
+                return status;
+            } else if (status != UCS_OK) {
                 /* remove from pending after request is completed */
                 ucp_proto_request_abort(req, status);
                 return UCS_OK;
@@ -250,7 +260,17 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_proto_multi_zcopy_progress(
         ucp_proto_multi_request_init(req);
         if (init_func != NULL) {
             status = init_func(req);
-            if (status != UCS_OK) {
+            if (status == UCP_STATUS_FENCE_DEFER) {
+                if (req->send.pending_lane != UCP_NULL_LANE) {
+                    ucp_ep_fence_pending_add(req->send.ep, &req->send.uct);
+                    req->send.pending_lane = UCP_NULL_LANE;
+                    return UCS_OK;
+                }
+
+                return status;
+            } else if (status == UCS_ERR_NO_RESOURCE) {
+                return status;
+            } else if (status != UCS_OK) {
                 goto out_abort;
             }
         }

--- a/src/ucp/rma/amo_offload.c
+++ b/src/ucp/rma/amo_offload.c
@@ -89,10 +89,9 @@ ucp_proto_amo_progress(uct_pending_req_t *self, ucp_operation_id_t op_id,
                                ucp_amo_request_reply_mem_type(req), op_size);
         }
 
-        status = ucp_ep_rma_handle_fence(ep, req, UCS_BIT(spriv->super.lane));
-        if (status != UCS_OK) {
-            ucp_proto_request_abort(req, status);
-            return UCS_OK;
+        if (!ucp_proto_rma_fence_progress(
+                    req, UCS_BIT(spriv->super.lane), &status)) {
+            return status;
         }
 
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;

--- a/src/ucp/rma/amo_sw.c
+++ b/src/ucp/rma/amo_sw.c
@@ -389,15 +389,14 @@ ucp_proto_amo_sw_progress(uct_pending_req_t *self, uct_pack_callback_t pack_cb,
             req->flags |= UCP_REQUEST_FLAG_PROTO_AMO_PACKED;
         }
 
-        status = ucp_ep_resolve_remote_id(ep, spriv->super.lane);
-        if (status != UCS_OK) {
+        if (!ucp_proto_rma_fence_progress(
+                    req, UCS_BIT(spriv->super.lane), &status)) {
             return status;
         }
 
-        status = ucp_ep_rma_handle_fence(ep, req, UCS_BIT(spriv->super.lane));
+        status = ucp_ep_resolve_remote_id(ep, spriv->super.lane);
         if (status != UCS_OK) {
-            ucp_proto_request_abort(req, status);
-            return UCS_OK;
+            return status;
         }
 
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -943,6 +943,76 @@ ucs_status_t ucp_ep_fence_strong(ucp_ep_h ep)
     return UCS_OK;
 }
 
+static void ucp_ep_fence_strong_nb_flushed_cb(ucp_request_t *req)
+{
+    ucp_ep_h ep         = req->send.ep;
+    ucs_status_t status = req->status;
+    int ep_destroyed;
+
+    ucs_assert(ep->ext->fence_inflight_req == req);
+
+    ep->ext->fence_inflight_req = NULL;
+    ep->ext->fence_status       = status;
+
+    if (ucs_likely(status == UCS_OK)) {
+        ep->ext->unflushed_lanes = 0;
+        ep->ext->fence_seq       = req->send.flush.fence_seq;
+    } else {
+        ucp_ep_fence_pending_purge(ep, status);
+    }
+
+    ep_destroyed = ucp_ep_refcount_remove(ep, flush);
+    ucp_request_put(req);
+    if (!ep_destroyed) {
+        ucp_ep_fence_pending_resume(ep);
+    }
+}
+
+ucs_status_t ucp_ep_fence_strong_nb(ucp_ep_h ep, uint64_t fence_seq)
+{
+    ucs_status_ptr_t request;
+    ucp_request_t *flush_req;
+    ucs_status_t status;
+
+    if (ucs_unlikely(ep->ext->fence_inflight_req != NULL)) {
+        return UCS_OK;
+    }
+
+    ep->ext->fence_status = UCS_INPROGRESS;
+    ucp_ep_refcount_add(ep, flush);
+
+    request = ucp_ep_flush_lanes_internal(ep, UCP_REQUEST_FLAG_RELEASED,
+                                          &ucp_request_null_param, NULL,
+                                          ucp_ep_fence_strong_nb_flushed_cb,
+                                          "ep_fence_strong_nb",
+                                          UCT_FLUSH_FLAG_REMOTE,
+                                          ep->ext->unflushed_lanes);
+    if (ucs_unlikely(UCS_PTR_IS_ERR(request))) {
+        status                = UCS_PTR_STATUS(request);
+        ep->ext->fence_status = status;
+        ucp_ep_refcount_remove(ep, flush);
+        return status;
+    }
+
+    if (ucs_unlikely(request == NULL)) {
+        int ep_destroyed;
+
+        ep->ext->unflushed_lanes = 0;
+        ep->ext->fence_seq       = fence_seq;
+        ep->ext->fence_status    = UCS_OK;
+        ep_destroyed             = ucp_ep_refcount_remove(ep, flush);
+        if (!ep_destroyed) {
+            ucp_ep_fence_pending_resume(ep);
+        }
+        return UCS_OK;
+    }
+
+    flush_req                       = (ucp_request_t*)request - 1;
+    flush_req->send.flush.fence_seq = fence_seq;
+    ep->ext->fence_inflight_req     = flush_req;
+    return UCS_OK;
+}
+
 static unsigned ucp_ep_flush_mem_resume_callback(void *arg)
 {
     ucp_request_t *req = arg;

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -77,9 +77,8 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
     ucp_lane_index_t lane;
     ucs_status_t status;
     uct_ep_h uct_ep;
-    ucp_lane_map_t ep_destroyed_lanes;
-    ucp_lane_map_t ep_new_lanes;
     ucp_lane_map_t next_lanes;
+    int lane_generation_changed;
 
     ucs_assertv(!(ep->flags & UCP_EP_FLAG_BLOCK_FLUSH), "req=%p ep=%p", req, 
                 ep);
@@ -89,15 +88,19 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
      * lanes we never started: started lanes are already accounted for - by
      * ucp_ep_flush_error, by the synchronous-OK decrement, or by the pending
      * uct completion that will be delivered via the discard flow. */
-    if (ucs_unlikely(ep_live_lanes != req->send.flush.all_lanes)) {
-        ep_destroyed_lanes = req->send.flush.all_lanes & ~ep_live_lanes &
-                             ~req->send.flush.started_lanes;
-        ep_new_lanes       = ep_live_lanes & ~req->send.flush.all_lanes;
-        ucp_ep_flush_request_update_uct_comp(req,
-                                             ucs_popcount(ep_new_lanes) -
-                                             ucs_popcount(ep_destroyed_lanes),
-                                             0);
-        req->send.flush.all_lanes = ep_live_lanes;
+    lane_generation_changed =
+            req->send.flush.lanes.lane_generation != ep->ext->lane_generation;
+    if (ucs_unlikely(lane_generation_changed ||
+                     (ep_live_lanes != req->send.flush.all_lanes))) {
+        ucp_ep_flush_request_update_uct_comp(
+                req,
+                ucp_ep_flush_lane_state_update(
+                        ep_live_lanes, lane_generation_changed,
+                        &req->send.flush.started_lanes,
+                        &req->send.flush.all_lanes,
+                        &req->send.flush.lanes.lane_mask),
+                0);
+        req->send.flush.lanes.lane_generation = ep->ext->lane_generation;
     }
 
     ucp_trace_req(req,
@@ -110,6 +113,13 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
 
         /* Search for next lane to start flush */
         lane   = ucs_ffs64(next_lanes);
+
+        /* Skip lanes that were not requested by this flush. */
+        if (!(req->send.flush.lanes.lane_mask & UCS_BIT(lane))) {
+            ucp_ep_flush_request_update_uct_comp(req, -1, UCS_BIT(lane));
+            continue;
+        }
+
         uct_ep = ucp_ep_get_lane(ep, lane);
         if (uct_ep == NULL) {
             ucp_ep_flush_request_update_uct_comp(req, -1, UCS_BIT(lane));
@@ -370,7 +380,8 @@ ucs_status_t ucp_ep_flush_progress_pending(uct_pending_req_t *self)
     /* If the operation has not completed, and not started on all alive lanes,
      * add slow-path progress to resume */
     if (!completed &&
-        (req->send.flush.started_lanes != req->send.flush.all_lanes)) {
+        ucp_ep_flush_has_unstarted_lanes(req->send.flush.all_lanes,
+                                         req->send.flush.started_lanes)) {
         ucp_ep_flush_request_resched(ep, req);
     }
 
@@ -397,6 +408,8 @@ static void ucp_ep_flush_request_reset(ucp_request_t *req)
     req->send.flush.all_lanes       = lanes;
     req->send.flush.started_lanes   = 0;
     req->send.flush.uct_flags       = req->send.flush.uct_flags_orig;
+    req->send.flush.lanes.lane_generation =
+            req->send.ep->ext->lane_generation;
     req->send.flush.sw_started      = 0;
     req->send.flush.sw_done         = 0;
 }
@@ -404,8 +417,15 @@ static void ucp_ep_flush_request_reset(ucp_request_t *req)
 static unsigned ucp_ep_flush_failover_oneshot_cb(void *arg)
 {
     ucp_request_t *req = arg;
+    int lane_generation_changed;
 
     ucp_trace_req(req, "flush restart");
+    lane_generation_changed = req->send.flush.lanes.lane_generation !=
+                              req->send.ep->ext->lane_generation;
+    (void)ucp_ep_flush_lane_state_update(
+            ucp_ep_get_live_lanes(req->send.ep), lane_generation_changed,
+            &req->send.flush.started_lanes, &req->send.flush.all_lanes,
+            &req->send.flush.lanes.lane_mask);
     ucp_ep_flush_request_reset(req);
     ucp_ep_flush_progress(req);
     ucp_flush_check_completion(req);
@@ -486,12 +506,13 @@ void ucp_ep_flush_remote_completed(ucp_request_t *req)
     }
 }
 
-ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned req_flags,
-                                       const ucp_request_param_t *param,
-                                       ucp_request_t *worker_req,
-                                       ucp_request_callback_t flushed_cb,
-                                       const char *debug_name,
-                                       unsigned uct_flags)
+ucs_status_ptr_t
+ucp_ep_flush_lanes_internal(ucp_ep_h ep, unsigned req_flags,
+                            const ucp_request_param_t *param,
+                            ucp_request_t *worker_req,
+                            ucp_request_callback_t flushed_cb,
+                            const char *debug_name, unsigned uct_flags,
+                            ucp_lane_map_t lane_mask)
 {
     ucs_status_t status;
     ucp_request_t *req;
@@ -516,6 +537,7 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned req_flags,
     req->send.flushed_cb           = flushed_cb;
     req->send.flush.uct_flags      =
     req->send.flush.uct_flags_orig = uct_flags;
+    req->send.flush.lanes.lane_mask = lane_mask;
     req->send.uct.func             = ucp_ep_flush_progress_pending;
     req->send.state.uct_comp.func  = ucp_ep_flush_completion;
 
@@ -536,6 +558,18 @@ ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned req_flags,
 
     ucp_trace_req(req, "return inprogress flush ep %p request %p", ep, req + 1);
     return req + 1;
+}
+
+ucs_status_ptr_t ucp_ep_flush_internal(ucp_ep_h ep, unsigned req_flags,
+                                       const ucp_request_param_t *param,
+                                       ucp_request_t *worker_req,
+                                       ucp_request_callback_t flushed_cb,
+                                       const char *debug_name,
+                                       unsigned uct_flags)
+{
+    return ucp_ep_flush_lanes_internal(ep, req_flags, param, worker_req,
+                                       flushed_cb, debug_name, uct_flags,
+                                       (ucp_lane_map_t)-1);
 }
 
 static void ucp_ep_flushed_callback(ucp_request_t *req)

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -15,6 +15,7 @@
 #include "rma.inl"
 
 static unsigned ucp_ep_flush_resume_slow_path_callback(void *arg);
+static void ucp_ep_flush_request_resched(ucp_ep_h ep, ucp_request_t *req);
 
 static void
 ucp_ep_flush_request_update_uct_comp(ucp_request_t *req, int diff,
@@ -69,7 +70,29 @@ static int ucp_ep_flush_is_completed(ucp_request_t *req)
     return (req->send.state.uct_comp.count == 0) && req->send.flush.sw_done;
 }
 
-static void ucp_ep_flush_progress(ucp_request_t *req)
+static UCS_F_ALWAYS_INLINE int
+ucp_ep_fence_pending_is_clear(ucp_ep_h ep, uint64_t fence_seq_th)
+{
+    ucp_request_t *head_req;
+
+    if ((ep->ext->fence_inflight_req != NULL) &&
+        (ep->ext->fence_inflight_req->send.flush.fence_seq <= fence_seq_th)) {
+        return 0;
+    }
+
+    if (!ucs_queue_is_empty(&ep->ext->fence_pending_q)) {
+        head_req = ucs_queue_head_elem_non_empty(&ep->ext->fence_pending_q,
+                                                 ucp_request_t,
+                                                 send.fence_pending_elem);
+        if (head_req->send.fence_seq <= fence_seq_th) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+static int ucp_ep_flush_progress(ucp_request_t *req)
 {
     ucp_ep_h ep                  = req->send.ep;
     ucp_lane_map_t ep_live_lanes = ucp_ep_get_live_lanes(ep);
@@ -108,6 +131,17 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
                   " count=%d",
                   ep, ep->flags, req->send.flush.started_lanes,
                   req->send.state.uct_comp.count);
+
+    /* A normal flush covers deferred work which existed when it started. A
+     * fence's own flush cannot wait for the request that triggered it. */
+    if (ucs_unlikely((req->send.flush.fence_seq > 0) &&
+                     !(req->send.flush.uct_flags & UCT_FLUSH_FLAG_CANCEL) &&
+                     (req != ep->ext->fence_inflight_req) &&
+                     !ucp_ep_fence_pending_is_clear(
+                             ep, req->send.flush.fence_seq))) {
+        ucp_ep_flush_request_resched(ep, req);
+        return 1;
+    }
 
     while ((next_lanes = ep_live_lanes & ~req->send.flush.started_lanes) != 0) {
 
@@ -196,6 +230,8 @@ static void ucp_ep_flush_progress(ucp_request_t *req)
 
         req->send.flush.sw_started = 1;
     }
+
+    return 0;
 }
 
 static int
@@ -348,6 +384,7 @@ ucs_status_t ucp_ep_flush_progress_pending(uct_pending_req_t *self)
     ucp_ep_h ep           = req->send.ep;
     ucs_status_t status;
     int completed;
+    int rescheduled;
 
     ucs_assert(!(req->flags & UCP_REQUEST_FLAG_COMPLETED));
 
@@ -374,12 +411,12 @@ ucs_status_t ucp_ep_flush_progress_pending(uct_pending_req_t *self)
     /* since req->flush.pend.lane is still non-NULL, this function will not
      * put anything on pending.
      */
-    ucp_ep_flush_progress(req);
-    completed = ucp_flush_check_completion(req);
+    rescheduled = ucp_ep_flush_progress(req);
+    completed   = ucp_flush_check_completion(req);
 
     /* If the operation has not completed, and not started on all alive lanes,
      * add slow-path progress to resume */
-    if (!completed &&
+    if (!completed && !rescheduled &&
         ucp_ep_flush_has_unstarted_lanes(req->send.flush.all_lanes,
                                          req->send.flush.started_lanes)) {
         ucp_ep_flush_request_resched(ep, req);
@@ -538,8 +575,9 @@ ucp_ep_flush_lanes_internal(ucp_ep_h ep, unsigned req_flags,
     req->send.flush.uct_flags      =
     req->send.flush.uct_flags_orig = uct_flags;
     req->send.flush.lanes.lane_mask = lane_mask;
-    req->send.uct.func             = ucp_ep_flush_progress_pending;
-    req->send.state.uct_comp.func  = ucp_ep_flush_completion;
+    req->send.flush.fence_seq      = ep->worker->fence_seq;
+    req->send.uct.func              = ucp_ep_flush_progress_pending;
+    req->send.state.uct_comp.func   = ucp_ep_flush_completion;
 
     ucp_request_set_super(req, worker_req);
     ucp_request_set_send_callback_param(param, req, send);
@@ -693,6 +731,20 @@ static void ucp_worker_flush_ep_flushed_cb(ucp_request_t *req)
     ucp_request_put(req);
 }
 
+static int ucp_worker_fence_pending_check(ucp_worker_h worker,
+                                          uint64_t fence_seq_th)
+{
+    ucp_ep_ext_t *ep_ext;
+
+    ucs_list_for_each(ep_ext, &worker->all_eps, ep_list) {
+        if (!ucp_ep_fence_pending_is_clear(ep_ext->ep, fence_seq_th)) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
 /* Drive the worker flush state machine one step. Returns the number of
  * completed operations in this invocation (0 means no work was done;
  * non-zero advertises progress to the UCT worker progress engine). */
@@ -712,6 +764,10 @@ static unsigned ucp_worker_flush_progress(void *arg)
             /* If all ifaces are flushed, or we finished going over all
              * endpoints, no need to progress this request actively anymore
              * and we complete the flush operation with UCS_OK status. */
+            if (!ucp_worker_fence_pending_check(
+                        worker, req->flush_worker.fence_seq_th)) {
+                return 0;
+            }
             ucp_worker_flush_complete_one(req, UCS_OK, 1);
             return 1;
         } else if (status != UCS_INPROGRESS) {
@@ -769,20 +825,24 @@ ucp_worker_flush_nbx_internal(ucp_worker_h worker,
         status = ucp_worker_flush_check(worker);
         if ((status != UCS_INPROGRESS) && (status != UCS_ERR_NO_RESOURCE)) {
             /* UCS_OK is returned here as well */
-            return UCS_STATUS_PTR(status);
+            if ((status != UCS_OK) ||
+                ucp_worker_fence_pending_check(worker, worker->fence_seq)) {
+                return UCS_STATUS_PTR(status);
+            }
         }
     }
 
     req = ucp_request_get_param(worker, param,
                                 {return UCS_STATUS_PTR(UCS_ERR_NO_MEMORY);});
 
-    req->flags                   = 0;
-    req->status                  = UCS_OK;
-    req->flush_worker.worker     = worker;
-    req->flush_worker.comp_count = 1; /* counting starts from 1, and decremented
+    req->flags                     = 0;
+    req->status                    = UCS_OK;
+    req->flush_worker.worker       = worker;
+    req->flush_worker.fence_seq_th = worker->fence_seq;
+    req->flush_worker.comp_count   = 1; /* counting starts from 1, and decremented
                                          when finished going over all endpoints */
-    req->flush_worker.uct_flags  = uct_flags;
-    req->flush_worker.prog_id    = UCS_CALLBACKQ_ID_NULL;
+    req->flush_worker.uct_flags    = uct_flags;
+    req->flush_worker.prog_id      = UCS_CALLBACKQ_ID_NULL;
 
     ucp_worker_flush_req_set_next_ep(req, 0, worker->all_eps.next);
     ucp_request_set_send_callback_param(param, req, flush_worker);

--- a/src/ucp/rma/flush.c
+++ b/src/ucp/rma/flush.c
@@ -930,16 +930,21 @@ ucs_status_t ucp_ep_fence_strong(ucp_ep_h ep)
                 "ep=%p unflushed_lanes=0x%" PRIx64, ep,
                 ep->ext->unflushed_lanes);
 
-    request = ucp_ep_flush_internal(ep, 0, &ucp_request_null_param, NULL,
-                                    ucp_ep_flushed_callback, "ep_fence_strong",
-                                    UCT_FLUSH_FLAG_REMOTE);
+    ucp_ep_fence_normalize_lanes(ep);
+
+    request = ucp_ep_flush_lanes_internal(ep, 0, &ucp_request_null_param, NULL,
+                                          ucp_ep_flushed_callback,
+                                          "ep_fence_strong",
+                                          UCT_FLUSH_FLAG_REMOTE,
+                                          ep->ext->unflushed_lanes);
     status  = ucp_flush_wait(ep->worker, request);
     if (status != UCS_OK) {
         return status;
     }
 
-    ep->ext->unflushed_lanes = 0;
-    ep->ext->fence_seq       = ep->worker->fence_seq;
+    ep->ext->unflushed_lanes   = 0;
+    ep->ext->fence_seq         = ep->worker->fence_seq;
+    ep->ext->fence_lanes_dirty = 0;
     return UCS_OK;
 }
 
@@ -955,8 +960,9 @@ static void ucp_ep_fence_strong_nb_flushed_cb(ucp_request_t *req)
     ep->ext->fence_status       = status;
 
     if (ucs_likely(status == UCS_OK)) {
-        ep->ext->unflushed_lanes = 0;
-        ep->ext->fence_seq       = req->send.flush.fence_seq;
+        ep->ext->unflushed_lanes   = 0;
+        ep->ext->fence_seq         = req->send.flush.fence_seq;
+        ep->ext->fence_lanes_dirty = 0;
     } else {
         ucp_ep_fence_pending_purge(ep, status);
     }
@@ -978,6 +984,8 @@ ucs_status_t ucp_ep_fence_strong_nb(ucp_ep_h ep, uint64_t fence_seq)
         return UCS_OK;
     }
 
+    ucp_ep_fence_normalize_lanes(ep);
+
     ep->ext->fence_status = UCS_INPROGRESS;
     ucp_ep_refcount_add(ep, flush);
 
@@ -997,10 +1005,11 @@ ucs_status_t ucp_ep_fence_strong_nb(ucp_ep_h ep, uint64_t fence_seq)
     if (ucs_unlikely(request == NULL)) {
         int ep_destroyed;
 
-        ep->ext->unflushed_lanes = 0;
-        ep->ext->fence_seq       = fence_seq;
-        ep->ext->fence_status    = UCS_OK;
-        ep_destroyed             = ucp_ep_refcount_remove(ep, flush);
+        ep->ext->unflushed_lanes   = 0;
+        ep->ext->fence_seq         = fence_seq;
+        ep->ext->fence_status      = UCS_OK;
+        ep->ext->fence_lanes_dirty = 0;
+        ep_destroyed               = ucp_ep_refcount_remove(ep, flush);
         if (!ep_destroyed) {
             ucp_ep_fence_pending_resume(ep);
         }

--- a/src/ucp/rma/get_am.c
+++ b/src/ucp/rma/get_am.c
@@ -48,6 +48,11 @@ static ucs_status_t ucp_proto_get_am_bcopy_progress(uct_pending_req_t *self)
     ucs_status_t status;
 
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
+        if (!ucp_proto_rma_fence_progress(
+                    req, UCS_BIT(spriv->super.lane), &status)) {
+            return status;
+        }
+
         status = ucp_ep_resolve_remote_id(ep, spriv->super.lane);
         if (status != UCS_OK) {
             return status;
@@ -57,14 +62,8 @@ static ucs_status_t ucp_proto_get_am_bcopy_progress(uct_pending_req_t *self)
          * processing */
         req->send.buffer = req->send.state.dt_iter.type.contig.buffer;
         req->send.length = req->send.state.dt_iter.length;
-        req->flags      |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
         ucp_send_request_id_alloc(req);
-
-        status = ucp_ep_rma_handle_fence(ep, req, UCS_BIT(spriv->super.lane));
-        if (status != UCS_OK) {
-            ucp_proto_request_abort(req, status);
-            return UCS_OK;
-        }
+        req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
     }
 
     ucp_worker_flush_ops_count_add(worker, +1);

--- a/src/ucp/rma/get_offload.c
+++ b/src/ucp/rma/get_offload.c
@@ -65,10 +65,8 @@ static ucs_status_t ucp_proto_get_offload_bcopy_progress(uct_pending_req_t *self
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
         ucp_proto_multi_request_init(req);
 
-        status = ucp_ep_rma_handle_fence(req->send.ep, req, mpriv->lane_map);
-        if (status != UCS_OK) {
-            ucp_proto_request_abort(req, status);
-            return UCS_OK;
+        if (!ucp_proto_rma_fence_progress(req, mpriv->lane_map, &status)) {
+            return status;
         }
 
         ucp_proto_completion_init(&req->send.state.uct_comp,
@@ -184,11 +182,18 @@ ucp_proto_get_offload_zcopy_send_func(ucp_request_t *req,
 static ucs_status_t ucp_proto_get_offload_zcopy_progress(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
-
     /* coverity[tainted_data_downcast] */
+    const ucp_proto_multi_priv_t *mpriv = req->send.proto_config->priv;
+    ucs_status_t status;
+
+    if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED) &&
+        !ucp_proto_rma_fence_progress(req, mpriv->lane_map, &status)) {
+        return status;
+    }
+
     return ucp_proto_multi_zcopy_progress(
-            req, req->send.proto_config->priv, ucp_proto_multi_rma_init_func,
-            UCT_MD_MEM_ACCESS_LOCAL_WRITE, UCP_DT_MASK_CONTIG_IOV,
+            req, mpriv, NULL, UCT_MD_MEM_ACCESS_LOCAL_WRITE,
+            UCP_DT_MASK_CONTIG_IOV,
             ucp_proto_get_offload_zcopy_send_func,
             ucp_request_invoke_uct_completion_success,
             ucp_proto_request_zcopy_completion);

--- a/src/ucp/rma/put_am.c
+++ b/src/ucp/rma/put_am.c
@@ -57,18 +57,15 @@ static ucs_status_t ucp_proto_put_am_bcopy_progress(uct_pending_req_t *self)
     ucs_status_t status;
 
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
+        ucp_proto_multi_request_init(req);
+        if (!ucp_proto_rma_fence_progress(req, mpriv->lane_map, &status)) {
+            return status;
+        }
+
         status = ucp_ep_resolve_remote_id(req->send.ep,
                                           mpriv->lanes[0].super.lane);
         if (status != UCS_OK) {
             return status;
-        }
-
-        ucp_proto_multi_request_init(req);
-
-        status = ucp_ep_rma_handle_fence(req->send.ep, req, mpriv->lane_map);
-        if (status != UCS_OK) {
-            ucp_proto_request_abort(req, status);
-            return UCS_OK;
         }
 
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;

--- a/src/ucp/rma/put_offload.c
+++ b/src/ucp/rma/put_offload.c
@@ -27,10 +27,9 @@ static ucs_status_t ucp_proto_put_offload_short_progress(uct_pending_req_t *self
     uct_rkey_t tl_rkey;
 
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
-        status = ucp_ep_rma_handle_fence(ep, req, UCS_BIT(spriv->super.lane));
-        if (status != UCS_OK) {
-            ucp_proto_request_abort(req, status);
-            return UCS_OK;
+        if (!ucp_proto_rma_fence_progress(
+                    req, UCS_BIT(spriv->super.lane), &status)) {
+            return status;
         }
 
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
@@ -174,10 +173,8 @@ static ucs_status_t ucp_proto_put_offload_bcopy_progress(uct_pending_req_t *self
     if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED)) {
         ucp_proto_multi_request_init(req);
 
-        status = ucp_ep_rma_handle_fence(req->send.ep, req, mpriv->lane_map);
-        if (status != UCS_OK) {
-            ucp_proto_request_abort(req, status);
-            return UCS_OK;
+        if (!ucp_proto_rma_fence_progress(req, mpriv->lane_map, &status)) {
+            return status;
         }
 
         req->flags |= UCP_REQUEST_FLAG_PROTO_INITIALIZED;
@@ -277,11 +274,18 @@ static ucs_status_t
 ucp_proto_put_offload_zcopy_progress(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
-
     /* coverity[tainted_data_downcast] */
+    const ucp_proto_multi_priv_t *mpriv = req->send.proto_config->priv;
+    ucs_status_t status;
+
+    if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED) &&
+        !ucp_proto_rma_fence_progress(req, mpriv->lane_map, &status)) {
+        return status;
+    }
+
     return ucp_proto_multi_zcopy_progress(
-            req, req->send.proto_config->priv, ucp_proto_multi_rma_init_func,
-            UCT_MD_MEM_ACCESS_LOCAL_READ, UCP_DT_MASK_CONTIG_IOV,
+            req, mpriv, NULL, UCT_MD_MEM_ACCESS_LOCAL_READ,
+            UCP_DT_MASK_CONTIG_IOV,
             ucp_proto_put_offload_zcopy_send_func,
             ucp_request_invoke_uct_completion_success,
             ucp_proto_request_zcopy_completion);
@@ -512,11 +516,18 @@ static ucs_status_t
 ucp_proto_put_sgl_offload_progress(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
-
     /* coverity[tainted_data_downcast] */
+    const ucp_proto_multi_priv_t *mpriv = req->send.proto_config->priv;
+    ucs_status_t status;
+
+    if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED) &&
+        !ucp_proto_rma_fence_progress(req, mpriv->lane_map, &status)) {
+        return status;
+    }
+
     return ucp_proto_multi_zcopy_progress(
-            req, req->send.proto_config->priv, ucp_proto_multi_rma_init_func,
-            UCT_MD_MEM_ACCESS_LOCAL_READ, UCS_BIT(UCP_DATATYPE_SGL),
+            req, mpriv, NULL, UCT_MD_MEM_ACCESS_LOCAL_READ,
+            UCS_BIT(UCP_DATATYPE_SGL),
             ucp_proto_put_sgl_offload_send_func,
             ucp_request_invoke_uct_completion_success,
             ucp_proto_request_zcopy_completion);
@@ -603,11 +614,18 @@ static ucs_status_t
 ucp_proto_put_sgl_offload_sw_progress(uct_pending_req_t *self)
 {
     ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
-
     /* coverity[tainted_data_downcast] */
+    const ucp_proto_multi_priv_t *mpriv = req->send.proto_config->priv;
+    ucs_status_t status;
+
+    if (!(req->flags & UCP_REQUEST_FLAG_PROTO_INITIALIZED) &&
+        !ucp_proto_rma_fence_progress(req, mpriv->lane_map, &status)) {
+        return status;
+    }
+
     return ucp_proto_multi_zcopy_progress(
-            req, req->send.proto_config->priv, ucp_proto_multi_rma_init_func,
-            UCT_MD_MEM_ACCESS_LOCAL_READ, UCS_BIT(UCP_DATATYPE_SGL),
+            req, mpriv, NULL, UCT_MD_MEM_ACCESS_LOCAL_READ,
+            UCS_BIT(UCP_DATATYPE_SGL),
             ucp_proto_put_sgl_offload_sw_send_func,
             ucp_request_invoke_uct_completion_success,
             ucp_proto_request_zcopy_completion);

--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -27,6 +27,38 @@
 #define UCP_PROTO_RMA_MAX_BCOPY_LANES 1
 
 /**
+ * Reconcile lanes carrying pre-fence operations with the endpoint's current
+ * live lanes. If a recorded lane disappeared, its replacement cannot be
+ * identified by lane index alone, so conservatively flush every live lane.
+ */
+static UCS_F_ALWAYS_INLINE ucp_lane_map_t
+ucp_ep_fence_lane_map_update(ucp_lane_map_t unflushed_lanes,
+                             ucp_lane_map_t live_lanes)
+{
+    if (unflushed_lanes & ~live_lanes) {
+        return live_lanes;
+    }
+
+    return unflushed_lanes;
+}
+
+/**
+ * Normalize fence lane tracking after the endpoint topology changed. A dirty
+ * topology expands tracked work to every live lane because a replacement may
+ * reuse the same lane index.
+ */
+static UCS_F_ALWAYS_INLINE ucp_lane_map_t
+ucp_ep_fence_lane_map_normalize(ucp_lane_map_t unflushed_lanes,
+                                ucp_lane_map_t live_lanes, int lanes_dirty)
+{
+    if ((unflushed_lanes != 0) && lanes_dirty) {
+        return live_lanes;
+    }
+
+    return ucp_ep_fence_lane_map_update(unflushed_lanes, live_lanes);
+}
+
+/**
  * Update an in-progress flush after the endpoint's live lanes changed.
  *
  * Lanes that disappeared before their flush started no longer need a

--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -26,6 +26,59 @@
  */
 #define UCP_PROTO_RMA_MAX_BCOPY_LANES 1
 
+/**
+ * Update an in-progress flush after the endpoint's live lanes changed.
+ *
+ * Lanes that disappeared before their flush started no longer need a
+ * completion. Lanes already started remain accounted for by their completion
+ * or discard flow. Newly created lanes need a completion and are added to the
+ * requested lane mask.
+ *
+ * If the lane generation changed without changing the live lane map, a
+ * transport endpoint was replaced at the same lane index. Preserve already
+ * started completions and restart the current live lanes.
+ *
+ * @return Change to apply to the flush completion count.
+ */
+static UCS_F_ALWAYS_INLINE int
+ucp_ep_flush_lane_state_update(ucp_lane_map_t live_lanes,
+                               int lane_generation_changed,
+                               ucp_lane_map_t *started_lanes_p,
+                               ucp_lane_map_t *all_lanes_p,
+                               ucp_lane_map_t *lane_mask_p)
+{
+    ucp_lane_map_t unstarted_lanes;
+    ucp_lane_map_t destroyed_lanes;
+    ucp_lane_map_t new_lanes;
+
+    if (lane_generation_changed) {
+        unstarted_lanes  = *all_lanes_p & ~*started_lanes_p;
+        *all_lanes_p     = live_lanes;
+        *lane_mask_p    |= live_lanes;
+        *started_lanes_p = 0;
+        return ucs_popcount(live_lanes) - ucs_popcount(unstarted_lanes);
+    }
+
+    destroyed_lanes = *all_lanes_p & ~live_lanes & ~*started_lanes_p;
+    new_lanes       = live_lanes & ~*all_lanes_p;
+
+    *all_lanes_p = live_lanes;
+    *lane_mask_p |= new_lanes;
+
+    return ucs_popcount(new_lanes) - ucs_popcount(destroyed_lanes);
+}
+
+/**
+ * Return whether an in-progress flush has not started on every live lane.
+ * Historical started bits for lanes destroyed after starting are ignored.
+ */
+static UCS_F_ALWAYS_INLINE int
+ucp_ep_flush_has_unstarted_lanes(ucp_lane_map_t live_lanes,
+                                 ucp_lane_map_t started_lanes)
+{
+    return !!(live_lanes & ~started_lanes);
+}
+
 
 /**
  * Defines functions for AMO protocol

--- a/src/ucp/rma/rma.h
+++ b/src/ucp/rma/rma.h
@@ -147,4 +147,6 @@ ucs_status_t ucp_ep_fence_weak(ucp_ep_h ep);
 
 ucs_status_t ucp_ep_fence_strong(ucp_ep_h ep);
 
+ucs_status_t ucp_ep_fence_strong_nb(ucp_ep_h ep, uint64_t fence_seq);
+
 #endif

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -160,11 +160,22 @@ ucp_ep_rma_get_fence_flag(ucp_ep_h ep)
     return 0;
 }
 
+static UCS_F_ALWAYS_INLINE void
+ucp_ep_fence_normalize_lanes(ucp_ep_h ep)
+{
+    ep->ext->unflushed_lanes = ucp_ep_fence_lane_map_normalize(
+            ep->ext->unflushed_lanes, ucp_ep_get_live_lanes(ep),
+            ep->ext->fence_lanes_dirty);
+    ep->ext->fence_lanes_dirty = 0;
+}
+
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_ep_rma_handle_fence(ucp_ep_h ep, ucp_request_t *req,
                         ucp_lane_map_t lane_map)
 {
     ucs_status_t status;
+
+    ucp_ep_fence_normalize_lanes(ep);
 
     /* Apply a fence if EP's sequence is behind worker's */
     if (ucs_unlikely(req->flags & UCP_REQUEST_FLAG_FENCE_REQUIRED)) {

--- a/src/ucp/rma/rma.inl
+++ b/src/ucp/rma/rma.inl
@@ -11,6 +11,7 @@
 
 #include <ucp/api/ucp.h>
 #include <ucp/core/ucp_request.inl>
+#include <ucp/proto/proto_common.h>
 #include <ucs/debug/log.h>
 
 
@@ -169,32 +170,111 @@ ucp_ep_fence_normalize_lanes(ucp_ep_h ep)
     ep->ext->fence_lanes_dirty = 0;
 }
 
+/**
+ * Admit an RMA/atomic request after its fence dependency is satisfied.
+ */
+static UCS_F_ALWAYS_INLINE void
+ucp_ep_fence_admit_request(ucp_ep_h ep, ucp_request_t *req,
+                           ucp_lane_map_t lane_map)
+{
+    req->flags &= ~UCP_REQUEST_FLAG_FENCE_REQUIRED;
+    ucp_ep_fence_normalize_lanes(ep);
+    ep->ext->unflushed_lanes |= lane_map;
+}
+
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_ep_rma_handle_fence(ucp_ep_h ep, ucp_request_t *req,
                         ucp_lane_map_t lane_map)
 {
     ucs_status_t status;
+    uint64_t fence_seq;
 
     ucp_ep_fence_normalize_lanes(ep);
 
-    /* Apply a fence if EP's sequence is behind worker's */
-    if (ucs_unlikely(req->flags & UCP_REQUEST_FLAG_FENCE_REQUIRED)) {
-        if (ucs_unlikely(ep->ext->unflushed_lanes == 0)) {
-            status = UCS_OK;
-        } else if (ucs_likely(
-            ucs_is_pow2_or_zero(ep->ext->unflushed_lanes | lane_map))) {
-            status = ucp_ep_fence_weak(ep);
-        } else {
-            status = ucp_ep_fence_strong(ep);
-        }
-    } else {
-        status = UCS_OK;
+    if (ucs_likely(!(req->flags & UCP_REQUEST_FLAG_FENCE_REQUIRED))) {
+        ep->ext->unflushed_lanes |= lane_map;
+        return UCS_OK;
     }
 
-    /* Re-set the lanes of the current operation for future fences */
-    ep->ext->unflushed_lanes |= lane_map;
+    ucs_assert(req->send.fence_seq > 0);
+    fence_seq = req->send.fence_seq;
 
-    return status;
+    if (ep->ext->fence_seq >= fence_seq) {
+        ucp_ep_fence_admit_request(ep, req, lane_map);
+        return UCS_OK;
+    }
+
+    if (ucs_unlikely(ep->ext->unflushed_lanes == 0)) {
+        ep->ext->fence_seq = fence_seq;
+        ucp_ep_fence_admit_request(ep, req, lane_map);
+        return UCS_OK;
+    }
+
+    if (ucs_likely(ucs_is_pow2(ep->ext->unflushed_lanes) &&
+                   ((lane_map & ep->ext->unflushed_lanes) == lane_map))) {
+        status = ucp_ep_fence_weak(ep);
+        if (ucs_likely(status == UCS_OK)) {
+            ep->ext->unflushed_lanes = 0;
+            ep->ext->fence_seq       = fence_seq;
+            ucp_ep_fence_admit_request(ep, req, lane_map);
+            return UCS_OK;
+        }
+        return status;
+    }
+
+    if (ep->ext->fence_inflight_req == NULL) {
+        status = ucp_ep_fence_strong_nb(ep, fence_seq);
+        if (ucs_unlikely(status != UCS_OK)) {
+            return status;
+        }
+
+        if (ep->ext->fence_inflight_req == NULL) {
+            status = ep->ext->fence_status;
+            if (ucs_unlikely(status != UCS_OK)) {
+                return status;
+            }
+
+            ucs_assert(ep->ext->fence_seq >= fence_seq);
+            ucp_ep_fence_admit_request(ep, req, lane_map);
+            return UCS_OK;
+        }
+    }
+
+    req->flags |= UCP_REQUEST_FLAG_FENCE_BLOCKED;
+    return UCP_STATUS_FENCE_DEFER;
+}
+
+/**
+ * Perform fence admission before protocol initialization can add the request
+ * to a UCT pending queue.
+ */
+static UCS_F_ALWAYS_INLINE int
+ucp_proto_rma_fence_progress(ucp_request_t *req, ucp_lane_map_t lane_map,
+                             ucs_status_t *status_p)
+{
+    ucs_status_t status;
+
+    status = ucp_ep_rma_handle_fence(req->send.ep, req, lane_map);
+    if (status == UCP_STATUS_FENCE_DEFER) {
+        if (req->send.pending_lane != UCP_NULL_LANE) {
+            ucp_ep_fence_pending_add(req->send.ep, &req->send.uct);
+            req->send.pending_lane = UCP_NULL_LANE;
+            *status_p              = UCS_OK;
+        } else {
+            *status_p = status;
+        }
+        return 0;
+    } else if (status == UCS_ERR_NO_RESOURCE) {
+        *status_p = status;
+        return 0;
+    } else if (status != UCS_OK) {
+        ucp_proto_request_abort(req, status);
+        *status_p = UCS_OK;
+        return 0;
+    }
+
+    *status_p = UCS_OK;
+    return 1;
 }
 
 #endif

--- a/src/ucp/rma/rma_rndv.c
+++ b/src/ucp/rma/rma_rndv.c
@@ -36,6 +36,12 @@ ucp_proto_rma_rndv_probe_check(const ucp_proto_init_params_t *init_params,
     const ucp_proto_select_param_t *sel_param = init_params->select_param;
     const ucp_context_h context               = init_params->worker->context;
 
+    /* RMA rendezvous needs separate remote-operation accounting before it can
+     * participate safely in endpoint-based fence ordering. */
+    if (context->config.worker_fence_mode == UCP_FENCE_MODE_EP_BASED) {
+        return 0;
+    }
+
     /* TODO: We prefer to use direct zcopy when possible, remove this check when
      * prioritization of protocols is implemented. */
     if (!context->config.ext.rma_ppln_enable &&

--- a/src/ucp/rma/rma_send.c
+++ b/src/ucp/rma/rma_send.c
@@ -183,6 +183,7 @@ ucp_put_send_short(ucp_ep_h ep, const void *buffer, size_t length,
                                                    rkey_config->put_short.lane),
                               buffer, length, remote_addr, tl_rkey);
     if (status == UCS_OK) {
+        ucp_ep_fence_normalize_lanes(ep);
         ep->ext->unflushed_lanes |= UCS_BIT(rkey_config->put_short.lane);
     }
 

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -50,7 +50,7 @@ UCS_TEST_F(test_obj_size, size) {
     UCS_TEST_SKIP_R("Assert enabled");
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
-    EXPECTED_SIZE(ucp_ep_ext_t, 216);
+    EXPECTED_SIZE(ucp_ep_ext_t, 224);
 #if ENABLE_PARAMS_CHECK
     EXPECTED_SIZE(ucp_rkey_t, 24 + sizeof(ucp_ep_h));
 #else

--- a/test/gtest/common/test_obj_size.cc
+++ b/test/gtest/common/test_obj_size.cc
@@ -50,14 +50,14 @@ UCS_TEST_F(test_obj_size, size) {
     UCS_TEST_SKIP_R("Assert enabled");
 #else
     EXPECTED_SIZE(ucp_ep_t, 64);
-    EXPECTED_SIZE(ucp_ep_ext_t, 224);
+    EXPECTED_SIZE(ucp_ep_ext_t, 256);
 #if ENABLE_PARAMS_CHECK
     EXPECTED_SIZE(ucp_rkey_t, 24 + sizeof(ucp_ep_h));
 #else
     EXPECTED_SIZE(ucp_rkey_t, 24);
 #endif
     /* TODO reduce request size to 240 or less after removing old protocols state */
-    EXPECTED_SIZE(ucp_request_t, 272);
+    EXPECTED_SIZE(ucp_request_t, 280);
     EXPECTED_SIZE(ucp_recv_desc_t, 48);
     EXPECTED_SIZE(ucp_mem_t, 160);
     EXPECTED_SIZE(uct_ep_t, 8);

--- a/test/gtest/ucp/test_ucp_fence.cc
+++ b/test/gtest/ucp/test_ucp_fence.cc
@@ -106,6 +106,23 @@ static void test_flush_completion(ucp_request_t *req)
     ucp_request_complete_send(req, req->status);
 }
 
+static int test_fence_count_oneshot(const ucs_callbackq_elem_t *, void *arg)
+{
+    ++*static_cast<unsigned*>(arg);
+    return 0;
+}
+
+static ucs_status_t test_fence_defer_once(uct_pending_req_t *self)
+{
+    ucp_request_t *req = ucs_container_of(self, ucp_request_t, send.uct);
+
+    if (req->send.state.completed_size++ == 0) {
+        return UCP_STATUS_FENCE_DEFER;
+    }
+
+    return UCS_OK;
+}
+
 
 class test_ucp_fence : public ucp_test {
 public:
@@ -454,6 +471,183 @@ UCS_TEST_P(test_ucp_fence32, slow_lane_storage_initialization)
 
     ucp_ep_delete(ep);
     UCS_ASYNC_UNBLOCK(&worker->async);
+}
+
+UCS_TEST_P(test_ucp_fence32, async_fence_tracks_inflight_flush)
+{
+    ucp_request_t blocked_req = {};
+    unsigned ep_refcount;
+    uint64_t prev_fence_seq;
+    uint64_t fence_seq;
+    uct_iface_h iface;
+    uct_ep_flush_func_t flush_func;
+    ucp_ep_h ep;
+
+    if (!is_self()) {
+        UCS_TEST_SKIP_R("Direct flush interception requires self transport");
+    }
+
+    sender().connect(&receiver(), get_ep_params());
+    ep                    = sender().ep();
+    iface                 = ucp_ep_get_lane(ep, 0)->iface;
+    flush_func            = iface->ops.ep_flush;
+    fence_seq             = ep->ext->fence_seq + 1;
+    ep->ext->unflushed_lanes = UCS_BIT(0);
+    test_flush_call_count = 0;
+    test_flush_comp       = NULL;
+    iface->ops.ep_flush   = test_flush_inprogress;
+
+    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
+    EXPECT_UCS_OK(ucp_ep_fence_strong_nb(ep, fence_seq));
+    EXPECT_EQ(1u, test_flush_call_count);
+    EXPECT_TRUE(ep->ext->fence_inflight_req != NULL);
+    EXPECT_EQ(UCS_INPROGRESS, ep->ext->fence_status);
+    EXPECT_NE(fence_seq, ep->ext->fence_seq);
+
+    ASSERT_NE(static_cast<uct_completion_t*>(NULL), test_flush_comp);
+    uct_invoke_completion(test_flush_comp, UCS_OK);
+
+    EXPECT_TRUE(ep->ext->fence_inflight_req == NULL);
+    EXPECT_EQ(UCS_OK, ep->ext->fence_status);
+    EXPECT_EQ(fence_seq, ep->ext->fence_seq);
+    EXPECT_EQ(0, ep->ext->unflushed_lanes);
+
+    prev_fence_seq                    = ep->ext->fence_seq;
+    fence_seq                         = prev_fence_seq + 1;
+    blocked_req.id                    = UCS_PTR_MAP_KEY_INVALID;
+    blocked_req.send.ep               = ep;
+    blocked_req.send.fence_seq        = fence_seq;
+    blocked_req.send.uct.func         = test_fence_defer_once;
+    blocked_req.flags                 = UCP_REQUEST_FLAG_FENCE_BLOCKED;
+    ep->ext->unflushed_lanes          = UCS_BIT(0);
+    test_flush_comp                   = NULL;
+    ep_refcount                       = ep->refcount;
+    EXPECT_UCS_OK(ucp_ep_fence_strong_nb(ep, fence_seq));
+    EXPECT_EQ(ep_refcount + 1, ep->refcount);
+    ucp_ep_fence_pending_add(ep, &blocked_req.send.uct);
+    ASSERT_NE(static_cast<uct_completion_t*>(NULL), test_flush_comp);
+    uct_invoke_completion(test_flush_comp, UCS_ERR_IO_ERROR);
+    EXPECT_EQ(ep_refcount, ep->refcount);
+    EXPECT_EQ(NULL, ep->ext->fence_inflight_req);
+    EXPECT_EQ(UCS_ERR_IO_ERROR, ep->ext->fence_status);
+    EXPECT_EQ(prev_fence_seq, ep->ext->fence_seq);
+    EXPECT_TRUE(ucs_queue_is_empty(&ep->ext->fence_pending_q));
+    EXPECT_TRUE(blocked_req.flags & UCP_REQUEST_FLAG_COMPLETED);
+    EXPECT_EQ(UCS_ERR_IO_ERROR, blocked_req.status);
+
+    iface->ops.ep_flush = flush_func;
+    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
+
+    disconnect(sender());
+    disconnect(receiver());
+}
+
+UCS_TEST_P(test_ucp_fence32, pending_purge_preserves_scheduled_progress)
+{
+    ucp_request_t purged_req  = {};
+    ucp_request_t readded_req = {};
+    unsigned num_oneshots;
+    ucp_ep_h ep;
+
+    if (!is_self()) {
+        UCS_TEST_SKIP_R("Synthetic fence-queue test uses stack requests");
+    }
+
+    sender().connect(&receiver(), get_ep_params());
+    ep = sender().ep();
+
+    purged_req.id                        = UCS_PTR_MAP_KEY_INVALID;
+    purged_req.send.ep                   = ep;
+    purged_req.send.fence_seq            = ep->ext->fence_seq;
+    purged_req.send.uct.func             = test_fence_defer_once;
+    purged_req.flags                     = UCP_REQUEST_FLAG_FENCE_BLOCKED;
+    readded_req.id                       = UCS_PTR_MAP_KEY_INVALID;
+    readded_req.send.ep                  = ep;
+    readded_req.send.fence_seq           = ep->ext->fence_seq;
+    readded_req.send.uct.func            = test_fence_defer_once;
+    readded_req.send.state.completed_size = 1;
+    readded_req.flags                    = UCP_REQUEST_FLAG_FENCE_BLOCKED;
+
+    ucp_ep_fence_pending_add(ep, &purged_req.send.uct);
+    ASSERT_TRUE(ep->ext->fence_pending_scheduled);
+
+    num_oneshots = 0;
+    ucs_callbackq_remove_oneshot(&ep->worker->uct->progress_q, ep,
+                                 test_fence_count_oneshot, &num_oneshots);
+    EXPECT_EQ(1u, num_oneshots);
+
+    ucp_ep_fence_pending_purge(ep, UCS_ERR_IO_ERROR);
+    EXPECT_TRUE(ucs_queue_is_empty(&ep->ext->fence_pending_q));
+    EXPECT_TRUE(ep->ext->fence_pending_scheduled);
+    EXPECT_FALSE(purged_req.flags & UCP_REQUEST_FLAG_FENCE_BLOCKED);
+    EXPECT_TRUE(purged_req.flags & UCP_REQUEST_FLAG_COMPLETED);
+    EXPECT_EQ(UCS_ERR_IO_ERROR, purged_req.status);
+
+    ucp_ep_fence_pending_add(ep, &readded_req.send.uct);
+    progress({&sender()});
+
+    EXPECT_TRUE(ucs_queue_is_empty(&ep->ext->fence_pending_q));
+    EXPECT_FALSE(ep->ext->fence_pending_scheduled);
+    EXPECT_FALSE(readded_req.flags & UCP_REQUEST_FLAG_FENCE_BLOCKED);
+    EXPECT_EQ(2, readded_req.send.state.completed_size);
+
+    disconnect(sender());
+    disconnect(receiver());
+}
+
+UCS_TEST_P(test_ucp_fence32, pending_queue_orders_fence_epochs)
+{
+    ucp_request_t first_epoch         = {};
+    ucp_request_t second_epoch_first  = {};
+    ucp_request_t second_epoch_second = {};
+    ucp_ep_h ep;
+
+    if (!is_self()) {
+        UCS_TEST_SKIP_R("Synthetic fence-queue test uses stack requests");
+    }
+
+    sender().connect(&receiver(), get_ep_params());
+    ep = sender().ep();
+
+    first_epoch.send.ep                   = ep;
+    first_epoch.send.fence_seq            = 1;
+    first_epoch.send.uct.func             = test_fence_defer_once;
+    first_epoch.send.state.completed_size = 1;
+    first_epoch.flags                     = UCP_REQUEST_FLAG_FENCE_BLOCKED;
+    second_epoch_first.send.ep            = ep;
+    second_epoch_first.send.fence_seq     = 2;
+    second_epoch_first.send.uct.func      = test_fence_defer_once;
+    second_epoch_first.send.state.completed_size = 1;
+    second_epoch_first.flags                     =
+            UCP_REQUEST_FLAG_FENCE_BLOCKED;
+    second_epoch_second.send.ep                  = ep;
+    second_epoch_second.send.fence_seq            = 2;
+    second_epoch_second.send.uct.func              = test_fence_defer_once;
+    second_epoch_second.send.state.completed_size  = 1;
+    second_epoch_second.flags                      =
+            UCP_REQUEST_FLAG_FENCE_BLOCKED;
+
+    ucp_ep_fence_pending_add(ep, &second_epoch_first.send.uct);
+    ucp_ep_fence_pending_add(ep, &first_epoch.send.uct);
+    ucp_ep_fence_pending_add(ep, &second_epoch_second.send.uct);
+
+    EXPECT_EQ(&first_epoch.send.fence_pending_elem,
+              ep->ext->fence_pending_q.head);
+    EXPECT_EQ(&second_epoch_first.send.fence_pending_elem,
+              ep->ext->fence_pending_q.head->next);
+    EXPECT_EQ(&second_epoch_second.send.fence_pending_elem,
+              ep->ext->fence_pending_q.head->next->next);
+
+    while (!ucs_queue_is_empty(&ep->ext->fence_pending_q)) {
+        progress({&sender()});
+    }
+
+    EXPECT_FALSE(first_epoch.flags & UCP_REQUEST_FLAG_FENCE_BLOCKED);
+    EXPECT_FALSE(second_epoch_first.flags & UCP_REQUEST_FLAG_FENCE_BLOCKED);
+    EXPECT_FALSE(second_epoch_second.flags & UCP_REQUEST_FLAG_FENCE_BLOCKED);
+
+    disconnect(sender());
+    disconnect(receiver());
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_fence32)

--- a/test/gtest/ucp/test_ucp_fence.cc
+++ b/test/gtest/ucp/test_ucp_fence.cc
@@ -681,6 +681,44 @@ UCS_TEST_P(test_ucp_fence32, async_fence_tracks_inflight_flush)
     disconnect(receiver());
 }
 
+UCS_TEST_P(test_ucp_fence32, fresh_defer_without_uct_lane)
+{
+    ucp_request_t req = {};
+    ucp_ep_h ep;
+    void *flush_req;
+
+    if (!is_self()) {
+        UCS_TEST_SKIP_R("Synthetic fence-queue test uses a stack request");
+    }
+
+    sender().connect(&receiver(), get_ep_params());
+    ep                    = sender().ep();
+    req.send.ep           = ep;
+    req.send.lane         = UCP_NULL_LANE;
+    req.send.pending_lane = UCP_NULL_LANE;
+    req.send.fence_seq    = ep->ext->fence_seq;
+    req.send.uct.func     = test_fence_defer_once;
+
+    ucp_request_send(&req);
+
+    EXPECT_FALSE(ucs_queue_is_empty(&ep->ext->fence_pending_q));
+    flush_req = ucp_worker_flush_nbx(sender().worker(),
+                                     &ucp_request_null_param);
+    EXPECT_TRUE(UCS_PTR_IS_PTR(flush_req));
+
+    while (!ucs_queue_is_empty(&ep->ext->fence_pending_q)) {
+        progress({&sender()});
+    }
+
+    EXPECT_FALSE(req.flags & UCP_REQUEST_FLAG_FENCE_BLOCKED);
+    if (UCS_PTR_IS_PTR(flush_req)) {
+        EXPECT_UCS_OK(request_wait(flush_req, {&sender()}));
+    }
+
+    disconnect(sender());
+    disconnect(receiver());
+}
+
 UCS_TEST_P(test_ucp_fence32, pending_purge_preserves_scheduled_progress)
 {
     ucp_request_t purged_req  = {};

--- a/test/gtest/ucp/test_ucp_fence.cc
+++ b/test/gtest/ucp/test_ucp_fence.cc
@@ -64,6 +64,31 @@ UCS_TEST_F(test_ucp_flush_lane_state, replace_same_index_lane)
     EXPECT_EQ(UCS_BIT(0) | UCS_BIT(1), lane_mask);
 }
 
+UCS_TEST_F(test_ucp_flush_lane_state, normalize_stale_lane_map)
+{
+    EXPECT_EQ(UCS_BIT(0) | UCS_BIT(2),
+              ucp_ep_fence_lane_map_update(UCS_BIT(0) | UCS_BIT(1),
+                                           UCS_BIT(0) | UCS_BIT(2)));
+}
+
+UCS_TEST_F(test_ucp_flush_lane_state, preserve_current_lane_subset)
+{
+    EXPECT_EQ(UCS_BIT(1),
+              ucp_ep_fence_lane_map_update(UCS_BIT(1),
+                                           UCS_BIT(0) | UCS_BIT(1) |
+                                           UCS_BIT(2)));
+}
+
+UCS_TEST_F(test_ucp_flush_lane_state, dirty_normalize_expands_lane_subset)
+{
+    ucp_lane_map_t live_lanes = UCS_BIT(0) | UCS_BIT(1);
+
+    EXPECT_EQ(live_lanes,
+              ucp_ep_fence_lane_map_normalize(UCS_BIT(0), live_lanes, 1));
+    EXPECT_EQ(UCS_BIT(0),
+              ucp_ep_fence_lane_map_normalize(UCS_BIT(0), live_lanes, 0));
+}
+
 UCS_TEST_F(test_ucp_flush_lane_state, destroyed_started_lane_is_not_unstarted)
 {
     EXPECT_FALSE(ucp_ep_flush_has_unstarted_lanes(
@@ -104,6 +129,20 @@ test_flush_inprogress(uct_ep_h ep, unsigned, uct_completion_t *comp)
 static void test_flush_completion(ucp_request_t *req)
 {
     ucp_request_complete_send(req, req->status);
+}
+
+static ucp_ep_h test_fence_flush_mutation_ep;
+static int test_fence_saw_clean_before_mutation;
+
+static ucs_status_t
+test_fence_flush_mutate_and_fail(uct_ep_h uct_ep, unsigned,
+                                 uct_completion_t *)
+{
+    test_fence_saw_clean_before_mutation =
+            !test_fence_flush_mutation_ep->ext->fence_lanes_dirty;
+    ucp_ep_set_lane(test_fence_flush_mutation_ep, 0, NULL);
+    ucp_ep_set_lane(test_fence_flush_mutation_ep, 0, uct_ep);
+    return UCS_ERR_IO_ERROR;
 }
 
 static int test_fence_count_oneshot(const ucs_callbackq_elem_t *, void *arg)
@@ -473,6 +512,106 @@ UCS_TEST_P(test_ucp_fence32, slow_lane_storage_initialization)
     UCS_ASYNC_UNBLOCK(&worker->async);
 }
 
+UCS_TEST_P(test_ucp_fence32, lane_topology_dirty_lifecycle)
+{
+    uint64_t lane_generation;
+    uct_ep_flush_func_t flush_func;
+    uct_iface_h iface;
+    ucs_status_t status;
+    ucp_ep_h ep;
+    uct_ep_h lane;
+
+    if (!is_self()) {
+        UCS_TEST_SKIP_R("Direct lane-state test requires self transport");
+    }
+
+    sender().connect(&receiver(), get_ep_params());
+    ep                        = sender().ep();
+    ep->ext->fence_lanes_dirty = 0;
+    ep->ext->unflushed_lanes   = UCS_BIT(0);
+    lane_generation            = ep->ext->lane_generation;
+    lane                       = ucp_ep_get_lane(ep, 0);
+
+    ucp_ep_set_lane(ep, 0, lane);
+    EXPECT_EQ(lane_generation, ep->ext->lane_generation);
+    EXPECT_FALSE(ep->ext->fence_lanes_dirty);
+
+    ucp_ep_set_lane(ep, 0, NULL);
+    EXPECT_EQ(lane_generation + 1, ep->ext->lane_generation);
+    EXPECT_TRUE(ep->ext->fence_lanes_dirty);
+
+    ucp_ep_set_lane(ep, 0, lane);
+    EXPECT_EQ(lane_generation + 2, ep->ext->lane_generation);
+    EXPECT_TRUE(ep->ext->fence_lanes_dirty);
+
+    EXPECT_UCS_OK(ucp_ep_fence_strong(ep));
+    EXPECT_EQ(0, ep->ext->unflushed_lanes);
+    EXPECT_FALSE(ep->ext->fence_lanes_dirty);
+
+    ucp_ep_set_lane(ep, 0, NULL);
+    EXPECT_EQ(lane_generation + 3, ep->ext->lane_generation);
+    EXPECT_FALSE(ep->ext->fence_lanes_dirty);
+
+    ep->ext->unflushed_lanes = UCS_BIT(0);
+    ucp_ep_set_lane(ep, 0, lane);
+    EXPECT_EQ(lane_generation + 4, ep->ext->lane_generation);
+    EXPECT_FALSE(ep->ext->fence_lanes_dirty);
+
+    iface                                = lane->iface;
+    flush_func                           = iface->ops.ep_flush;
+    test_fence_flush_mutation_ep         = ep;
+    test_fence_saw_clean_before_mutation = 0;
+    iface->ops.ep_flush                  = test_fence_flush_mutate_and_fail;
+
+    {
+        scoped_log_handler slh(hide_errors_logger);
+        scoped_log_handler warn_slh(hide_warns_logger);
+        status = ucp_ep_fence_strong(ep);
+    }
+
+    iface->ops.ep_flush          = flush_func;
+    test_fence_flush_mutation_ep = NULL;
+
+    EXPECT_EQ(UCS_ERR_IO_ERROR, status);
+    EXPECT_TRUE(test_fence_saw_clean_before_mutation);
+    EXPECT_TRUE(ep->ext->fence_lanes_dirty);
+
+    disconnect(sender());
+    disconnect(receiver());
+}
+
+UCS_TEST_P(test_ucp_fence32, rma_admission_normalizes_dirty_lanes)
+{
+    static const size_t memheap_size = sizeof(uint64_t);
+    uint64_t initial_value           = 1;
+    uint64_t result                  = 0;
+    ucp_ep_h ep;
+
+    if (!is_self()) {
+        UCS_TEST_SKIP_R("Direct lane-state test requires self transport");
+    }
+
+    if (!(get_variant_value() & EP_BASED_FENCE)) {
+        UCS_TEST_SKIP_R("EP-based fence mode is required");
+    }
+
+    sender().connect(&receiver(), get_ep_params());
+    mapped_buffer buffer(memheap_size, receiver(), 0);
+
+    ep                         = sender().ep();
+    ep->ext->unflushed_lanes   = UCS_BIT(0);
+    ep->ext->fence_lanes_dirty = 1;
+
+    sender().fence();
+    blocking_add<uint32_t>(&sender(), &initial_value, &result, buffer.ptr(),
+                           buffer.rkey(sender()));
+
+    EXPECT_FALSE(ep->ext->fence_lanes_dirty);
+
+    disconnect(sender());
+    disconnect(receiver());
+}
+
 UCS_TEST_P(test_ucp_fence32, async_fence_tracks_inflight_flush)
 {
     ucp_request_t blocked_req = {};
@@ -590,6 +729,41 @@ UCS_TEST_P(test_ucp_fence32, pending_purge_preserves_scheduled_progress)
     EXPECT_FALSE(ep->ext->fence_pending_scheduled);
     EXPECT_FALSE(readded_req.flags & UCP_REQUEST_FLAG_FENCE_BLOCKED);
     EXPECT_EQ(2, readded_req.send.state.completed_size);
+
+    disconnect(sender());
+    disconnect(receiver());
+}
+
+UCS_TEST_P(test_ucp_fence32, pending_queue_survives_reconfiguration_purge)
+{
+    ucp_request_t req = {};
+    ucp_ep_h ep;
+
+    if (!is_self()) {
+        UCS_TEST_SKIP_R("Synthetic fence-queue test uses a stack request");
+    }
+
+    sender().connect(&receiver(), get_ep_params());
+    ep                    = sender().ep();
+    req.id                = UCS_PTR_MAP_KEY_INVALID;
+    req.send.ep           = ep;
+    req.send.fence_seq    = ep->ext->fence_seq;
+    req.send.uct.func     = test_fence_defer_once;
+    req.flags             = UCP_REQUEST_FLAG_FENCE_BLOCKED;
+
+    ucp_ep_fence_pending_add(ep, &req.send.uct);
+    ucp_ep_reqs_purge(ep, UCS_ERR_IO_ERROR, 0);
+
+    EXPECT_FALSE(ucs_queue_is_empty(&ep->ext->fence_pending_q));
+    EXPECT_TRUE(req.flags & UCP_REQUEST_FLAG_FENCE_BLOCKED);
+    EXPECT_FALSE(req.flags & UCP_REQUEST_FLAG_COMPLETED);
+
+    ucp_ep_reqs_purge(ep, UCS_ERR_IO_ERROR, 1);
+
+    EXPECT_TRUE(ucs_queue_is_empty(&ep->ext->fence_pending_q));
+    EXPECT_FALSE(req.flags & UCP_REQUEST_FLAG_FENCE_BLOCKED);
+    EXPECT_TRUE(req.flags & UCP_REQUEST_FLAG_COMPLETED);
+    EXPECT_EQ(UCS_ERR_IO_ERROR, req.status);
 
     disconnect(sender());
     disconnect(receiver());

--- a/test/gtest/ucp/test_ucp_fence.cc
+++ b/test/gtest/ucp/test_ucp_fence.cc
@@ -6,6 +6,106 @@
 
 #include "ucp_test.h"
 
+extern "C" {
+#include <ucp/core/ucp_request.inl>
+#include <ucp/rma/rma.h>
+#include <uct/base/uct_iface.h>
+}
+
+class test_ucp_flush_lane_state : public ucs::test {
+};
+
+UCS_TEST_F(test_ucp_flush_lane_state, replace_unstarted_lane)
+{
+    ucp_lane_map_t all_lanes     = UCS_BIT(0) | UCS_BIT(1);
+    ucp_lane_map_t lane_mask     = UCS_BIT(1);
+    ucp_lane_map_t started_lanes = 0;
+    int count_diff;
+
+    count_diff = ucp_ep_flush_lane_state_update(
+            UCS_BIT(0) | UCS_BIT(2), 0, &started_lanes, &all_lanes,
+            &lane_mask);
+
+    EXPECT_EQ(0, count_diff);
+    EXPECT_EQ(UCS_BIT(0) | UCS_BIT(2), all_lanes);
+    EXPECT_EQ(UCS_BIT(1) | UCS_BIT(2), lane_mask);
+}
+
+UCS_TEST_F(test_ucp_flush_lane_state, replace_started_lane)
+{
+    ucp_lane_map_t all_lanes     = UCS_BIT(0) | UCS_BIT(1);
+    ucp_lane_map_t lane_mask     = UCS_BIT(1);
+    ucp_lane_map_t started_lanes = UCS_BIT(1);
+    int count_diff;
+
+    count_diff = ucp_ep_flush_lane_state_update(
+            UCS_BIT(0) | UCS_BIT(2), 0, &started_lanes, &all_lanes,
+            &lane_mask);
+
+    EXPECT_EQ(1, count_diff);
+    EXPECT_EQ(UCS_BIT(0) | UCS_BIT(2), all_lanes);
+    EXPECT_EQ(UCS_BIT(1) | UCS_BIT(2), lane_mask);
+}
+
+UCS_TEST_F(test_ucp_flush_lane_state, replace_same_index_lane)
+{
+    ucp_lane_map_t all_lanes     = UCS_BIT(0) | UCS_BIT(1);
+    ucp_lane_map_t lane_mask     = UCS_BIT(0);
+    ucp_lane_map_t started_lanes = UCS_BIT(0);
+    int count_diff;
+
+    count_diff = ucp_ep_flush_lane_state_update(
+            UCS_BIT(0) | UCS_BIT(1), 1, &started_lanes, &all_lanes,
+            &lane_mask);
+
+    EXPECT_EQ(1, count_diff);
+    EXPECT_EQ(0, started_lanes);
+    EXPECT_EQ(UCS_BIT(0) | UCS_BIT(1), all_lanes);
+    EXPECT_EQ(UCS_BIT(0) | UCS_BIT(1), lane_mask);
+}
+
+UCS_TEST_F(test_ucp_flush_lane_state, destroyed_started_lane_is_not_unstarted)
+{
+    EXPECT_FALSE(ucp_ep_flush_has_unstarted_lanes(
+            UCS_BIT(0) | UCS_BIT(2),
+            UCS_BIT(0) | UCS_BIT(1) | UCS_BIT(2)));
+}
+
+UCS_TEST_F(test_ucp_flush_lane_state, live_unstarted_lane)
+{
+    EXPECT_TRUE(ucp_ep_flush_has_unstarted_lanes(
+            UCS_BIT(0) | UCS_BIT(2), UCS_BIT(0) | UCS_BIT(1)));
+}
+
+static unsigned test_flush_call_count;
+
+static ucs_status_t
+test_flush_count_calls(uct_ep_h, unsigned, uct_completion_t *)
+{
+    ++test_flush_call_count;
+    return UCS_ERR_IO_ERROR;
+}
+
+static uct_completion_t *test_flush_comp;
+static uct_ep_h test_flush_eps[2];
+
+static ucs_status_t
+test_flush_inprogress(uct_ep_h ep, unsigned, uct_completion_t *comp)
+{
+    if (test_flush_call_count < ucs_static_array_size(test_flush_eps)) {
+        test_flush_eps[test_flush_call_count] = ep;
+    }
+
+    ++test_flush_call_count;
+    test_flush_comp = comp;
+    return UCS_INPROGRESS;
+}
+
+static void test_flush_completion(ucp_request_t *req)
+{
+    ucp_request_complete_send(req, req->status);
+}
+
 
 class test_ucp_fence : public ucp_test {
 public:
@@ -178,6 +278,182 @@ public:
 UCS_TEST_P(test_ucp_fence32, atomic_add_fadd) {
     test<uint32_t>(&test_ucp_fence32::blocking_add<uint32_t>,
                    &test_ucp_fence32::blocking_fadd<uint32_t>);
+}
+
+UCS_TEST_P(test_ucp_fence32, empty_lane_mask_skips_transport_flush)
+{
+    ucp_request_param_t param = {};
+    ucp_ep_h ep;
+    uct_iface_h iface;
+    uct_ep_flush_func_t flush_func;
+    ucs_status_ptr_t request;
+
+    if (!is_self()) {
+        UCS_TEST_SKIP_R("Direct flush interception requires self transport");
+    }
+
+    sender().connect(&receiver(), get_ep_params());
+    ep         = sender().ep();
+    iface      = ucp_ep_get_lane(ep, 0)->iface;
+    flush_func = iface->ops.ep_flush;
+
+    test_flush_call_count = 0;
+    iface->ops.ep_flush   = test_flush_count_calls;
+
+    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
+    request = ucp_ep_flush_lanes_internal(
+            ep, 0, &param, NULL, test_flush_completion, "flush_lane_mask_test",
+            UCT_FLUSH_FLAG_LOCAL, 0);
+    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
+
+    iface->ops.ep_flush = flush_func;
+
+    EXPECT_EQ(0, test_flush_call_count);
+    EXPECT_EQ(NULL, request);
+
+    disconnect(sender());
+    disconnect(receiver());
+}
+
+UCS_TEST_P(test_ucp_fence32, replace_lane_during_selective_flush)
+{
+    ucp_request_param_t param = {};
+    uct_ep_t replacement_lane = {};
+    ucp_ep_h ep;
+    uct_ep_h original_lane;
+    uct_iface_h iface;
+    uct_ep_flush_func_t flush_func;
+    ucs_status_ptr_t request;
+
+    if (!is_self()) {
+        UCS_TEST_SKIP_R("Direct flush interception requires self transport");
+    }
+
+    sender().connect(&receiver(), get_ep_params());
+    ep                       = sender().ep();
+    original_lane            = ucp_ep_get_lane(ep, 0);
+    iface                    = original_lane->iface;
+    replacement_lane.iface   = iface;
+    flush_func               = iface->ops.ep_flush;
+    test_flush_call_count    = 0;
+    test_flush_comp          = NULL;
+    test_flush_eps[0]        = NULL;
+    test_flush_eps[1]        = NULL;
+    iface->ops.ep_flush      = test_flush_inprogress;
+
+    UCP_WORKER_THREAD_CS_ENTER_CONDITIONAL(ep->worker);
+    request = ucp_ep_flush_lanes_internal(
+            ep, 0, &param, NULL, test_flush_completion,
+            "replace_lane_during_flush", UCT_FLUSH_FLAG_LOCAL, UCS_BIT(0));
+    EXPECT_TRUE(UCS_PTR_IS_PTR(request));
+    EXPECT_EQ(1u, test_flush_call_count);
+    EXPECT_EQ(original_lane, test_flush_eps[0]);
+
+    ucp_ep_set_lane(ep, 0, &replacement_lane);
+    uct_invoke_completion(test_flush_comp, UCS_OK);
+
+    EXPECT_EQ(2u, test_flush_call_count);
+    EXPECT_EQ(&replacement_lane, test_flush_eps[1]);
+
+    uct_invoke_completion(test_flush_comp, UCS_OK);
+    ucp_ep_set_lane(ep, 0, original_lane);
+    iface->ops.ep_flush = flush_func;
+    UCP_WORKER_THREAD_CS_EXIT_CONDITIONAL(ep->worker);
+
+    EXPECT_UCS_OK(ucp_request_check_status(request));
+    ucp_request_release(request);
+
+    disconnect(sender());
+    disconnect(receiver());
+}
+
+UCS_TEST_P(test_ucp_fence32, lane_generation_updates_on_pointer_change)
+{
+    uint64_t lane_generation;
+    ucp_ep_h ep;
+    uct_ep_h lane;
+
+    if (!is_self()) {
+        UCS_TEST_SKIP_R("Direct lane-state test requires self transport");
+    }
+
+    sender().connect(&receiver(), get_ep_params());
+    ep              = sender().ep();
+    lane_generation = ep->ext->lane_generation;
+    lane            = ucp_ep_get_lane(ep, 0);
+
+    ucp_ep_set_lane(ep, 0, lane);
+    EXPECT_EQ(lane_generation, ep->ext->lane_generation);
+
+    ucp_ep_set_lane(ep, 0, NULL);
+    EXPECT_EQ(lane_generation + 1, ep->ext->lane_generation);
+
+    ucp_ep_set_lane(ep, 0, lane);
+    EXPECT_EQ(lane_generation + 2, ep->ext->lane_generation);
+
+    disconnect(sender());
+    disconnect(receiver());
+}
+
+UCS_TEST_P(test_ucp_fence32, recycled_ep_lane_storage_initialization)
+{
+    ucp_worker_h worker = sender().worker();
+    ucp_ep_h ep;
+    ucp_ep_h recycled_ep;
+    ucp_lane_index_t lane;
+
+    UCS_ASYNC_BLOCK(&worker->async);
+    ASSERT_UCS_OK(ucp_ep_create_base(worker, UCP_EP_INIT_FLAG_INTERNAL,
+                                     "lane-init", "lane-init", &ep));
+
+    for (lane = 0; lane < UCP_MAX_FAST_PATH_LANES; ++lane) {
+        ep->uct_eps[lane] = reinterpret_cast<uct_ep_h>(
+                static_cast<uintptr_t>(lane + 1));
+    }
+
+    ucp_ep_delete(ep);
+
+    ASSERT_UCS_OK(ucp_ep_create_base(worker, UCP_EP_INIT_FLAG_INTERNAL,
+                                     "lane-recycle", "lane-recycle",
+                                     &recycled_ep));
+
+    EXPECT_EQ(ep, recycled_ep);
+    EXPECT_EQ(0, recycled_ep->ext->lane_generation);
+    for (lane = 0; lane < UCP_MAX_FAST_PATH_LANES; ++lane) {
+        EXPECT_EQ(NULL, recycled_ep->uct_eps[lane]);
+    }
+
+    ucp_ep_delete(recycled_ep);
+    UCS_ASYNC_UNBLOCK(&worker->async);
+}
+
+UCS_TEST_P(test_ucp_fence32, slow_lane_storage_initialization)
+{
+    const unsigned num_lanes = UCP_MAX_FAST_PATH_LANES + 2;
+    ucp_worker_h worker       = sender().worker();
+    ucp_ep_h ep;
+    ucp_lane_index_t lane;
+
+    UCS_ASYNC_BLOCK(&worker->async);
+    ASSERT_UCS_OK(ucp_ep_create_base(worker, UCP_EP_INIT_FLAG_INTERNAL,
+                                     "lane-init", "lane-init", &ep));
+    ASSERT_UCS_OK(ucp_ep_realloc_lanes(ep, num_lanes));
+
+    for (lane = UCP_MAX_FAST_PATH_LANES; lane < num_lanes; ++lane) {
+        ep->ext->uct_eps[lane - UCP_MAX_FAST_PATH_LANES] =
+                reinterpret_cast<uct_ep_h>(static_cast<uintptr_t>(lane + 1));
+    }
+
+    ep->ext->lane_generation = 0;
+    ASSERT_UCS_OK(ucp_ep_realloc_lanes(ep, num_lanes));
+
+    EXPECT_EQ(0, ep->ext->lane_generation);
+    for (lane = 0; lane < num_lanes; ++lane) {
+        EXPECT_EQ(NULL, ucp_ep_get_lane(ep, lane));
+    }
+
+    ucp_ep_delete(ep);
+    UCS_ASYNC_UNBLOCK(&worker->async);
 }
 
 UCP_INSTANTIATE_TEST_CASE(test_ucp_fence32)


### PR DESCRIPTION
## What

Activate non-blocking endpoint fences for ordinary RMA and atomic requests.

## Why

This is Part 4 of 5 of an updated split of the earlier [endpoint-fence PR #11199](https://github.com/openucx/ucx/pull/11199).

Parts 1–3 provide the selective flush, asynchronous lifecycle, and topology safety needed to change the normal request path. This PR is the first one that changes ordinary RMA/atomic behavior: a request that is behind a strong endpoint fence is deferred and resumed asynchronously instead of blocking progress.

## How

- Route RMA and atomic fence admission through the asynchronous endpoint-fence engine when a strong fence is required.
- Capture each request's fence epoch and queue a newly deferred request even before it owns a UCT lane.
- Keep the existing cheap weak-fence fast path when one lane is sufficient.
- Make endpoint and worker flush wait for relevant queued/in-flight fence work, without a fence flush waiting for its own triggering request.
- Add coverage for the fresh-defer path and the activated fence flow.

RMA rendezvous ordering is completed by Part 5.

**Draft — merge only after [PR #11925](https://github.com/openucx/ucx/pull/11925) is merged.**
