### PR TITLE
[DNM] UCT/IB/MLX5: Set real iov length for zcopy

### DIFF
--- a/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/dc/dc_mlx5_ep.c
@@ -79,18 +79,17 @@ uct_dc_mlx5_iface_bcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
                                        buffer, log_sge);
 }
 
-static UCS_F_ALWAYS_INLINE void
-uct_dc_mlx5_iface_zcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
-                             unsigned opcode, const uct_iov_t *iov,
-                             size_t iovcnt, size_t iov_total_length,
-                             /* SEND */ uint8_t am_id, const void *am_hdr, unsigned am_hdr_len,
-                             /* RDMA */ uint64_t rdma_raddr, uct_rkey_t rdma_rkey,
-                             /* TAG  */ uct_tag_t tag, uint32_t app_ctx, uint32_t ib_imm_be,
-                             uct_rc_send_handler_t handler, uint16_t op_flags,
-                             uct_completion_t *comp, uint8_t send_flags)
+static UCS_F_ALWAYS_INLINE void uct_dc_mlx5_iface_zcopy_post(
+        uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep, unsigned opcode,
+        /* IOV */ const uct_iov_t *iov, size_t iovcnt,
+        /* SEND */ uint8_t am_id, const void *am_hdr, unsigned am_hdr_len,
+        /* RDMA */ uint64_t rdma_raddr, uct_rkey_t rdma_rkey,
+        /* TAG  */ uct_tag_t tag, uint32_t app_ctx, uint32_t ib_imm_be,
+        uct_rc_send_handler_t handler, uint16_t op_flags,
+        uct_completion_t *comp, uint8_t send_flags)
 {
     uint16_t sn;
-    size_t av_size;
+    size_t av_size, iov_length;
     UCT_DC_MLX5_TXQP_DECL(txqp, txwq);
 
     UCT_DC_MLX5_IFACE_TXQP_GET(iface, ep, txqp, txwq);
@@ -98,18 +97,16 @@ uct_dc_mlx5_iface_zcopy_post(uct_dc_mlx5_iface_t *iface, uct_dc_mlx5_ep_t *ep,
     sn = txwq->sw_pi;
     av_size = uct_dc_mlx5_set_dgram_seg(txwq, iface, &ep->av,
                                         uct_dc_mlx5_ep_get_grh(ep));
-    uct_rc_mlx5_txqp_dptr_post_iov(&iface->super, UCT_IB_QPT_DCI, txqp,
-                                   txwq, opcode, iov, iovcnt,
-                                   am_id, am_hdr, am_hdr_len,
-                                   rdma_raddr, rdma_rkey,
-                                   tag, app_ctx, ib_imm_be, NULL, av_size,
-                                   MLX5_WQE_CTRL_CQ_UPDATE | send_flags,
-                                   ep->dci_channel_index,
-                                   UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super.super));
+    iov_length = uct_rc_mlx5_txqp_dptr_post_iov(
+            &iface->super, UCT_IB_QPT_DCI, txqp, txwq, opcode, iov, iovcnt,
+            am_id, am_hdr, am_hdr_len, rdma_raddr, rdma_rkey, tag, app_ctx,
+            ib_imm_be, NULL, av_size, MLX5_WQE_CTRL_CQ_UPDATE | send_flags,
+            ep->dci_channel_index,
+            UCT_IB_MAX_ZCOPY_LOG_SGE(&iface->super.super.super));
 
     uct_rc_txqp_add_send_comp(&iface->super.super, txqp, handler, comp, sn,
                               op_flags | UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY, iov,
-                              iovcnt, iov_total_length);
+                              iovcnt, iov_length);
 }
 
 static UCS_F_ALWAYS_INLINE void
@@ -471,10 +468,10 @@ ucs_status_t uct_dc_mlx5_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *hea
                                UCT_IB_MLX5_AV_FULL_SIZE);
     UCT_DC_CHECK_RES_AND_FC(iface, ep);
 
