### PR TITLE
CI: Do not start PR pipelines for draft pull requests

### DIFF
--- a/buildlib/azure-pipelines-pr.yml
+++ b/buildlib/azure-pipelines-pr.yml
@@ -3,6 +3,7 @@
 
 trigger: none
 pr:
+  drafts: false
   branches:
     include:
     - master


### PR DESCRIPTION
## What?
Do not start CI for draft PRs.

## Why?
Azure behaviour change - now marking a draft PR "ready for review" makes Azure queue a second run of the same commit. This causes extra full runs, adding load to already strained resources.
Microsoft has no fix planned (https://developercommunity.visualstudio.com/t/11032682).

## How?
`buildlib/azure-pipelines-pr.yml`: 
    `drafts: false` in the `pr:` block. One line.
