### PR TITLE
UCT/IB/MLX5: fix credits for FT unpolled CQEs

### DIFF
--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -1333,7 +1333,7 @@ UCS_CLASS_CLEANUP_FUNC(uct_rc_mlx5_ep_t)
     uct_rc_mlx5_iface_common_t *iface = ucs_derived_of(
             self->super.super.super.super.iface, uct_rc_mlx5_iface_common_t);
     uct_rc_mlx5_iface_qp_cleanup_ctx_t *cleanup_ctx;
-    uint16_t outstanding, wqe_count, cq_credits;
+    uint16_t unreleased_cq_credits, unpolled_cqes, cq_credits;
 
     cleanup_ctx = ucs_malloc(sizeof(*cleanup_ctx), "mlx5_qp_cleanup_ctx");
     ucs_assert_always(cleanup_ctx != NULL);
@@ -1355,18 +1355,12 @@ UCS_CLASS_CLEANUP_FUNC(uct_rc_mlx5_ep_t)
 
     /* Keep only one unreleased CQ credit per WQE, so we will not have CQ
        overflow. These CQ credits will be released by error CQE handler. */
-    if (self->super.err_handler_inprogress) {
-        ucs_assert(self->super.super.txqp.available ==
-                   self->super.tx.wq.bb_max);
-        cq_credits = 0;
-    } else {
-        outstanding = self->super.tx.wq.bb_max -
-                      self->super.super.txqp.available;
-        wqe_count   = uct_ib_mlx5_txwq_num_posted_wqes(&self->super.tx.wq,
-                                                       outstanding);
-        ucs_assert(outstanding >= wqe_count);
-        cq_credits = outstanding - wqe_count;
-    }
+    unreleased_cq_credits = self->super.tx.wq.prev_sw_pi -
+                            self->super.tx.wq.hw_ci;
+    unpolled_cqes = uct_ib_mlx5_txwq_num_posted_wqes(&self->super.tx.wq,
+                                                     unreleased_cq_credits);
+    ucs_assert(unreleased_cq_credits >= unpolled_cqes);
+    cq_credits = unreleased_cq_credits - unpolled_cqes;
 
     uct_rc_ep_cleanup_qp(&self->super.super, &cleanup_ctx->super,
                          self->super.tx.wq.super.qp_num, cq_credits);


### PR DESCRIPTION
## What?
Fix CQ credit reservation during RC mlx5 endpoint cleanup in the FT path.
Add resource-accounting assertions.

## Why?
CQ credit reservation must use hw_ci, which represents the CQEs hardware may still produce, rather than TXQP availability.
During FT, SQ resources are owned by the caller and tracked by ft_ci, so they may diverge from hardware CQ progress.

## How?
Rename confused variables.
Release cq credits according to un-arrived CQEs.