-    uct_dc_mlx5_iface_zcopy_post(iface, ep, MLX5_OPCODE_SEND, iov, iovcnt, 0ul,
-                                 id, header, header_length, 0, 0, 0ul, 0, 0,
-                                 uct_rc_ep_send_op_completion_handler, 0,
-                                 comp, MLX5_WQE_CTRL_SOLICITED);
+    uct_dc_mlx5_iface_zcopy_post(iface, ep, MLX5_OPCODE_SEND, iov, iovcnt, id,
+                                 header, header_length, 0, 0, 0ul, 0, 0,
+                                 uct_rc_ep_send_op_completion_handler, 0, comp,
+                                 MLX5_WQE_CTRL_SOLICITED);
 
     UCT_RC_UPDATE_FC_WND(&ep->fc);
     UCT_TL_EP_STAT_OP(&ep->super, AM, ZCOPY, header_length +
@@ -603,7 +600,7 @@ ucs_status_t uct_dc_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size
                              atomic_mr_offset, &fm_ce_se);
 
     uct_dc_mlx5_iface_zcopy_post(iface, ep, MLX5_OPCODE_RDMA_WRITE, iov, iovcnt,
-                                 0ul, 0, NULL, 0, remote_addr, rkey, 0ul, 0, 0,
+                                 0, NULL, 0, remote_addr, rkey, 0ul, 0, 0,
                                  uct_rc_ep_send_op_completion_handler, 0, comp,
                                  fm_ce_se);
 
@@ -665,11 +662,9 @@ ucs_status_t uct_dc_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
     uct_rc_mlx5_ep_fence_get(&iface->super, txwq, &rkey, &fm_ce_se);
 
     uct_dc_mlx5_iface_zcopy_post(iface, ep, MLX5_OPCODE_RDMA_READ, iov, iovcnt,
-                                 total_length, 0, NULL, 0, remote_addr, rkey,
-                                 0ul, 0, 0,
+                                 0, NULL, 0, remote_addr, rkey, 0ul, 0, 0,
                                  uct_rc_ep_get_zcopy_completion_handler,
-                                 UCT_RC_IFACE_SEND_OP_FLAG_IOV, comp,
-                                 fm_ce_se);
+                                 UCT_RC_IFACE_SEND_OP_FLAG_IOV, comp, fm_ce_se);
 
     UCT_RC_RDMA_READ_POSTED(&iface->super.super, total_length);
     UCT_TL_EP_STAT_OP(&ep->super, GET, ZCOPY, total_length);
@@ -1089,8 +1084,8 @@ ucs_status_t uct_dc_mlx5_ep_tag_eager_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
 
     UCT_RC_MLX5_FILL_TM_IMM(imm, app_ctx, ib_imm, opcode, MLX5_OPCODE_SEND, _IMM);
 
-    uct_dc_mlx5_iface_zcopy_post(iface, ep, opcode|UCT_RC_MLX5_OPCODE_FLAG_TM,
-                                 iov, iovcnt, 0ul, 0, "", 0, 0, 0, tag, app_ctx,
+    uct_dc_mlx5_iface_zcopy_post(iface, ep, opcode | UCT_RC_MLX5_OPCODE_FLAG_TM,
+                                 iov, iovcnt, 0, "", 0, 0, 0, tag, app_ctx,
                                  ib_imm, uct_rc_ep_send_op_completion_handler,
                                  0, comp, MLX5_WQE_CTRL_SOLICITED);
 

--- a/src/uct/ib/mlx5/gga/gga_mlx5.c
+++ b/src/uct/ib/mlx5/gga/gga_mlx5.c
@@ -573,9 +573,8 @@ uct_gga_mlx5_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
 
     status = uct_rc_mlx5_base_ep_zcopy_post(
             ep, MLX5_OPCODE_MMO | UCT_RC_MLX5_OPCODE_FLAG_MMO_PUT, iov, iovcnt,
-            0ul, 0, NULL, 0, remote_addr, rkey_copy, 0ul, 0, 0,
-            &gga_ep->dma_opaque.opaque_mr,
-            fm_ce_se | MLX5_WQE_CTRL_CQ_UPDATE,
+            0, NULL, 0, remote_addr, rkey_copy, 0ul, 0, 0,
+            &gga_ep->dma_opaque.opaque_mr, fm_ce_se | MLX5_WQE_CTRL_CQ_UPDATE,
             uct_rc_ep_send_op_completion_handler, 0, comp);
     UCT_TL_EP_STAT_OP_IF_SUCCESS(status, &ep->super.super, PUT, ZCOPY,
                                  uct_iov_total_length(iov, iovcnt));
@@ -614,9 +613,8 @@ uct_gga_mlx5_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov, size_t iovcnt,
     uct_rc_mlx5_ep_fence_get(iface, &ep->tx.wq, &rkey_copy, &fm_ce_se);
     status = uct_rc_mlx5_base_ep_zcopy_post(
             ep, MLX5_OPCODE_MMO | UCT_RC_MLX5_OPCODE_FLAG_MMO_GET, iov, iovcnt,
-            total_length, 0, NULL, 0, remote_addr, rkey_copy, 0ul, 0, 0,
-            &gga_ep->dma_opaque.opaque_mr,
-            fm_ce_se | MLX5_WQE_CTRL_CQ_UPDATE,
+            0, NULL, 0, remote_addr, rkey_copy, 0ul, 0, 0,
+            &gga_ep->dma_opaque.opaque_mr, fm_ce_se | MLX5_WQE_CTRL_CQ_UPDATE,
             uct_rc_ep_get_zcopy_completion_handler,
             UCT_RC_IFACE_SEND_OP_FLAG_IOV, comp);
 

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -851,16 +851,16 @@ uct_rc_mlx5_txqp_dptr_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
 }
 
 static UCS_F_ALWAYS_INLINE
