### PR TITLE
DOCS: Default pull requests to ready for review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,8 @@ them.
 
 - Create PRs as ready for review by default; do not use GitHub's draft state.
 - For PRs that are not ready for review, keep them non-draft, add the
-  `[DNM-WIP]` label, and prefix the PR title with `[DNM-WIP] `.
-- Remove both the `[DNM-WIP]` label and title prefix when the PR is ready for
+  `WIP-DNM` label, and prefix the PR title with `[DNM-WIP] `.
+- Remove both the `WIP-DNM` label and title prefix when the PR is ready for
   review.
 
 ## Project Map

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,14 @@ them.
 - Commit messages usually follow `COMPONENT/SUBCOMPONENT: Imperative message`,
   for example `UCP/CORE: Fix endpoint flush completion`.
 
+## Pull Request Creation
+
+- Create PRs as ready for review by default; do not use GitHub's draft state.
+- For PRs that are not ready for review, keep them non-draft, add the
+  `[DNM-WIP]` label, and prefix the PR title with `[DNM-WIP] `.
+- Remove both the `[DNM-WIP]` label and title prefix when the PR is ready for
+  review.
+
 ## Project Map
 
 UCX is a C communication framework with C++ unit tests. Use the nearest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ them.
 
 - Create PRs as ready for review by default; do not use GitHub's draft state.
 - For PRs that are not ready for review, keep them non-draft, add the
-  `WIP-DNM` label, and prefix the PR title with `[DNM-WIP] `.
+  `WIP-DNM` label, and prefix the PR title with `[WIP-DNM] `.
 - Remove both the `WIP-DNM` label and title prefix when the PR is ready for
   review.
 


### PR DESCRIPTION
## What?
Create pull requests as ready for review by default. Keep unfinished PRs non-draft, with both the `WIP-DNM` label and a `[WIP-DNM]` title prefix, and remove both markers once they are ready for review.

## Why?
Make the repository guidance explicit so PR creation consistently uses the UCX work-in-progress convention.