-void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_type,
-                                    uct_rc_txqp_t *txqp, uct_ib_mlx5_txwq_t *txwq,
-                                    unsigned opcode_flags,
-                         /* IOV  */ const uct_iov_t *iov, size_t iovcnt,
-                         /* SEND */ uint8_t am_id, const void *am_hdr, unsigned am_hdr_len,
-                         /* RDMA */ uint64_t remote_addr, uct_rkey_t rkey,
-                         /* TAG  */ uct_tag_t tag, uint32_t app_ctx, uint32_t ib_imm_be,
-                         /* MMO  */ const uct_ib_mlx5_dma_opaque_mr_t *opaque_mr,
-                                    size_t av_size, uint8_t fm_ce_se,
-                                    uint16_t dci_channel, int max_log_sge)
+size_t uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_type,
+                                      uct_rc_txqp_t *txqp, uct_ib_mlx5_txwq_t *txwq,
+                                      unsigned opcode_flags,
+                           /* IOV  */ const uct_iov_t *iov, size_t iovcnt,
+                           /* SEND */ uint8_t am_id, const void *am_hdr, unsigned am_hdr_len,
+                           /* RDMA */ uint64_t remote_addr, uct_rkey_t rkey,
+                           /* TAG  */ uct_tag_t tag, uint32_t app_ctx, uint32_t ib_imm_be,
+                           /* MMO  */ const uct_ib_mlx5_dma_opaque_mr_t *opaque_mr,
+                                      size_t av_size, uint8_t fm_ce_se,
+                                      uint16_t dci_channel, int max_log_sge)
 {
     struct mlx5_wqe_ctrl_seg     *ctrl;
     struct mlx5_wqe_raddr_seg    *raddr;
@@ -940,11 +940,12 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
         uct_ib_mlx5_ep_set_rdma_seg(raddr, remote_addr, rkey);
 
         /* Data segment */
-        wqe_size = ctrl_av_size + sizeof(*raddr) +
-                   uct_ib_mlx5_set_data_seg_iov(
-                           txwq, (void*)(raddr + 1), iov, iovcnt,
-                           &message_length);
-        opmod    = 0;
+        wqe_size       = ctrl_av_size + sizeof(*raddr) +
+                         uct_ib_mlx5_set_data_seg_iov(
+                                 txwq, (void*)(raddr + 1), iov, iovcnt,
+                                 &iov_length);
+        opmod          = 0;
+        message_length = iov_length;
         ucs_assert(message_length <= UCT_IB_MAX_MESSAGE_SIZE);
         break;
 
@@ -983,6 +984,7 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
                          (2 * sizeof(*dptr));
         opmod          = UCT_IB_MLX5_OPMOD_MMO_DMA;
         message_length = 0;
+        iov_length     = iov[0].length;
         break;
 #endif
     default:
@@ -995,7 +997,7 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
                                  max_log_sge, NULL);
 #if HAVE_MLX5_MMO
     if ((opcode_flags & UCT_RC_MLX5_OPCODE_MASK) == MLX5_OPCODE_MMO) {
-        return;
+        return iov_length;
     }
 #endif
 
@@ -1005,6 +1007,8 @@ void uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_ty
          * PUT_ZCOPY gets the branchless one-PSN adjustment. */
         uct_rc_mlx5_txwq_add_psn(txwq, qp_type, !message_length);
     }
+
+    return iov_length;
 }
 
 /*
@@ -2007,7 +2011,7 @@ uct_rc_mlx5_iface_poll_tx(uct_rc_mlx5_iface_common_t *iface, int poll_flags)
  */
 static UCS_F_ALWAYS_INLINE ucs_status_t uct_rc_mlx5_base_ep_zcopy_post(
         uct_rc_mlx5_base_ep_t *ep, unsigned opcode, const uct_iov_t *iov,
-        size_t iovcnt, size_t iov_total_length,
+        size_t iovcnt,
         /* SEND */ uint8_t am_id, const void *am_hdr, unsigned am_hdr_len,
         /* RDMA */ uint64_t rdma_raddr, uct_rkey_t rdma_rkey,
         /* TAG  */ uct_tag_t tag, uint32_t app_ctx, uint32_t ib_imm_be,
@@ -2019,10 +2023,11 @@ static UCS_F_ALWAYS_INLINE ucs_status_t uct_rc_mlx5_base_ep_zcopy_post(
                                                        uct_rc_mlx5_iface_common_t);
     uint8_t fm_ce_se                  = (comp == NULL) ? wqe_flags :
                                         (wqe_flags | MLX5_WQE_CTRL_CQ_UPDATE);
+    size_t iov_length;
     uint16_t sn;
 
     sn = ep->tx.wq.sw_pi;
-    uct_rc_mlx5_txqp_dptr_post_iov(iface, IBV_QPT_RC,
+    iov_length = uct_rc_mlx5_txqp_dptr_post_iov(iface, IBV_QPT_RC,
                                    &ep->super.txqp, &ep->tx.wq, opcode,
                                    iov, iovcnt,
                                    am_id, am_hdr, am_hdr_len,
@@ -2034,7 +2039,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_t uct_rc_mlx5_base_ep_zcopy_post(
 
     uct_rc_txqp_add_send_comp(&iface->super, &ep->super.txqp, handler, comp, sn,
                               op_flags | UCT_RC_IFACE_SEND_OP_FLAG_ZCOPY,
-                              iov, iovcnt, iov_total_length);
+                              iov, iovcnt, iov_length);
 
     return UCS_INPROGRESS;
 }

--- a/src/uct/ib/mlx5/rc/rc_mlx5.inl
+++ b/src/uct/ib/mlx5/rc/rc_mlx5.inl
@@ -850,17 +850,15 @@ uct_rc_mlx5_txqp_dptr_post(uct_rc_mlx5_iface_common_t *iface, int qp_type,
     uct_rc_mlx5_txwq_update_psn(txwq, qp_type, length);
 }
 
-static UCS_F_ALWAYS_INLINE
-size_t uct_rc_mlx5_txqp_dptr_post_iov(uct_rc_mlx5_iface_common_t *iface, int qp_type,
-                                      uct_rc_txqp_t *txqp, uct_ib_mlx5_txwq_t *txwq,
-                                      unsigned opcode_flags,
-                           /* IOV  */ const uct_iov_t *iov, size_t iovcnt,
-                           /* SEND */ uint8_t am_id, const void *am_hdr, unsigned am_hdr_len,
-                           /* RDMA */ uint64_t remote_addr, uct_rkey_t rkey,
-                           /* TAG  */ uct_tag_t tag, uint32_t app_ctx, uint32_t ib_imm_be,
-                           /* MMO  */ const uct_ib_mlx5_dma_opaque_mr_t *opaque_mr,
-                                      size_t av_size, uint8_t fm_ce_se,
-                                      uint16_t dci_channel, int max_log_sge)
+static UCS_F_ALWAYS_INLINE size_t uct_rc_mlx5_txqp_dptr_post_iov(
+    uct_rc_mlx5_iface_common_t *iface, int qp_type, uct_rc_txqp_t *txqp,
+    uct_ib_mlx5_txwq_t *txwq, unsigned opcode_flags,
+    /* IOV  */ const uct_iov_t *iov, size_t iovcnt,
+    /* SEND */ uint8_t am_id, const void *am_hdr, unsigned am_hdr_len,
+    /* RDMA */ uint64_t remote_addr, uct_rkey_t rkey,
+    /* TAG  */ uct_tag_t tag, uint32_t app_ctx, uint32_t ib_imm_be,
+    /* MMO  */ const uct_ib_mlx5_dma_opaque_mr_t *opaque_mr, size_t av_size,
+    uint8_t fm_ce_se, uint16_t dci_channel, int max_log_sge)
 {
     struct mlx5_wqe_ctrl_seg     *ctrl;
     struct mlx5_wqe_raddr_seg    *raddr;

--- a/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
+++ b/src/uct/ib/mlx5/rc/rc_mlx5_ep.c
@@ -221,9 +221,8 @@ ucs_status_t uct_rc_mlx5_base_ep_put_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
                              ep->super.atomic_mr_offset, &fm_ce_se);
 
     status = uct_rc_mlx5_base_ep_zcopy_post(
-            ep, MLX5_OPCODE_RDMA_WRITE, iov, iovcnt, 0ul, 0, NULL, 0,
-            remote_addr, rkey, 0ul, 0, 0, NULL,
-            fm_ce_se | MLX5_WQE_CTRL_CQ_UPDATE,
+            ep, MLX5_OPCODE_RDMA_WRITE, iov, iovcnt, 0, NULL, 0, remote_addr,
+            rkey, 0ul, 0, 0, NULL, fm_ce_se | MLX5_WQE_CTRL_CQ_UPDATE,
             uct_rc_ep_send_op_completion_handler, 0, comp);
     UCT_TL_EP_STAT_OP_IF_SUCCESS(status, &ep->super.super, PUT, ZCOPY,
                                  uct_iov_total_length(iov, iovcnt));
@@ -389,9 +388,8 @@ ucs_status_t uct_rc_mlx5_base_ep_get_zcopy(uct_ep_h tl_ep, const uct_iov_t *iov,
 
     uct_rc_mlx5_ep_fence_get(iface, &ep->tx.wq, &rkey, &fm_ce_se);
     status = uct_rc_mlx5_base_ep_zcopy_post(
-            ep, MLX5_OPCODE_RDMA_READ, iov, iovcnt, total_length, 0, NULL, 0,
-            remote_addr, rkey, 0ul, 0, 0, NULL,
-            fm_ce_se | MLX5_WQE_CTRL_CQ_UPDATE,
+            ep, MLX5_OPCODE_RDMA_READ, iov, iovcnt, 0, NULL, 0, remote_addr,
+            rkey, 0ul, 0, 0, NULL, fm_ce_se | MLX5_WQE_CTRL_CQ_UPDATE,
             uct_rc_ep_get_zcopy_completion_handler,
             UCT_RC_IFACE_SEND_OP_FLAG_IOV, comp);
     if (!UCS_STATUS_IS_ERR(status)) {
@@ -516,8 +514,8 @@ uct_rc_mlx5_base_ep_am_zcopy(uct_ep_h tl_ep, uint8_t id, const void *header,
     UCT_RC_CHECK_RES_AND_FC(&iface->super, &ep->super, id);
 
     status = uct_rc_mlx5_base_ep_zcopy_post(
-            ep, MLX5_OPCODE_SEND, iov, iovcnt, 0ul, id, header, header_length,
-            0, 0, 0ul, 0, 0, NULL, MLX5_WQE_CTRL_SOLICITED,
+            ep, MLX5_OPCODE_SEND, iov, iovcnt, id, header, header_length, 0, 0,
+            0ul, 0, 0, NULL, MLX5_WQE_CTRL_SOLICITED,
             uct_rc_ep_send_op_completion_handler, 0, comp);
     if (ucs_likely(status >= 0)) {
         UCT_TL_EP_STAT_OP(&ep->super.super, AM, ZCOPY,
@@ -1169,8 +1167,8 @@ ucs_status_t uct_rc_mlx5_ep_tag_eager_zcopy(uct_ep_h tl_ep, uct_tag_t tag,
                       uct_iov_total_length(iov, iovcnt));
 
     return uct_rc_mlx5_base_ep_zcopy_post(
-            &ep->super, opcode | UCT_RC_MLX5_OPCODE_FLAG_TM, iov, iovcnt, 0ul,
-            0, "", 0, 0, 0, tag, app_ctx, ib_imm, NULL, MLX5_WQE_CTRL_SOLICITED,
+            &ep->super, opcode | UCT_RC_MLX5_OPCODE_FLAG_TM, iov, iovcnt, 0, "",
+            0, 0, 0, tag, app_ctx, ib_imm, NULL, MLX5_WQE_CTRL_SOLICITED,
             uct_rc_ep_send_op_completion_handler, 0, comp);
 }
 


### PR DESCRIPTION
## What?
Set real iov length in send op for zcopy

## Why?
We set length to 0 for all zcopy operatiosn(put/am/get).

## How?
`uct_rc_mlx5_txqp_dptr_post_iov` returns iov length.
Pass real iov length to send_op